### PR TITLE
docs(alva): tighten design references and UI schema

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -599,32 +599,19 @@ POST /api/v1/release/playbook
 ## Alva Design System
 
 All Alva playbook pages, dashboards, and widgets must follow the Alva Design
-System. The system defines design tokens (colors, spacing, shadows), typography
-rules, and component/widget templates.
+System. Start with [design-system.md](references/design-system.md): it is the
+single global entry point for tokens, typography, page-level layout rules, and
+the reading path to the more detailed design references.
 
-Key rules:
+Read only what you need:
 
-- **Font**: Delight (Regular 400, Medium 500). No Semibold/Bold. Font files: [Delight-Regular.ttf](https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf),
-  [Delight-Medium.ttf](https://alva-ai-static.b-cdn.net/fonts/Delight-Medium.ttf)
-- **Page background**: `--b0-page` (`#ffffff`)
-- **Semantic colors**: `--main-m3` (bullish/green), `--main-m4` (bearish/red),
-  `--main-m1` (Alva theme/teal)
-- **Charts**: Use ECharts. Select colors from the chart palette in
-  [design-system.md](references/design-system.md). Grey only when >= 3 series.
-- **Widgets**: No borders on widget cards. Chart cards use dotted background;
-  table card has no background; other cards use `--grey-g01`.
-- **Grid**: 8-column grid (web), 4-column grid (mobile). Column spans must sum
-  to 8 per row.
-
-**Reference documents** (read for detailed specs when building playbook web
-apps):
-
-| When                                                                    | Read                                                                          |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Design tokens, typography, font rules, general guidelines               | [design-system.md](references/design-system.md)                               |
-| Widget types, chart/KPI/table/feed cards, grid layout                   | [design-widgets.md](references/design-widgets.md)                             |
-| Component templates (button, dropdown, modal, select, switch, markdown) | [design-components.md](references/design-components.md)                       |
-| Trading strategy playbook layout, sections, and content guidelines      | [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md) |
+- **Global rules only** → [design-system.md](references/design-system.md)
+- **Widget and chart implementation** →
+  [design-widgets.md](references/design-widgets.md)
+- **Component behavior and templates** →
+  [design-components.md](references/design-components.md)
+- **Trading strategy playbooks** →
+  [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md)
 
 ---
 

--- a/skills/alva/references/design-components.md
+++ b/skills/alva/references/design-components.md
@@ -61,7 +61,7 @@
 
 .list-item-text {
   flex: 1 0 0;
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-style: normal;
   font-size: 14px;
   line-height: 22px;
@@ -134,7 +134,7 @@ document.querySelectorAll(".list-item").forEach((item) => {
 
 ## Markdown
 
-> For font specification, see [design-system.md - Typography & Font](./design-system.md#typography--font). Headings and body text use Delight; code uses JetBrains Mono.
+> For font specification, see [design-system.md - Typography & Font](./design-system.md#typography--font). Headings and body text use Delight with `-apple-system`, `BlinkMacSystemFont`, `sans-serif` fallbacks; code uses JetBrains Mono.
 
 Uses [markdown-it](https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js) for automatic rendering. Write raw markdown inside `<script type="text/markdown">`, the init script parses it into standard HTML tags, and scoped CSS maps them to the Alva design spec.
 
@@ -196,7 +196,7 @@ Paragraph with `inline code`.
 .markdown-container h4,
 .markdown-container h5,
 .markdown-container h6 {
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-weight: 500;
   font-style: normal;
   color: var(--text-n9);
@@ -212,7 +212,7 @@ Paragraph with `inline code`.
 
 /* ── Paragraph ── */
 .markdown-container p {
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
   color: var(--text-n9); margin: 0; white-space: pre-wrap;
 }
@@ -224,7 +224,7 @@ Paragraph with `inline code`.
   list-style: none; margin: 0; padding: 0;
 }
 .markdown-container li {
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
   color: var(--text-n9);
   position: relative; padding-left: 24px;
@@ -274,7 +274,7 @@ Paragraph with `inline code`.
 .markdown-container td {
   padding: 12px; min-height: 180px;
   border-bottom: 1px solid rgba(0,0,0,0.07);
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
   color: var(--text-n9); text-align: left;
 }
@@ -404,7 +404,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** = 
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: "Delight", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   font-weight: 500;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
@@ -723,7 +723,7 @@ Modal                        ← Overlay
 
 | Property         | Value                               |
 | ---------------- | ----------------------------------- |
-| Background Color | `#var(--b0-container)`              |
+| Background Color | `var(--b0-container)`               |
 | Font             | `Delight`                           |
 | Font Weight      | `400`                               |
 | Border Style     | `0.5px solid`                       |
@@ -788,7 +788,7 @@ Modal                        ← Overlay
 
 ### Click Behavior
 
-Clicking the Select container triggers the associated **Dropdown Menu** (see [Dropdown Menu](#dropdown-menu)).
+Clicking the Select container triggers the associated [Dropdown](#dropdown).
 
 - Dropdown width defaults to the same width as the Select container
 - Dropdown list item text size follows the Select size (see table below)
@@ -874,7 +874,7 @@ border through their transparent border.
   align-items: center;
 }
 .tab-item {
-  font-family: "Delight", sans-serif;
+  font-family: "Delight", -apple-system, BlinkMacSystemFont, sans-serif;
   cursor: pointer;
   transition: all 0.15s ease;
 }

--- a/skills/alva/references/design-playbook-trading-strategy.md
+++ b/skills/alva/references/design-playbook-trading-strategy.md
@@ -5,8 +5,9 @@
 > strictly — page structure, tab layout, module order, component references,
 > and data schema must all match exactly. Do not invent alternative layouts.
 >
-> Depends on `alva-design` skill for design tokens; this spec covers page-specific
-> structure and interactions only.
+> Use [design-system.md](./design-system.md) as the global design entry point.
+> This document only adds trading-strategy-specific page structure, interactions,
+> and UI data requirements.
 
 ---
 
@@ -106,6 +107,11 @@ Sits directly below the Tab Bar; **fields vary per tab**.
 
 Displays all tickers ever traded by the strategy.
 
+The page reads symbol-level UI data from the active item in `tradedSymbols[]`:
+summary fields render the name/price row, `candles[]` powers the candlestick
+chart, and `tradeLog[]` powers both trade markers and the Trade Log modal. This
+is a UI projection contract, not a direct dump of Altra's raw ALFS directories.
+
 #### Layout
 
 Title, Symbol Pills, selected symbol price, and chart stack vertically with gap = 16px (`--spacing-m`).
@@ -150,7 +156,10 @@ Follows [Chart Card](./design-widgets.md#chart-card) spec. Candlestick is a Char
 | barMaxWidth | 16px                         |
 | DataZoom    | `inside` + `slider` (bottom) |
 
-> **Data source note**: OHLCV candlestick data is NOT included in Altra backtest output. After running the backtest, you must separately fetch the traded symbols' OHLCV data (e.g. from exchange API or OHLCV provider) for the same date range. Do not skip the candlestick chart.
+> **Data source note**: OHLCV candlestick data is NOT included in Altra backtest
+> output. After running the backtest, separately fetch the traded symbols'
+> OHLCV data (e.g. from exchange API or OHLCV provider), then project it into
+> each symbol's `candles[]`. Do not skip the candlestick chart.
 
 #### Trade Log Markers
 
@@ -265,9 +274,14 @@ Benchmark Attribution:  Alpha {computed}%  Beta {computed}
 | Chart height     | chart-body total 280px (padding 16×2 + legend 16+8, ECharts canvas 224px)               |
 | Y-axis range     | Dynamic: min/max of all series, expanded 10% each side (data range × 120%)              |
 
-> **Benchmark** is data-driven: read from `equityCurve.benchmark.label` (e.g. "BTC" for crypto, "NASDAQ" for equities).
+> **Benchmark** is data-driven: read from `equityCurve.benchmark.label` (e.g.
+> "BTC" for crypto, "NASDAQ" for equities).
 
-> **Data source note**: Benchmark price data is NOT included in Altra backtest output. After running the backtest, you must separately fetch the benchmark asset's historical prices (e.g. from OHLCV provider) for the same date range and normalize to the initial amount. Do not skip the benchmark series.
+> **Data source note**: Benchmark price data is NOT included in Altra backtest
+> output. After running the backtest, separately fetch the benchmark asset's
+> historical prices (e.g. from an OHLCV provider), normalize them to the initial
+> amount, and project the result into
+> `overview.equityCurve.series.benchmark.data`. Do not skip the benchmark series.
 
 #### Chart Spec
 
@@ -346,7 +360,8 @@ All charts follow [Chart Card](./design-widgets.md#chart-card) spec.
 ### Requirements
 
 - Use **actual computed strategy data**, not placeholders.
-- Each chart must include: title, axis labels, legend (if applicable), and a brief interpretation.
+- Each chart must include: title, axis labels, legend (if applicable), and a
+  brief interpretation.
 
 ---
 
@@ -513,6 +528,11 @@ All text in the signal card uses `--text-n9` except the ticker link.
 
 ## 7. Data Schema (JSON)
 
+This schema is the UI-facing projection consumed by the playbook page. Build it
+from Altra outputs plus any required enrichments (for example benchmark history
+or traded-symbol OHLCV). Do not pass raw ALFS directory trees directly to the
+page.
+
 ```jsonc
 {
   // === Shared ===
@@ -530,10 +550,16 @@ All text in the signal card uses `--text-n9` except the ticker link.
       "changePct": 1.84,
       "changeAbs": 1427.46,
       "source": "Binance",
+      "candles": [
+        { "time": "2025-11-18", "open": 89200.1, "high": 91020.4, "low": 88780.3, "close": 90634.34 }
+      ],
+      "tradeLog": [
+        { "time": "2025-11-18", "side": "BUY", "price": 89880.0, "quantity": 0.8 }
+      ]
     },
-    { "symbol": "ETH" },
-    { "symbol": "SOL" },
-    { "symbol": "BNB" },
+    { "symbol": "ETH", "candles": [], "tradeLog": [] },
+    { "symbol": "SOL", "candles": [], "tradeLog": [] },
+    { "symbol": "BNB", "candles": [], "tradeLog": [] }
   ],
 
   // === Overview ===
@@ -635,6 +661,7 @@ All text in the signal card uses `--text-n9` except the ticker link.
           { "name": "Xxxxxx", "color": "#76b900", "yAxisIndex": 0, "data": [] },
         ],
         "areaFill": true,
+        "interpretation": "Explain what this chart means in one concise sentence.",
       },
       {
         "type": "multi-lines",
@@ -648,6 +675,7 @@ All text in the signal card uses `--text-n9` except the ticker link.
         ],
         "dualYAxis": { "left": "Price (USD)", "right": "Vol / Drawdown (%)" },
         "areaFill": false,
+        "interpretation": "Explain the relationship between the plotted series.",
       },
     ],
   },
@@ -738,7 +766,8 @@ All text in the signal card uses `--text-n9` except the ticker link.
 - Meta Info Bar (4 fields)
 - Performance Metrics Row (6 KPI-Sparkline cards, correct colors)
 - Equity Curve Chart (3 lines + Alpha/Beta + legend) — benchmark series requires separate price data fetch; do not skip if backtest output lacks it
-- Traded Symbols (Pills + Candlestick + Trade Markers)
+- Traded Symbols (Pills + Candlestick + Trade Markers) — uses
+  `tradedSymbols[].candles` and `tradedSymbols[].tradeLog`
 - Current Positions Table (LONG/SHORT/CASH tags + P&L coloring)
 - Daily P&L Chart (positive/negative dual-color bars)
 - Drawdown Chart (all-negative red bars)
@@ -747,6 +776,7 @@ All text in the signal card uses `--text-n9` except the ticker link.
 
 - Meta Info Bar (2 fields)
 - Charts auto-selected by data type
+- Each chart includes a short `interpretation`
 - ≥1280px: 2-column grid; <1280px: single column
 - Alva watermark bottom-left
 

--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -1,6 +1,10 @@
 
 # Alva Design System
 
+This file is the global entry point for Alva design rules. It summarizes the
+rules that apply everywhere and points to the more detailed widget, component,
+and trading-strategy specs when you need them.
+
 ## Design Tokens
 
 Full token definitions (colors, spacing, radius, theme) are in
@@ -14,6 +18,7 @@ exact values. Below is a quick reference for the most common categories:
 | Text | `--text-n9/n7/n5/n3/n2` | n9=primary, n7=secondary, n5=supporting |
 | Background | `--b0-page`, `--grey-g01`~`g1`, `--b-r02`~`r1` | g01 for dashboard cards |
 | Line | `--line-l05/l07/l12/l2/l3` | l07=default |
+| Shadow | `--shadow-xs/s/l` | Floating surfaces only |
 | Spacing | `--spacing-xxxs`(2) ~ `--spacing-xxxxxxl`(56) | Common: xs=8, m=16, xl=24 |
 | Radius | `--radius-ct-xs`(2) ~ `--radius-ct-l`(8) | xs=Tag, s=Card, l=Page |
 
@@ -22,7 +27,7 @@ exact values. Below is a quick reference for the most common categories:
 ### General Rules
 
 1. **The default font for Alva must be Delight**;
-2. Backup fonts: -apple-system, BlinkMacSystemFont, sans-serif;
+2. Backup fonts: `-apple-system`, `BlinkMacSystemFont`, `sans-serif`;
 
 ### Font Weight
 
@@ -51,7 +56,7 @@ text-rendering: optimizeLegibility;
 
 ## Background
 
-**The page background color must use '--b0-page'**
+**The page background color must use `--b0-page`**
 
 ## Playbook Container
 
@@ -81,5 +86,6 @@ text-rendering: optimizeLegibility;
    This spec defines the complete page structure, tab layout, module order,
    component usage, and data schema. Do not deviate from it or invent
    alternative layouts.
-4. **Only need tokens or typography** → this file has everything you need, don't
-   load references
+4. **Only need global rules** → stay in this file. Open
+   [design-tokens.css](./design-tokens.css) only when you need exact token
+   values.

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -400,12 +400,13 @@ Charts and tables never wrap — they always fill `width: 100%`.
 | -------------- | ---------------------- | ------------------------ |
 | KPI Card       | auto (content-driven)  | Wrap via flex-wrap       |
 | Chart Card     | 320px                  | Chart scales internally  |
-| Table Card     | auto, capped at 5600px | Scroll within table body |
+| Table Card     | auto, capped at 560px  | Scroll within table body |
 | Free Text Card | auto (content-driven)  | Scroll or truncate       |
 | Feed Card      | auto, capped at 560px  | Scroll within feed body  |
 
-**Table Card / Feed Card**: Content < 560px → auto height fits content;
-content ≥ 320px → default height 320px, body scrolls.
+**Table Card / Feed Card**: Content < 320px → auto height fits content;
+content ≥ 320px → use a 320px body with internal scroll. Do not exceed 560px
+total height.
 
 Max height for all widgets: **960px**. Apply `overflow-y: auto` to the widget
 body (not the entire card) when exceeded.
@@ -484,17 +485,17 @@ const AX = {
   axisTick: { show: false },
   axisLabel: {
     fontSize: 10,
-    color: "rgba(0,0,0,0.7)",
-    fontFamily: "'Delight',-apple-system,BlinkMacSystemFont,sans-serif",
-    margin: 8,
+    color: "var(--text-n7)",
+    fontFamily: "'Delight', -apple-system, BlinkMacSystemFont, sans-serif",
+    margin: 8, // 8px gap from label to axis line
   },
   splitLine: { show: false },
 };
 
-// Grid — always use containLabel
-grid: { top: 4, right: 4, bottom: 4, left: 4, containLabel: true }
+// Grid must use containLabel:true -- auto-calculate margin from axis labels to container edge
+const GRID = { top: 4, right: 4, bottom: 4, left: 4, containLabel: true };
 
-// Line chart xAxis — add boundaryGap:false
+// Line chart xAxis must add boundaryGap:false
 xAxis: { type: "category", data: x, boundaryGap: false, ...AX }
 ```
 
@@ -698,7 +699,7 @@ Body cell additional constraints: `max-height: 180px`, `white-space: nowrap`,
 ### Responsive
 
 - `>= 960px`: Full table, no scroll
-- `< 960px`: Horizontal `overflow: clip`, scrollable
+- `< 960px`: Horizontal `overflow-x: auto`, scrollable content
 - No hover effects (static display)
 
 ---


### PR DESCRIPTION
## Summary
- collapse duplicated Alva design guidance in `SKILL.md` down to a single global entry path
- tighten `design-system.md`, `design-components.md`, and `design-widgets.md` so examples and references are directly usable
- clarify the trading-strategy playbook as a UI projection contract and align the example schema with page requirements

## Details
- replace the repeated design-system checklist in `SKILL.md` with a short read-only-what-you-need guide
- clarify that exact token values live in `design-tokens.css`, add shadow token summary, and normalize global typography wording
- fix broken or misleading component/widget examples (`#dropdown-menu`, `#var(--b0-container)`, JS chart config snippets, table overflow/height wording)
- add `tradedSymbols[].candles`, `tradedSymbols[].tradeLog`, and `analytics.charts[].interpretation` to the trading-strategy schema and document how enrichments map into the UI

## Validation
- `git diff --check -- skills/alva/SKILL.md skills/alva/references/design-components.md skills/alva/references/design-playbook-trading-strategy.md skills/alva/references/design-system.md skills/alva/references/design-widgets.md`