### PR TITLE
docs: add PR template and clarify display_name handling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+# Pull Request
+
+## Summary
+
+<!-- What changed, why it changed, and which skill workflows or docs are affected? -->
+
+## Affected Areas
+
+- [ ] Prompt instructions or agent-facing behavior
+- [ ] Setup or configuration flow
+- [ ] Local evaluation or validation flow
+- [ ] Release or rollout behavior
+- [ ] Compatibility for downstream agents or users
+
+## Type of Change
+
+- [ ] Documentation
+- [ ] Bug fix
+- [ ] Improvement
+- [ ] New feature
+- [ ] Security fix
+- [ ] Breaking change
+
+## Submission Checklist
+
+- [ ] Validated with representative skill prompts locally
+- [ ] Expected behavior and observed behavior were compared
+- [ ] Relevant references, examples, and instructions were kept in sync
+- [ ] Edge cases or failure paths were checked where relevant
+- [ ] Prompt or workflow changes were checked for instruction conflicts
+- [ ] Backward compatibility was considered
+
+## Release and Compatibility
+
+- [ ] No release impact
+- [ ] Requires dev release
+- [ ] Requires version bump
+- [ ] Introduces a breaking change


### PR DESCRIPTION
## Summary
- add a repository-level pull request template so contributors document scope, validation, and compatibility impact consistently
- clarify that when users provide `display_name`, it should be used as-is as the base title and only normalized if parts are non-compliant

## Test plan
- [x] Ran `git diff --check`
- [x] Reviewed `git diff origin/main...HEAD --stat`
- [x] Checked IDE diagnostics for `skills/alva/references/api-reference.md` and confirmed the file only has pre-existing markdown warnings