### PR TITLE
fix(alva): pin update commands to release tag instead of main branch

### DIFF
--- a/skills/alva/scripts/version_check.sh
+++ b/skills/alva/scripts/version_check.sh
@@ -80,8 +80,8 @@ Alva skill update available.
   Installed: $local_tag
   Latest:    $remote_tag
 Update with one of:
-  npx skills update
+  npx skills add https://github.com/alva-ai/skills/tree/${remote_tag}/skills/alva --skill alva -y
   clawhub update alva
-  git clone https://github.com/alva-ai/skills ./tmp/alva-skills && cp -r ./tmp/alva-skills/skills/alva/* "<skill-dir>/" && rm -rf ./tmp/alva-skills
+  git clone --branch ${remote_tag} --depth 1 https://github.com/alva-ai/skills ./tmp/alva-skills && cp -r ./tmp/alva-skills/skills/alva/* "${SKILL_DIR}/" && rm -rf ./tmp/alva-skills
 EOF
 fi


### PR DESCRIPTION
## Summary

- `npx skills update` 硬编码拉取 `main` 分支（[源码 `src/cli.ts:558`](https://github.com/vercel-labs/skills/blob/main/src/cli.ts#L558)），可能导致用户安装到未发布的不稳定代码
- 将 `npx skills update` 替换为 `npx skills add .../tree/{tag}/skills/alva`，精确安装到 `version_check.sh` 检测到的 Release tag
- git clone 命令也改为 `--branch {tag}` 并将 `<skill-dir>` 占位符替换为实际的 `$SKILL_DIR` 路径

## Changes

| Before | After |
|--------|-------|
| `npx skills update` (pulls main) | `npx skills add .../tree/v1.0.1/... --skill alva -y` (pulls exact tag) |
| `git clone ... "<skill-dir>/"` | `git clone --branch v1.0.1 --depth 1 ... "$SKILL_DIR/"` |

## Why `npx skills add` instead of `npx skills update`

`npx skills add` 只做文件复制（clone repo → copy skill files → 创建 symlink），不会修改用户的任何现有配置文件。具体来说：

- `.alva.json`（api_key、last_check）**不受影响** — add 只复制 SKILL.md、references/、scripts/，不触碰运行时配置
- `~/.agents/.skill-lock.json` 会更新 hash 和时间戳，但不改变其他字段
- 用户的 settings、环境变量、其他 skill 均不受影响

本质上 `npx skills add` 和 `npx skills update` 内部执行的操作相同（都是 clone + copy），区别仅在于 add 允许通过 URL 指定 tag，而 update 硬编码了 main。

## Root Cause

[`vercel-labs/skills` v1.4.5 `runUpdate()` hardcodes `tree/main`](https://github.com/vercel-labs/skills/blob/main/src/cli.ts#L558):
```javascript
installUrl = `${installUrl}/tree/main/${skillFolder}`;
```

No configuration to change this behavior. The lock file also doesn't record the ref used during `npx skills add`.

## Test plan

- [x] Run `version_check.sh` with local version set to `v0.9.0` — verify output shows `npx skills add .../tree/v1.0.0/...`
- [x] Copy and run the `npx skills add` command from output — verify it installs v1.0.0 tag (not main)
- [x] Copy and run the `git clone --branch` command — verify it clones the correct tag
- [x] Verify `$SKILL_DIR` resolves to actual path in output