### PR TITLE
docs: fix SDK endpoints to match actual gateway routes

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -64,7 +64,7 @@ executes server-side -- nothing runs on your local machine.
 two-step retrieval flow:
 
 1. **Pick a partition** from the index below.
-2. **Call `GET /api/v1/sdk/partitions/:partition/modules`** to see module
+2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
    summaries, then load the full doc for the chosen module.
 
 #### SDK Partition Index

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -490,6 +490,21 @@ POST /api/v1/release/playbook
 
 Browse the 250+ SDK modules available in the runtime — covering crypto/equity/ETF market data (OHLCV, fundamentals, on-chain metrics), 60+ technical indicators (SMA, RSI, MACD, Bollinger Bands…), macro & economic series (GDP, CPI, Treasury yields), and alternative data (news, social sentiment, DeFi). All endpoints are under `/api/v1/sdk/`.
 
+### Get SDK Doc
+
+```
+GET /api/v1/sdk/doc?name={module_name}
+```
+
+| Parameter | Type   | Required | Description                                      |
+| --------- | ------ | -------- | ------------------------------------------------ |
+| name      | string | yes      | Full module name (e.g. `@arrays/crypto/ohlcv:v1.0.0`) |
+
+```
+GET /api/v1/sdk/doc?name=@arrays/crypto/ohlcv:v1.0.0
+→ {"name":"@arrays/crypto/ohlcv:v1.0.0","doc":"..."}
+```
+
 ### List SDK Partitions
 
 ```
@@ -498,22 +513,22 @@ GET /api/v1/sdk/partitions
 
 ```
 GET /api/v1/sdk/partitions
-→ {"partitions":["@arrays/crypto","@arrays/equity","@arrays/macro",...]}
+→ {"partitions":["spot_market_price_and_volume","crypto_onchain_and_derivatives",...]}
 ```
 
-### List Modules in Partition
+### Get Partition Summary
 
 ```
-GET /api/v1/sdk/partitions/:partition/modules
+GET /api/v1/sdk/partitions/:partition/summary
 ```
 
-```
-GET /api/v1/sdk/partitions/@arrays%2Fcrypto/modules
-→ {"modules":["@arrays/crypto/ohlcv:v1.0.0","@arrays/crypto/funding-rate:v1.0.0",...]}
-```
+| Parameter | Type   | Required | Description                                        |
+| --------- | ------ | -------- | -------------------------------------------------- |
+| partition | string | yes      | Partition name (URL-encoded if contains `/`)       |
 
-Note: URL-encode the partition name (e.g. `@arrays/crypto` →
-`@arrays%2Fcrypto`).
+```
+GET /api/v1/sdk/partitions/spot_market_price_and_volume/summary
+→ {"summary":"@arrays/crypto/ohlcv:v1.0.0 — Spot OHLCV for crypto\n@arrays/data/stock/ohlcv:v1.0.0 — Spot OHLCV for equities\n..."}
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace non-existent `GET /api/v1/sdk/partitions/:partition/modules` with `GET /api/v1/sdk/partitions/:partition/summary` (SKILL.md + api-reference.md)
- Add missing `GET /api/v1/sdk/doc?name=...` endpoint documentation

Verified against actual gateway handler: `alva-gateway/pkg/handler/sdk.go`

## Test plan
- [ ] Verify all SDK endpoints in docs match gateway routes (`doc`, `partitions`, `partitions/:partition/summary`)
- [ ] No references to removed `/modules` endpoint remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)