### PR TITLE
docs(alva): add trading_symbols field to playbook API documentation

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -216,6 +216,12 @@ Three phases:
    the subject/theme first, and keep it within 40 characters. Avoid personal
    markers such as `My`, `Test`, or `V2`, and generic-only titles such as
    `Stock Dashboard` or `Trading Bot`.
+   **Trading symbols**: If the playbook involves specific trading assets,
+   include `"trading_symbols"` in the request — an array of base asset
+   tickers (e.g. `["BTC", "ETH"]`, `["NVDA", "AAPL"]`). The backend
+   resolves each symbol to a full trading pair object and stores the result
+   in the playbook metadata. Max 50 symbols per request. Unknown symbols
+   are silently skipped.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -875,8 +881,9 @@ POST /api/v1/release/feed
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
+#    Include trading_symbols when the playbook involves specific assets.
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}],"trading_symbols":["BTC"]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -537,12 +537,13 @@ Create a new playbook with a draft version.
 
 Requires both a URL-safe `name` and a human-readable `display_name`.
 
-| Field        | Type   | Required | Description                                                            |
-| ------------ | ------ | -------- | ---------------------------------------------------------------------- |
-| name         | string | yes      | URL-safe playbook name (e.g. `btc-dashboard`), must be unique per user |
-| display_name | string | yes      | Human-readable playbook title, max 40 chars                            |
-| description  | string | no       | Short description of the playbook                                      |
-| feeds        | array  | yes      | Feed references `[{feed_id, feed_major?}]`                             |
+| Field           | Type     | Required | Description                                                                                                                  |
+| --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| name            | string   | yes      | URL-safe playbook name (e.g. `btc-dashboard`), must be unique per user                                                       |
+| display_name    | string   | yes      | Human-readable playbook title, max 40 chars                                                                                  |
+| description     | string   | no       | Short description of the playbook                                                                                            |
+| feeds           | array    | yes      | Feed references `[{feed_id, feed_major?}]`                                                                                   |
+| trading_symbols | string[] | no       | Base asset tickers (e.g. `["BTC","ETH"]`). Resolved server-side to full trading pairs, stored in playbook metadata. Max 50.  |
 
 `display_name` conventions:
 
@@ -558,7 +559,8 @@ POST /api/v1/draft/playbook
   "name": "btc-dashboard",
   "display_name": "BTC Trend Dashboard",
   "description": "BTC market dashboard with price, technicals, and volume",
-  "feeds": [{"feed_id": 100}]
+  "feeds": [{"feed_id": 100}],
+  "trading_symbols": ["BTC"]
 }
 → {"playbook_id": 99, "playbook_version_id": 200}
 ```


### PR DESCRIPTION
# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
