### PR TITLE
docs(alva): add secret manager workflow guidance

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -82,6 +82,32 @@ API calls in this session.
 
 ---
 
+## Secret Manager
+
+Use Alva Secret Manager whenever a playbook or runtime script needs a
+third-party credential such as an LLM API key, search token, exchange key, or
+webhook secret.
+
+- **Preferred upload path**: ask the user to add or edit the secret in the web
+  UI at <https://alva.ai/apikey>. Assume this page is available.
+- **Do not ask the user to paste sensitive third-party secrets into chat** when
+  the web upload flow is feasible.
+- **Do not hardcode secrets** in source code, ALFS files, `.alva.json`, shell
+  snippets, or released playbook assets.
+- **Runtime access**: load secrets inside Alva Cloud code with
+  `require("secret-manager").loadPlaintext("NAME")`.
+- `loadPlaintext(name)` returns the plaintext string when present, or `null`
+  when the secret is missing for the current user.
+- If a required secret is missing, stop and tell the user exactly which secret
+  name to upload at <https://alva.ai/apikey>.
+- For agent-managed setup, inspection, or cleanup, authenticated CRUD endpoints
+  are available under `/api/v1/secrets`.
+
+Read [secret-manager.md](references/secret-manager.md) whenever the task
+involves uploading, naming, rotating, listing, or using third-party secrets.
+
+---
+
 ## Capabilities & Common Workflows
 
 ### 1. ALFS (Alva FileSystem)
@@ -237,6 +263,7 @@ guide.
 | [remix-workflow.md](references/remix-workflow.md)       | Remix: create a new playbook from an existing template                                                     |
 | [adk.md](references/adk.md)                             | Agent Development Kit: `adk.agent()` API, tool calling, ReAct loop, examples                               |
 | [search.md](references/search.md)                       | Content search SDKs: per-source usage, enrichment patterns, and gotchas for Twitter/X, news, Reddit, YouTube, podcasts, and web |
+| [secret-manager.md](references/secret-manager.md)       | Secret upload, CRUD API, and runtime usage via `require("secret-manager")`                                 |
 
 ---
 
@@ -248,6 +275,11 @@ All configuration is done via environment variables.
 | --------------- | -------- | ----------------------------------------------------------------------- |
 | `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
 | `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+
+`ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
+substitute for third-party vendor secrets. Vendor credentials belong in Alva
+Secret Manager and should be loaded at runtime via
+`require("secret-manager")`.
 
 ### First-Time Setup
 
@@ -400,6 +432,20 @@ GET /api/v1/trading-pairs/search?q=BTC,ETH
 | ------ | ------------ | ---------------------------------------- |
 | GET    | `/api/v1/me` | Get authenticated user's id and username |
 
+### Secrets (`/api/v1/secrets`)
+
+| Method | Endpoint                 | Description                                 |
+| ------ | ------------------------ | ------------------------------------------- |
+| POST   | `/api/v1/secrets`        | Create a secret                             |
+| GET    | `/api/v1/secrets`        | List secret metadata for the current user   |
+| GET    | `/api/v1/secrets/:name`  | Get the plaintext value for one secret      |
+| PUT    | `/api/v1/secrets/:name`  | Overwrite the plaintext value for one secret |
+| DELETE | `/api/v1/secrets/:name`  | Delete a secret                             |
+
+Prefer the web UI at <https://alva.ai/apikey> when the user is manually
+entering a sensitive secret. Use the API flow when the task explicitly needs
+agent-managed CRUD.
+
 ---
 
 ## Runtime Modules Quick Reference
@@ -413,6 +459,7 @@ variables, or shell. Host-agent permissions still apply. See
 | --------------- | ---------------------------- | ----------------------------------------------------------------------- |
 | alfs            | `require("alfs")`            | Filesystem (uses absolute paths `/alva/home/<username>/...`)            |
 | env             | `require("env")`             | `userId`, `username`, `args` from request                               |
+| secret-manager  | `require("secret-manager")`  | Read user-scoped third-party secrets stored in Alva Secret Manager      |
 | net/http        | `require("net/http")`        | `fetch(url, init)` for async HTTP requests                              |
 | @alva/algorithm | `require("@alva/algorithm")` | Statistics                                                              |
 | @alva/feed      | `require("@alva/feed")`      | Feed SDK for persistent data pipelines + FeedAltra trading engine       |
@@ -423,6 +470,10 @@ variables, or shell. Host-agent permissions still apply. See
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
 (defaults to `v1.0.0`). To discover function signatures and response shapes, use
 the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
+
+**Secret Manager**: use `const secret = require("secret-manager");` then
+`secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
+`null` when the current user has not uploaded that secret.
 
 **Key constraints**: No top-level `await` (wrap script in
 `(async () => { ... })();`). No Node.js builtins (`fs`, `path`, `http`). Module

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -23,6 +23,104 @@ GET /api/v1/me
 
 ---
 
