### PR TITLE
docs(alva): enhance playbook draft API documentation

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -67,7 +67,7 @@ bash "<this skill's directory>/scripts/version_check.sh"
 ### 2. API Key
 
 Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
-ask the user for their Alva API key (available at https://alva.ai) and write it
+ask the user for their Alva API key (available at <https://alva.ai>) and write it
 to `.alva.json`. Do not proceed until a valid key is configured. Example format:
 
 ```json
@@ -156,7 +156,7 @@ specific paths so anyone -- or any playbook page -- can read the data.
 ### 6. Build the Playbook Web App
 
 After your data pipelines are deployed and producing data, build the playbook's
-web interface. Create HTML5 pages that read from Alva's data gateway and
+web interface. Create HTML5 pages with Alva Design System that read from Alva's data gateway and
 visualize the results. Follow the Alva Design System for styling, layout, and
 component guidelines. Unless the user explicitly asks for a static snapshot,
 default to a live playbook. A live playbook may mix live and static sections;
@@ -170,6 +170,11 @@ Three phases:
    `~/playbooks/{name}/index.html`.
 2. **Create playbook draft**: `POST /api/v1/draft/playbook` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
+   This request must include both the URL-safe `name` and the human-readable
+   `display_name`. Use `[subject/theme] [analysis angle/strategy logic]`, put
+   the subject/theme first, and keep it within 40 characters. Avoid personal
+   markers such as `My`, `Test`, or `V2`, and generic-only titles such as
+   `Stock Dashboard` or `Trading Bot`.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -524,10 +529,12 @@ Every feed follows a 6-step lifecycle:
 2. **Upload** -- write script to `~/feeds/<name>/v1/src/index.js`
 3. **Test** -- `POST /api/v1/run` with `entry_path` to verify output
 4. **Grant** -- make feed data publicly readable:
+
    ```
    POST /api/v1/fs/grant
    {"path":"~/feeds/<name>","subject":"special:user:*","permission":"read"}
    ```
+
    Grant on the feed root path (not on `data/`). Subject format:
    `special:user:*` (public), `special:user:+` (authenticated only), `user:<id>`
    (specific user).
@@ -789,7 +796,7 @@ POST /api/v1/release/feed
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
@@ -877,6 +884,9 @@ consistent read pattern (`@last`, `@range`, etc.).
 - **Always create a draft before releasing.** `POST /api/v1/release/playbook`
   requires the playbook to already exist (created via
   `POST /api/v1/draft/playbook`).
+- **Create new playbooks from scratch unless you are doing a version update.**
+  Only version updates may refer to an existing playbook. For all other new
+  playbooks, do not read existing ones.
 
 ---
 

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -437,16 +437,27 @@ POST /api/v1/draft/playbook
 
 Create a new playbook with a draft version.
 
-| Field       | Type   | Required | Description                                                            |
-| ----------- | ------ | -------- | ---------------------------------------------------------------------- |
-| name        | string | yes      | URL-safe playbook name (e.g. `btc-dashboard`), must be unique per user |
-| description | string | no       | Short description of the playbook                                      |
-| feeds       | array  | yes      | Feed references `[{feed_id, feed_major?}]`                             |
+Requires both a URL-safe `name` and a human-readable `display_name`.
+
+| Field        | Type   | Required | Description                                                            |
+| ------------ | ------ | -------- | ---------------------------------------------------------------------- |
+| name         | string | yes      | URL-safe playbook name (e.g. `btc-dashboard`), must be unique per user |
+| display_name | string | yes      | Human-readable playbook title, max 40 chars                            |
+| description  | string | no       | Short description of the playbook                                      |
+| feeds        | array  | yes      | Feed references `[{feed_id, feed_major?}]`                             |
+
+`display_name` conventions:
+
+- Format: `[subject/theme] [analysis angle/strategy logic]`
+- Max 40 characters
+- Avoid personal markers such as `My`, `Test`, or `V2`
+- Avoid generic-only titles such as `Stock Dashboard` or `Trading Bot`
 
 ```
 POST /api/v1/draft/playbook
 {
   "name": "btc-dashboard",
+  "display_name": "BTC Trend Dashboard",
   "description": "BTC market dashboard with price, technicals, and volume",
   "feeds": [{"feed_id": 100}]
 }
@@ -467,7 +478,7 @@ Release an existing playbook for public hosting. Reads the playbook HTML from
 | name      | string | yes      | URL-safe playbook name (must already exist) |
 | version   | string | yes      | SemVer (e.g. `v1.0.0`)                      |
 | feeds     | array  | yes      | Feed references `[{feed_id, feed_major?}]`  |
-| changelog | string | no       | Release changelog                           |
+| changelog | string | yes      | Release changelog                           |
 
 Feed reference fields:
 
@@ -576,7 +587,9 @@ under `/api/v1/playbook/`. Auth (API key or JWT) is required.
 ### Create Comment
 
 ```
+
 POST /api/v1/playbook/comment
+
 ```
 
 Create a top-level comment or a reply to an existing comment.
@@ -765,4 +778,5 @@ All errors return: `{"error":{"code":"...","message":"..."}}`
 | 500         | INTERNAL          | Server error                       |
 
 ---
+
 ```


### PR DESCRIPTION
- Updated the draft playbook API to require a human-readable `display_name` alongside the URL-safe `name`.
- Added conventions for `display_name` formatting to improve clarity and consistency.
- Clarified the requirement for a changelog in the release API.
- Improved the overall structure and readability of the API reference documentation.

These changes aim to streamline the playbook creation process and ensure better adherence to naming conventions.