### PR TITLE
docs(alva): clarify display_name and feed lifecycle rules

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -533,7 +533,7 @@ and deduplication behavior.
 
 ## Deploying Feeds
 
-Every feed follows a 6-step lifecycle:
+Every feed follows a 6-step lifecycle including every newly created feed or re-created feed:
 
 1. **Write** -- define schema + incremental logic with `ctx.kv`
 2. **Upload** -- write script to `~/feeds/<name>/v1/src/index.js`

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -452,6 +452,7 @@ Requires both a URL-safe `name` and a human-readable `display_name`.
 - Max 40 characters
 - Avoid personal markers such as `My`, `Test`, or `V2`
 - Avoid generic-only titles such as `Stock Dashboard` or `Trading Bot`
+- If the user provides `display_name`, use it and normalize any non-compliant parts
 
 ```
 POST /api/v1/draft/playbook


### PR DESCRIPTION
## Summary
- clarify that user-provided `display_name` values should be used and normalized if they do not fully comply with naming rules
- clarify that the feed deployment lifecycle applies to newly created feeds and recreated feeds, not only first-time creations

## Affected Areas
- [x] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change
- [x] Documentation
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist
- [x] Validated with representative skill prompts locally
- [x] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility
- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change

## Test Plan
- [x] Run `git diff --check`
- [ ] Run representative skill prompts locally

Made with [Cursor](https://cursor.com)