+## Secrets API
+
+Use these endpoints to manage user-scoped third-party secrets. Secrets are
+stored encrypted at rest in `jagent`, and runtime code reads them through
+`require("secret-manager")`.
+
+These endpoints are authenticated and user-scoped. They work with the same
+`X-Alva-Api-Key` header used elsewhere in this skill, or with an authenticated
+website session. When a human is manually entering a sensitive secret, prefer
+the web UI at <https://alva.ai/apikey>. Use the API flow when agent-managed
+CRUD is explicitly needed.
+
+### Create Secret
+
+```
+POST /api/v1/secrets
+{"name":"OPENAI_API_KEY","value":"sk-..."}
+```
+
+Validation:
+
+- `name` must be non-empty
+- `value` must be non-empty
+- Creating the same name twice returns `AlreadyExists`
+
+Response: `201 Created` with empty JSON body (`{}`)
+
+### List Secrets
+
+```
+GET /api/v1/secrets
+→ {"secrets":[{"name":"OPENAI_API_KEY","keyVersion":1,"createdAt":"2026-03-20T08:00:00Z","updatedAt":"2026-03-20T08:00:00Z","valueLength":56,"keyPrefix":"sk-proj-abc12"}]}
+```
+
+List returns metadata only:
+
+- `name`
+- `keyVersion`
+- `createdAt`
+- `updatedAt`
+- `valueLength`
+- `keyPrefix`
+
+### Get Secret
+
+```
+GET /api/v1/secrets/OPENAI_API_KEY
+→ {"name":"OPENAI_API_KEY","value":"sk-...","createdAt":"2026-03-20T08:00:00Z","updatedAt":"2026-03-20T08:00:00Z"}
+```
+
+Returns the decrypted plaintext value for the current user. Missing secrets
+return `NotFound`.
+
+### Update Secret
+
+```
+PUT /api/v1/secrets/OPENAI_API_KEY
+{"value":"sk-new-..."}
+```
+
+Overwrites the secret value in place. Missing secrets return `NotFound`.
+
+Response: `200 OK` with empty JSON body (`{}`)
+
+### Delete Secret
+
+```
+DELETE /api/v1/secrets/OPENAI_API_KEY
+```
+
+Deletes the secret for the current user. Missing secrets return `NotFound`.
+
+Response: `200 OK` with empty JSON body (`{}`)
+
+### Runtime Usage
+
+Inside `/api/v1/run` JavaScript, load the secret by name:
+
+```javascript
+const secret = require("secret-manager");
+const openaiApiKey = secret.loadPlaintext("OPENAI_API_KEY");
+
+if (!openaiApiKey) {
+  throw new Error(
+    "Missing OPENAI_API_KEY. Upload it at https://alva.ai/apikey and retry.",
+  );
+}
+```
+
+Behavior:
+
+- `loadPlaintext(name)` returns the plaintext string when present
+- `loadPlaintext(name)` returns `null` when the secret does not exist
+- calling it without an authenticated execution context throws an error
+- do not log secret values or write them into ALFS or released assets
+
+---
+
 ## Filesystem API
 
 All filesystem endpoints are under `/api/v1/fs/`.

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -23,8 +23,8 @@ cronjobs.
 
 1. **ALFS files** -- paths ending in `.js` that don't start with `@` (e.g.
    `require("./helper.js")`) -- resolved from the filesystem on ALFS
