### PR TITLE
docs: update playbook URLs and improve skill documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ That's it. Your agent now has full access to the Alva platform.
 
 ## What Can You Build?
 
-
 | Use Case         | Example Prompt                                                                            |
 | ---------------- | ----------------------------------------------------------------------------------------- |
 | Stock Dashboard  | *"Build a playbook tracking AAPL with price charts, analyst targets, and insider trades"* |
@@ -47,7 +46,6 @@ That's it. Your agent now has full access to the Alva platform.
 | Trading Strategy | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing"*                 |
 | Macro Overview   | *"Build a macro dashboard with CPI, GDP, Treasury rates, and recession probability"*      |
 | Screening Tool   | *"Screen for stocks with PE < 15, ROE > 20%, and positive insider buying"*                |
-
 
 ---
 
@@ -57,7 +55,6 @@ That's it. Your agent now has full access to the Alva platform.
 
 Unified access to crypto, equities, ETFs, macro, on-chain, and social data:
 
-
 | Category      | Highlights                                                                                                  |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
 | Crypto        | Spot & futures OHLCV, funding rates, open interest, long/short ratios, exchange flows, DeFi metrics         |
@@ -66,7 +63,6 @@ Unified access to crypto, equities, ETFs, macro, on-chain, and social data:
 | On-Chain      | MVRV, SOPR, NUPL, whale ratio, exchange inflow/outflow                                                      |
 | Social & News | Twitter/X, Reddit, YouTube, podcasts, news feeds, web search                                                |
 | Technical     | 50+ indicator calculations — RSI, MACD, Bollinger, ATR, VWAP, Ichimoku, and more                            |
-
 
 ### Compute — Cloud JavaScript Runtime
 
@@ -82,7 +78,7 @@ Event-driven backtesting with historical data and live paper trading. Define str
 
 ### Deploy & Share — Playbook Web Apps
 
-Turn your work into a hosted web app at `https://yourusername.playbook.alva.ai/playbook-name`. Built with the Alva Design System — charts, KPIs, tables, and more.
+Turn your work into a hosted web app at `https://alva.ai/<username>/playbooks/<playbook_id>`. Built with the Alva Design System — charts, KPIs, tables, and more.
 
 ---
 
@@ -112,11 +108,9 @@ Turn your work into a hosted web app at `https://yourusername.playbook.alva.ai/p
 
 ## Available Skills
 
-
 | Skill                            | Description                                                                                                                                                               |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **[alva](skills/alva/SKILL.md)** | Full Alva platform access — data SDKs, cloud runtime, feeds, backtesting, and playbook deployment. See the [skill reference](skills/alva/SKILL.md) for detailed API docs. |
-
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -35,7 +35,7 @@ it you can:
 - **Deploy trading strategies** -- backtest with the Altra trading engine and
   run continuous live paper trading.
 - **Release and share** -- turn your work into a hosted playbook web app at
-  `https://yourusername.playbook.alva.ai/playbook-name/version/index.html`, and share it with the world.
+  `https://alva.ai/<username>/playbooks/<playbook_id>`, and share it with the world.
 
 In short: turn your ideas into a forever-running finance agent that gets things
 done for you.
@@ -121,9 +121,10 @@ Three phases:
 
 1. **Write HTML to ALFS**: `POST /api/v1/fs/write` the playbook HTML to
    `~/playbooks/{name}/index.html`.
-2. **Call release API**: `POST /api/v1/release/playbook` — creates DB records
+2. **Create playbook draft**: `POST /api/v1/draft/playbook` — creates a draft version of the playbook.
+3. **Call release API**: `POST /api/v1/release/playbook` — creates DB records
    and uploads HTML to CDN. Returns `playbook_id` (numeric).
-3. **Write ALFS files**: Using the returned numeric `playbook_id`, write
+4. **Write ALFS files**: Using the returned numeric `playbook_id`, write
    release files, draft files, and `playbook.json` to ALFS. See
    [api-reference.md](references/api-reference.md) for details.
 
@@ -132,7 +133,7 @@ The `playbook.json` **must** include a `type` field (`"dashboard"` or
 routing; omitting `draft` causes the dashboard iframe to never load.
 
 Once released, the playbook is accessible at
-`https://yourusername.playbook.alva.ai/playbook-name/version/index.html`.
+`https://<username>.playbook.alva.ai/playbooks/<playbook_id>/index.html`.
 -- ready to share with the world.
 
 ---
@@ -542,8 +543,7 @@ cronjobs per user. Min interval: 1 minute.
 
 After deploying a cronjob, register the feed, create a playbook draft, then
 release the playbook for public hosting. The playbook HTML must already be
-written to ALFS at `~/playbooks/{name}/index.html` via `fs/write` before
-releasing.
+written to ALFS at `~/playbooks/{name}/index.html` via `fs/write` before releasing.
 
 **Important**: Feed names and playbook names must be unique within your user
 space. Before creating a new feed or playbook, use
@@ -567,7 +567,7 @@ POST /api/v1/release/playbook
 → {"playbook_id":99,"version":"v1.0.0","published_url":"https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html"}
 ```
 
-The playbook will be accessible at `https://username.playbook.alva.ai/{name}/{version}/index.html`.
+The playbook will be accessible at `https://alva.ai/<username>/playbooks/<playbook_id>`.
 
 ---
 

--- a/skills/alva/references/adk.md
+++ b/skills/alva/references/adk.md
@@ -88,36 +88,32 @@ Single-function entry point. Runs a ReAct loop (reason → act → observe) unti
 4. If `maxTurns` exhausted → return last assistant content
 
 **Error handling:**
+
 - Unknown tool name → throws
 - Tool execution failure → throws (not swallowed)
 - LLM API errors → throws with status code and body
 
-## Example: Calculator Agent
+## Example: Multiply Tool
 
 ```javascript
 const adk = require("@alva/adk");
 
 const result = await adk.agent({
-  system: "You are a helpful assistant. Always use the calculator tool for math.",
-  prompt: "Calculate 17 * 31",
+  system: "You are a helpful assistant. Use the multiply tool for math.",
+  prompt: "What is 17 times 31?",
   tools: [
     {
       name: "calculator",
-      description: "Evaluate a math expression and return the numeric result",
+      description: "Multiply two numbers",
       parameters: {
         type: "object",
         properties: {
-          expression: {
-            type: "string",
-            description: "Math expression, e.g. '17 * 31'",
-          },
+          a: { type: "number", description: "First number" },
+          b: { type: "number", description: "Second number" },
         },
-        required: ["expression"],
+        required: ["a", "b"],
       },
-      fn: async (args) => {
-        // Your evaluation logic here
-        return { result: eval(args.expression) };
-      },
+      fn: async ({ a, b }) => ({ result: a * b }),
     },
   ],
   maxTurns: 5,


### PR DESCRIPTION
- Changed playbook hosting URLs in README.md and SKILL.md to the new format: `https://alva.ai/<username>/playbooks/<playbook_id>`.
- Updated instructions for creating and releasing playbooks in SKILL.md for clarity.
- Revised example in adk.md to reflect the new multiply tool functionality.