### PR TITLE
fix(alva): use correct /u/ URL format in screenshot API examples

### DIFF
--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -887,16 +887,16 @@ Response:
 
 ```
 # Screenshot a playbook page
-GET /api/v1/screenshot?url=https://alva.ai/alice/playbooks/123
+GET /api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard
 
 # Screenshot a specific chart element
-GET /api/v1/screenshot?url=https://alva.ai/alice/playbooks/123&selector=.chart-container
+GET /api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard&selector=.chart-container
 ```
 
 ```bash
 # curl example
 curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" \
-  "$ALVA_ENDPOINT/api/v1/screenshot?url=https://alva.ai/alice/playbooks/123"
+  "$ALVA_ENDPOINT/api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixed screenshot API examples in `api-reference.md` that used incorrect URL format `/alice/playbooks/123` (missing `/u/` prefix, numeric ID)
- Updated to match the canonical format `/u/alice/playbooks/btc-dashboard` consistent with SKILL.md and actual playbook URLs

## Test plan
- [ ] Verify screenshot API examples match the URL pattern used in SKILL.md § Release
- [ ] Confirm `/u/<username>/playbooks/<name>` is the correct production URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)