-2. **Official/system modules** -- `alfs`, `env`, `net/http`,
-   `@alva/algorithm`, `@alva/feed`, `@alva/adk`
+2. **Official/system modules** -- `alfs`, `env`, `secret-manager`,
+   `net/http`, `@alva/algorithm`, `@alva/feed`, `@alva/adk`
 3. **SDKHub modules** -- versioned modules like
    `require("@arrays/crypto/ohlcv:v1.0.0")`
 
@@ -99,6 +99,31 @@ env.userId; // "1" (string) -- your numeric user ID
 env.username; // "alice" (string) -- your username, used in ALFS paths
 env.args; // parsed JSON from the request's "args" field
 ```
+
+### secret-manager -- Third-Party Secrets
+
+Use this built-in module for user-scoped third-party credentials that were
+uploaded to Alva Secret Manager.
+
+```javascript
+const secret = require("secret-manager");
+const braveApiKey = secret.loadPlaintext("BRAVE_API_KEY");
+
+if (!braveApiKey) {
+  throw new Error(
+    "Missing BRAVE_API_KEY. Upload it at https://alva.ai/apikey and retry.",
+  );
+}
+```
+
+Behavior:
+
+- `loadPlaintext(name)` returns the plaintext string when the secret exists
+- `loadPlaintext(name)` returns `null` when the secret is missing
+- calling it without an authenticated execution context throws an error
+- the module is read-only from JS; writes happen through the web UI or
+  `/api/v1/secrets`
+- do not log the returned value or write it into ALFS / released assets
 
 ### net/http -- HTTP Requests
 

--- a/skills/alva/references/secret-manager.md
+++ b/skills/alva/references/secret-manager.md
@@ -1,0 +1,173 @@
+# Secret Manager
+
+Use this reference when a task needs to upload, rotate, inspect, or consume a
+third-party credential inside Alva Cloud.
+
+---
+
+## Mental Model
+
+- `ALVA_API_KEY` authenticates the agent to the Alva platform itself.
+- Alva Secret Manager stores **user-scoped third-party secrets** such as LLM API
+  keys, search tokens, exchange credentials, and webhook secrets.
+- Secrets are stored encrypted at rest in `jagent`.
+- Runtime code reads them through the built-in JS module
+  `require("secret-manager")`.
+
+Do **not** confuse platform auth with vendor credentials. A task may need both:
+
+- `ALVA_API_KEY` to call Alva APIs
+- `OPENAI_API_KEY`, `BRAVE_API_KEY`, `EXCHANGE_SECRET`, etc. inside Secret
+  Manager for runtime code
+
+---
+
+## Default Workflow
+
+1. Prefer the web UI at <https://alva.ai/apikey> for initial upload or manual
+   edits.
+2. Avoid asking the user to paste a sensitive third-party secret into chat when
+   the web upload flow is available.
+3. Choose a stable secret name, usually uppercase with underscores, such as
+   `OPENAI_API_KEY`, `BRAVE_API_KEY`, or `BINANCE_API_SECRET`.
+4. Reference the secret by name in runtime code with
+   `require("secret-manager").loadPlaintext("NAME")`.
+5. If the runtime gets `null`, stop and tell the user exactly which secret name
+   is missing and where to upload it.
+
+Do not:
+
+- hardcode secrets in source code
+- save secrets into ALFS files
+- embed secrets into released playbook HTML, JSON, or screenshots
+- log secret values
+
+---
+
+## Runtime Usage
+
+```javascript
+const secret = require("secret-manager");
+const openaiApiKey = secret.loadPlaintext("OPENAI_API_KEY");
+
+if (!openaiApiKey) {
+  throw new Error(
+    "Missing OPENAI_API_KEY. Upload it at https://alva.ai/apikey and retry.",
+  );
+}
+```
+
+Behavior from the runtime implementation:
+
+- `loadPlaintext(name)` returns the plaintext string when the secret exists
+- `loadPlaintext(name)` returns `null` when the secret does not exist
+- an authenticated execution context is required
+- if the secret loader is not configured, the module throws a clear error
+- the JS module is read-only; writes and updates happen outside the runtime
+
+Use this whenever the code needs to call an external service from `/api/v1/run`
+or from a deployed cronjob.
+
+---
+
+## Programmatic CRUD API
+
+Authenticated CRUD is available under `/api/v1/secrets`. These endpoints are
+scoped to the current user.
+
+### Create
+
+```http
+POST /api/v1/secrets
+Content-Type: application/json
+
+{"name":"OPENAI_API_KEY","value":"sk-..."}
+```
+
+### List
+
+```http
+GET /api/v1/secrets
+```
+
+Returns metadata only:
+
+```json
+{
+  "secrets": [
+    {
+      "name": "OPENAI_API_KEY",
+      "keyVersion": 1,
+      "createdAt": "2026-03-20T08:00:00Z",
+      "updatedAt": "2026-03-20T08:00:00Z",
+      "valueLength": 56,
+      "keyPrefix": "sk-proj-abc12"
+    }
+  ]
+}
+```
+
+### Get plaintext value
+
+```http
+GET /api/v1/secrets/OPENAI_API_KEY
+```
+
+### Update
+
+```http
+PUT /api/v1/secrets/OPENAI_API_KEY
+Content-Type: application/json
+
+{"value":"sk-new-..."}
+```
+
+### Delete
+
+```http
+DELETE /api/v1/secrets/OPENAI_API_KEY
+```
+
+Validation and error behavior:
+
+- empty `name` or `value` returns `INVALID_ARGUMENT`
+- creating the same name twice returns `AlreadyExists`
+- get/update/delete on a missing secret returns `NotFound`
+
+Prefer the web UI over CRUD API when a human is manually entering a secret.
+Prefer the API when the task explicitly needs agent-managed setup, migration, or
+cleanup.
+
+---
+
+## Agent Guidance
+
+When helping a user build with external providers:
+
+- first identify the exact secret name the code will use
+- tell the user where to upload it: <https://alva.ai/apikey>
+- write runtime code that fails clearly when the secret is missing
+- keep the secret name consistent across instructions, code, and deployment
+
+Example:
+
+```javascript
+const secret = require("secret-manager");
+const braveApiKey = secret.loadPlaintext("BRAVE_API_KEY");
+
+if (!braveApiKey) {
+  throw new Error("Missing BRAVE_API_KEY. Upload it at https://alva.ai/apikey.");
+}
+
+const http = require("net/http");
+
+(async () => {
+  const resp = await http.fetch("https://api.search.brave.com/res/v1/web/search?q=NVDA", {
+    headers: {
+      "X-Subscription-Token": braveApiKey,
+    },
+  });
+  const data = await resp.json();
+  return data;
+})();
+```


### PR DESCRIPTION
# Pull Request

## Summary

- add Secret Manager workflow guidance to `skills/alva/SKILL.md`
- add `skills/alva/references/secret-manager.md` for upload, naming, CRUD, and runtime usage
- sync `api-reference.md` and `jagent-runtime.md` with the current `jagent` and `alva-gateway` secret-manager behavior, including `/api/v1/secrets`, `require("secret-manager")`, and the preferred UI flow at `https://alva.ai/apikey`

## Affected Areas

- [x] Prompt instructions or agent-facing behavior
- [x] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [x] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility

- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
