### PR TITLE
Enhance remix functionality in SKILL.md and remix-workflow.md

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -182,10 +182,11 @@ construct this URL.
 ### 8. Remix (Create from Existing Playbook)
 
 Users can remix any published playbook to create a customized version. The Remix
-prompt includes the source playbook's owner username and playbook name. The
-agent reads the source playbook's feed scripts (strategy logic) and HTML
-(dashboard UI), customizes them per the user's request, and deploys a new
-playbook under their own namespace.
+prompt uses the format `@{owner}/{name}` to identify the source playbook — e.g.
+`Playbook(@alice/btc-momentum)`. The agent reads the source playbook's feed
+scripts (strategy logic) and HTML (dashboard UI), customizes them per the user's
+request, and deploys a new playbook under their own namespace. If the user does
+not specify what to change, the agent should ask before proceeding.
 
 See [remix-workflow.md](references/remix-workflow.md) for the full step-by-step
 guide.

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -12,28 +12,32 @@ customizes them per the user's preferences, and deploys a new playbook.
 The Remix prompt arrives in this shape:
 
 ```
-Create a customized version based on this Playbook template:
+Use Alva skill to remix this Playbook(@alice/btc-momentum) into my own version:
 
-1. Keep the core strategy logic
-2. Adjust parameters to my investment preferences
-3. Add stop-loss / take-profit rules matching my risk appetite
+1. Customize it based on my preferences
+2. Deploy as a new playbook under my account
 
-Playbook Owner: alice
-Playbook Name: btc-momentum
+If I don't specify what to change, ask me what I'd like to customize.
 ```
 
-Extract two fields:
+The `@{owner}/{name}` token after "Playbook(" contains the two key fields:
 
-| Field            | Description                                  |
-| ---------------- | -------------------------------------------- |
-| `Playbook Owner` | Username of the original creator             |
-| `Playbook Name`  | Filesystem name (URL-safe slug used in ALFS) |
+| Field   | Description                                  | Extracted From        |
+| ------- | -------------------------------------------- | --------------------- |
+| `owner` | Username of the original creator             | Before the `/`        |
+| `name`  | Filesystem name (URL-safe slug used in ALFS) | After the `/`         |
+
+For the example above: owner = `alice`, name = `btc-momentum`.
 
 Together they resolve to the ALFS base path:
 
 ```
 /alva/home/{owner}/playbooks/{name}/
 ```
+
+**Behavior note**: If the user's prompt does not specify what to change (only
+the default "Customize it based on my preferences"), the agent should **ask the
+user what they'd like to customize** before proceeding.
 
 ---
 
@@ -136,12 +140,18 @@ POST /api/v1/remix
 
 ## Example
 
-Given:
+Given prompt:
 
 ```
-Playbook Owner: alice
-Playbook Name: btc-momentum
+Use Alva skill to remix this Playbook(@alice/btc-momentum) into my own version:
+
+1. Customize it based on my preferences
+2. Deploy as a new playbook under my account
+
+Add a summary section at the bottom.
 ```
+
+Extracted: owner = `alice`, name = `btc-momentum`.
 
 Agent reads:
 


### PR DESCRIPTION
- Updated the Remix prompt format to use `@{owner}/{name}` for source playbook identification.
- Clarified agent behavior to prompt users for customization if no changes are specified.
- Revised example prompts and added a summary section in remix-workflow.md for better user guidance.