### PR TITLE
docs(alva): default playbooks to live updates

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -116,6 +116,8 @@ After your data pipelines are deployed and producing data, build the playbook's
 web interface. Create HTML5 pages that read from Alva's data gateway and
 visualize the results. Follow the Alva Design System for styling, layout, and
 component guidelines.
+Unless the user explicitly asks for a static snapshot, default to a live playbook.
+A live playbook may mix live and static sections; only widgets that need fresh data must read cronjob-backed feeds at runtime.
 
 ### 7. Release
 
@@ -128,7 +130,6 @@ Three phases:
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release
    DB records, uploads HTML to CDN, and writes release files to ALFS
    automatically. Returns `playbook_id` (numeric).
-
 Once released, the playbook is accessible at
 `https://alva.ai/<username>/playbooks/<playbook_id>` — ready to share with the
 world. Use the `playbook_id` from the release response and the username from

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -608,7 +608,7 @@ POST /api/v1/fs/grant
 GET /api/v1/fs/read?path=/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100  (public, no auth)
 ```
 
-### Step 5: Deploy as a cronjob (optional)
+### Step 5: Deploy as a cronjob (required for live playbooks)
 
 ```
 POST /api/v1/deploy/cronjob


### PR DESCRIPTION
## Summary
- default the skill toward live playbooks unless the user explicitly asks for a static snapshot
- clarify that live playbooks may mix live and static sections
- mark cronjob deployment as required for live playbooks in the feed SDK guide

## Notes
- docs-only change
- no API or runtime behavior changes