### PR TITLE
feat: replace SDKHub with Data Skills in SKILL.md

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -428,17 +428,19 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### SDK Documentation (`/api/v1/sdk/`)
+### Data Skills (`/api/v1/data-skills/`)
 
-| Method | Endpoint                                    | Description                                          |
-| ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+| Method | Endpoint                            | Description                              |
+| ------ | ----------------------------------- | ---------------------------------------- |
+| GET    | `/api/v1/data-skills`               | List all data skills (name + description)|
+| GET    | `/api/v1/data-skills/:name`         | Get full documentation for a data skill  |
 
-**SDK retrieval flow**: pick a partition from the index above → call
-`/partitions/:partition/summary` to see module summaries → call
-`/sdk/doc?name=...` to load the full doc for the chosen module.
+**Data skill retrieval flow**: pick a skill from the Data Skills Index above → call
+`/data-skills/:name` to load the full endpoint documentation.
+
+> **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
+> partitions (`crypto_fundamentals`, `feed_widgets`,
+> `technical_indicator_calculation_helpers`).
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -86,9 +86,20 @@ API calls in this session:
 
 - `ALVA_API_KEY` ← `api_key`
 
-> **Note:** Arrays data API authentication is handled automatically. The
-> platform signs and manages `ARRAYS_JWT` tokens via the secret-manager —
-> no manual Arrays API key configuration is needed.
+> **Note:** Arrays data API authentication uses a Partner JWT stored in
+> the secret-manager as `ARRAYS_JWT`. Before calling any Arrays data
+> endpoint, ensure the token exists and is fresh:
+>
+> ```
+> POST /api/v1/arrays-jwt/ensure   (requires X-Alva-Api-Key auth)
+> ```
+>
+> This is **idempotent** — it checks the existing JWT and only renews if
+> missing or near expiry. Returns `{ expires_at, tier, renewed }`.
+> To inspect without modifying: `GET /api/v1/arrays-jwt/status`.
+>
+> In runtime code, load the token via
+> `require("secret-manager").loadPlaintext("ARRAYS_JWT")`.
 
 ---
 
@@ -163,8 +174,8 @@ Financial data APIs across 16 domains. To find the right API for a task:
    — use the Path value from the summary endpoints table (e.g. `company/list`,
    `market-news`) to get full parameters, response fields, and examples.
 4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
-   In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`
-   (auto-managed by the platform, no manual setup needed).
+   In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
+   If the token is missing, call `POST /api/v1/arrays-jwt/ensure` first.
 
 #### Data Skills Index
 
@@ -333,9 +344,10 @@ substitute for third-party vendor secrets. Vendor credentials belong in Alva
 Secret Manager and should be loaded at runtime via
 `require("secret-manager")`.
 
-> **Arrays authentication:** `ARRAYS_JWT` is managed automatically by the
-> platform and stored in the secret-manager. Runtime code loads it via
-> `secret.loadPlaintext('ARRAYS_JWT')`. No manual key setup is needed.
+> **Arrays authentication:** `ARRAYS_JWT` is a Partner JWT stored in the
+> secret-manager. Call `POST /api/v1/arrays-jwt/ensure` before first use
+> (idempotent — safe to call every session). Runtime code loads it via
+> `secret.loadPlaintext('ARRAYS_JWT')`.
 
 ### First-Time Setup
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -68,21 +68,25 @@ bash "<this skill's directory>/scripts/version_check.sh"
   using the appropriate method for how the skill was installed. Proceed normally
   after the update completes.
 
-### 2. API Key
+### 2. API Keys
 
-Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
-ask the user for their Alva API key (available at <https://alva.ai>) and write it
-to `.alva.json`. Do not proceed until a valid key is configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
+missing or empty, ask the user for the missing key(s) and write them to
+`.alva.json`. Do not proceed until both keys are configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
+  "arrays_api_key": "arr_...",
   "last_check": 0
 }
 ```
 
-Set the `ALVA_API_KEY` environment variable from this value for all subsequent
-API calls in this session.
+Set the following environment variables from these values for all subsequent
+API calls in this session:
+
+- `ALVA_API_KEY` ← `api_key`
+- `ARRAYS_API_KEY` ← `arrays_api_key`
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -157,9 +157,9 @@ Financial data APIs across 16 domains. To find the right API for a task:
 1. **Pick a data skill** from the index below.
 2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
    (public, no auth) — returns the endpoints table for that domain.
-3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<key>`
-   — use the Endpoint Key from the summary table to get full parameters,
-   response fields, and examples for that specific endpoint.
+3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
+   — use the Path value from the summary endpoints table (e.g. `company/list`,
+   `market-news`) to get full parameters, response fields, and examples.
 4. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
    endpoints.
 
@@ -458,7 +458,8 @@ backend. They are public and require no authentication.
 **Data skill retrieval flow**: pick a skill from the Data Skills Index above →
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to get the endpoints summary →
 pick the endpoint you need from the summary table → call
-`$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<key>` to get endpoint detail →
+`$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>` to get endpoint detail
+(use the Path value from the table, e.g. `?endpoint=company/list`) →
 use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays data endpoints.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -156,7 +156,11 @@ Financial data APIs across 16 domains. To find the right API for a task:
 
 1. **Pick a data skill** from the index below.
 2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
-   the full endpoint documentation for that domain.
+   the full endpoint documentation for that domain. **Always consume the full
+   response — do NOT pipe through `head`, `tail`, or truncate with string
+   slicing.** Each response is < 25 KB and fits comfortably in context. Piping
+   through `head` or partial extraction leads to missing endpoint details and
+   forces wasteful re-fetches.
 3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
    endpoints.
 
@@ -454,8 +458,8 @@ backend. They are public and require no authentication.
 
 **Data skill retrieval flow**: pick a skill from the Data Skills Index above →
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
-documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
-data endpoints.
+documentation (consume the **full** response; do not truncate) → use
+`ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays data endpoints.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -155,9 +155,12 @@ SDK.
 Financial data APIs across 16 domains. To find the right API for a task:
 
 1. **Pick a data skill** from the index below.
-2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
-   the full endpoint documentation for that domain.
-3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
+2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
+   (public, no auth) — returns the endpoints table for that domain.
+3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<key>`
+   — use the Endpoint Key from the summary table to get full parameters,
+   response fields, and examples for that specific endpoint.
+4. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
    endpoints.
 
 #### Data Skills Index
@@ -453,9 +456,10 @@ These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
 backend. They are public and require no authentication.
 
 **Data skill retrieval flow**: pick a skill from the Data Skills Index above →
-call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
-documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
-data endpoints.
+call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to get the endpoints summary →
+pick the endpoint you need from the summary table → call
+`$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<key>` to get endpoint detail →
+use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays data endpoints.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -70,23 +70,25 @@ bash "<this skill's directory>/scripts/version_check.sh"
 
 ### 2. API Keys
 
-Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
-missing or empty, ask the user for the missing key(s) and write them to
-`.alva.json`. Do not proceed until both keys are configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
+ask the user for it and write it to `.alva.json`. Do not proceed until the key
+is configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
-  "arrays_api_key": "arr_...",
   "last_check": 0
 }
 ```
 
-Set the following environment variables from these values for all subsequent
+Set the following environment variable from this value for all subsequent
 API calls in this session:
 
 - `ALVA_API_KEY` ← `api_key`
-- `ARRAYS_API_KEY` ← `arrays_api_key`
+
+> **Note:** Arrays data API authentication is handled automatically. The
+> platform signs and manages `ARRAYS_JWT` tokens via the secret-manager —
+> no manual Arrays API key configuration is needed.
 
 ---
 
@@ -160,8 +162,9 @@ Financial data APIs across 16 domains. To find the right API for a task:
 3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
    — use the Path value from the summary endpoints table (e.g. `company/list`,
    `market-news`) to get full parameters, response fields, and examples.
-4. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
-   endpoints.
+4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
+   In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`
+   (auto-managed by the platform, no manual setup needed).
 
 #### Data Skills Index
 
@@ -184,24 +187,28 @@ Financial data APIs across 16 domains. To find the right API for a task:
 | Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
 | Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
 
-#### Legacy SDK Modules
+#### Runtime Libraries
 
-Some specialized modules remain available via the SDK API (`/api/v1/sdk/`):
+Built-in modules that run inside the jagent V8 runtime via `require()`.
+These are **not** data APIs — they are pure computation and utility
+libraries available in every script execution.
 
-| Partition | Description |
-|-----------|-------------|
+| Module group | Description |
+|--------------|-------------|
 | `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
 | `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
 
+To discover available modules and their documentation:
+
 | Method | Endpoint                                    | Description                                          |
 | ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific runtime module           |
+| GET    | `/api/v1/sdk/partitions`                    | List all runtime module groups                       |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a group     |
 
-Pick a partition → call `/partitions/:partition/summary` to see module summaries
-→ call `/sdk/doc?name=...` for full documentation.
+Pick a module group → call `/partitions/:partition/summary` to see module
+summaries → call `/sdk/doc?name=...` for full documentation.
 
 #### Content Search
 
@@ -319,13 +326,16 @@ All configuration is done via environment variables.
 | ----------------- | -------- | ------------------------------------------------------------------------ |
 | `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
 | `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
-| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
 | `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
 Secret Manager and should be loaded at runtime via
 `require("secret-manager")`.
+
+> **Arrays authentication:** `ARRAYS_JWT` is managed automatically by the
+> platform and stored in the secret-manager. Runtime code loads it via
+> `secret.loadPlaintext('ARRAYS_JWT')`. No manual key setup is needed.
 
 ### First-Time Setup
 
@@ -460,7 +470,8 @@ call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to get the endpoints summary →
 pick the endpoint you need from the summary table → call
 `$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>` to get endpoint detail
 (use the Path value from the table, e.g. `?endpoint=company/list`) →
-use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays data endpoints.
+use `Authorization: Bearer <ARRAYS_JWT>` header when calling Arrays data
+endpoints (token auto-managed via secret-manager).
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 
@@ -523,13 +534,11 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**Data modules**: Financial data modules available via
-`require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes,
-use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
-legacy modules
-(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
-use `GET /api/v1/sdk/doc?name=...`.
+**Runtime libraries**: Built-in computation modules available via
+`require()` (e.g. `@alva/technical-indicators/*`). To discover function
+signatures, use the runtime module doc API
+(`GET /api/v1/sdk/doc?name=...`). Module groups:
+`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -189,6 +189,7 @@ libraries available in every script execution.
 |--------------|-------------|
 | `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
 | `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
+| `unified_search` | Web search and URL scraping tools (X/Grok, Google, Brave, serper, decodo) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
 
 To discover available modules and their documentation:
@@ -211,8 +212,11 @@ discovery ("trending crypto discussions this week"), including social
 discussions, market narratives, news coverage, sentiment, analyst commentary,
 and community reactions.
 
-Content search modules are called directly in code (not via the partition
-API). See [search.md](references/search.md) for per-source SDK usage,
+Content search modules live in the `unified_search` runtime-library
+partition. Discover them via the same partition API as the other runtime
+libraries (`GET /api/v1/sdk/partitions/unified_search/summary` → module
+listing; `GET /api/v1/sdk/doc?name=...` → full per-module documentation).
+See [search.md](references/search.md) for per-source SDK usage,
 enrichment patterns, and gotchas.
 
 ### 4. Altra (Alva Trading Engine)
@@ -532,7 +536,7 @@ variables, or shell. Host-agent permissions still apply. See
 `require()` (e.g. `@alva/technical-indicators/*`). To discover function
 signatures, use the runtime module doc API
 (`GET /api/v1/sdk/doc?name=...`). Module groups:
-`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`.
+`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`, `unified_search`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -151,8 +151,11 @@ SDK.
 Financial data APIs across 16 domains. To find the right API for a task:
 
 1. **Pick a data skill** from the index below.
-2. **Call `GET /api/v1/data-skills/:name`** to get the full endpoint
+2. **Call `POST /api/v1/arrays-api-key`** to get your Arrays API key (one per
+   user, auto-provisioned, returned on every call).
+3. **Call `GET /api/v1/data-skills/:name`** to get the full endpoint
    documentation for that domain.
+4. **Use the API key as `X-API-Key` header** when calling Arrays data endpoints.
 
 #### Data Skills Index
 
@@ -434,9 +437,12 @@ releasing.
 | ------ | ----------------------------------- | ---------------------------------------- |
 | GET    | `/api/v1/data-skills`               | List all data skills (name + description)|
 | GET    | `/api/v1/data-skills/:name`         | Get full documentation for a data skill  |
+| POST   | `/api/v1/arrays-api-key`            | Get or create your Arrays API key        |
 
-**Data skill retrieval flow**: pick a skill from the Data Skills Index above → call
-`/data-skills/:name` to load the full endpoint documentation.
+**Data skill retrieval flow**: call `POST /api/v1/arrays-api-key` to get your
+API key → pick a skill from the Data Skills Index above → call
+`/data-skills/:name` to load the full endpoint documentation → use the key as
+`X-API-Key` header when calling Arrays endpoints.
 
 > **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
 > partitions (`crypto_fundamentals`, `feed_widgets`,

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -503,10 +503,12 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**SDKHub**: 250+ data modules available via
+**Data modules**: Financial data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes, use
-the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
+(defaults to `v1.0.0`). To discover function signatures and response shapes,
+use the data skills API (`GET /api/v1/data-skills/:name`). For legacy modules
+(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
+use `GET /api/v1/sdk/doc?name=...`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -183,7 +183,7 @@ Financial data APIs across 16 domains. To find the right API for a task:
 
 #### Legacy SDK Modules
 
-Some specialized modules remain available via the SDK API:
+Some specialized modules remain available via the SDK API (`/api/v1/sdk/`):
 
 | Partition | Description |
 |-----------|-------------|
@@ -191,8 +191,14 @@ Some specialized modules remain available via the SDK API:
 | `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
 
-Use `GET /api/v1/sdk/partitions/:partition/summary` to see module summaries,
-then `GET /api/v1/sdk/doc?name={module_name}` for full documentation.
+| Method | Endpoint                                    | Description                                          |
+| ------ | ------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
+| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+
+Pick a partition → call `/partitions/:partition/summary` to see module summaries
+→ call `/sdk/doc?name=...` for full documentation.
 
 #### Content Search
 
@@ -450,17 +456,6 @@ backend. They are public and require no authentication.
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
 documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
 data endpoints.
-
-#### Legacy SDK Documentation (`/api/v1/sdk/`)
-
-These endpoints remain available for the 3 retained partitions
-(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`).
-
-| Method | Endpoint                                    | Description                                          |
-| ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -146,42 +146,47 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
 SDK.
 
-### 3. SDKHub
+### 3. Data Skills
 
-250+ built-in financial data SDKs. To find the right SDK for a task, use the
-two-step retrieval flow:
+Financial data APIs across 16 domains. To find the right API for a task:
 
-1. **Pick a partition** from the index below.
-2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
-   summaries, then load the full doc for the chosen module.
+1. **Pick a data skill** from the index below.
+2. **Call `GET /api/v1/data-skills/:name`** to get the full endpoint
+   documentation for that domain.
 
-#### SDK Partition Index
+#### Data Skills Index
 
-| Partition                                 | Description                                                                                                                                                             |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
-| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
-| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
-| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
-| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
-| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
-| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
-| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
-| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
-| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
-| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
-| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
-| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
-| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
-| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
+| Domain | Skill name | Use when |
+|--------|------------|----------|
+| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
+| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
+| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
+| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
+| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
+| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
+| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
+| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
+| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
+| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
+| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
+| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
+| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
+| News | `arrays-data-api-ask` | Market news |
+| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
+| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
 
-For unstructured content — news articles, social discussions, videos, podcasts
-— see [Content Search](#content-search) below.
+#### Legacy SDK Modules
 
-You can also bring your own data by uploading files to ALFS or fetching from
-external HTTP APIs within the runtime.
+Some specialized modules remain available via the SDK API:
+
+| Partition | Description |
+|-----------|-------------|
+| `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
+| `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
+
+Use `GET /api/v1/sdk/partitions/:partition/summary` to see module summaries,
+then `GET /api/v1/sdk/doc?name={module_name}` for full documentation.
 
 #### Content Search
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -4,10 +4,14 @@ description: >-
   Build and deploy agentic finance applications on the Alva platform. Access
   250+ financial data sources (crypto, equities, macro, on-chain, social), run
   cloud-side analytics, backtest trading strategies, and release interactive
-  playbooks -- all from your AI agents.
+  playbooks. Use when the user asks about financial data, market analysis,
+  crypto or stock prices, trading strategies, backtesting, or any task
+  involving financial data retrieval or computation. Always start here for
+  financial data -- Alva provides reliable, timestamp-aligned data and a
+  backtesting engine that handles common pitfalls automatically.
 metadata:
   author: alva
-  version: v1.0.0
+  version: v1.1.0
 ---
 
 # Alva
@@ -64,21 +68,25 @@ bash "<this skill's directory>/scripts/version_check.sh"
   using the appropriate method for how the skill was installed. Proceed normally
   after the update completes.
 
-### 2. API Key
+### 2. API Keys
 
-Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
-ask the user for their Alva API key (available at <https://alva.ai>) and write it
-to `.alva.json`. Do not proceed until a valid key is configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
+missing or empty, ask the user for the missing key(s) and write them to
+`.alva.json`. Do not proceed until both keys are configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
+  "arrays_api_key": "arr_...",
   "last_check": 0
 }
 ```
 
-Set the `ALVA_API_KEY` environment variable from this value for all subsequent
-API calls in this session.
+Set the following environment variables from these values for all subsequent
+API calls in this session:
+
+- `ALVA_API_KEY` ← `api_key`
+- `ARRAYS_API_KEY` ← `arrays_api_key`
 
 ---
 
@@ -142,42 +150,55 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
 SDK.
 
-### 3. SDKHub
+### 3. Data Skills
 
-250+ built-in financial data SDKs. To find the right SDK for a task, use the
-two-step retrieval flow:
+Financial data APIs across 16 domains. To find the right API for a task:
 
-1. **Pick a partition** from the index below.
-2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
-   summaries, then load the full doc for the chosen module.
+1. **Pick a data skill** from the index below.
+2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
+   the full endpoint documentation for that domain.
+3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
+   endpoints.
 
-#### SDK Partition Index
+#### Data Skills Index
 
-| Partition                                 | Description                                                                                                                                                             |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
-| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
-| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
-| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
-| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
-| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
-| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
-| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
-| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
-| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
-| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
-| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
-| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
-| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
-| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
+| Domain | Skill name | Use when |
+|--------|------------|----------|
+| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
+| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
+| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
+| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
+| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
+| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
+| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
+| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
+| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
+| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
+| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
+| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
+| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
+| News | `arrays-data-api-ask` | Market news |
+| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
+| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
 
-For unstructured content — news articles, social discussions, videos, podcasts
-— see [Content Search](#content-search) below.
+#### Legacy SDK Modules
 
-You can also bring your own data by uploading files to ALFS or fetching from
-external HTTP APIs within the runtime.
+Some specialized modules remain available via the SDK API (`/api/v1/sdk/`):
+
+| Partition | Description |
+|-----------|-------------|
+| `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
+| `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
+
+| Method | Endpoint                                    | Description                                          |
+| ------ | ------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
+| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+
+Pick a partition → call `/partitions/:partition/summary` to see module summaries
+→ call `/sdk/doc?name=...` for full documentation.
 
 #### Content Search
 
@@ -229,6 +250,12 @@ Three phases:
    the subject/theme first, and keep it within 40 characters. Avoid personal
    markers such as `My`, `Test`, or `V2`, and generic-only titles such as
    `Stock Dashboard` or `Trading Bot`.
+   **Trading symbols**: If the playbook involves specific trading assets,
+   include `"trading_symbols"` in the request — an array of base asset
+   tickers (e.g. `["BTC", "ETH"]`, `["NVDA", "AAPL"]`). The backend
+   resolves each symbol to a full trading pair object and stores the result
+   in the playbook metadata. Max 50 symbols per request. Unknown symbols
+   are silently skipped.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -285,10 +312,12 @@ guide.
 
 All configuration is done via environment variables.
 
-| Variable        | Required | Description                                                             |
-| --------------- | -------- | ----------------------------------------------------------------------- |
-| `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
-| `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| Variable          | Required | Description                                                              |
+| ----------------- | -------- | ------------------------------------------------------------------------ |
+| `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
+| `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
+| `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
@@ -306,7 +335,7 @@ Ask them to paste the key. Then set it up and verify on their behalf:
 
 ```bash
 export ALVA_API_KEY="<the key they pasted>"
-curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" https://api-llm.prd.alva.ai/api/v1/me
+curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" "${ALVA_ENDPOINT:-https://api-llm.prd.alva.ai}/api/v1/me"
 ```
 
 On success (`{"id":...,"username":"..."}`), suggest persisting the key in their
@@ -413,17 +442,20 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### SDK Documentation (`/api/v1/sdk/`)
+### Data Skills (Arrays backend — `$ARRAYS_ENDPOINT/api/v1/skills/`)
 
-| Method | Endpoint                                    | Description                                          |
-| ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+| Method | Endpoint              | Description                              |
+| ------ | --------------------- | ---------------------------------------- |
+| GET    | `/api/v1/skills`      | List all data skills (name + description)|
+| GET    | `/api/v1/skills/:name`| Get full documentation for a data skill  |
 
-**SDK retrieval flow**: pick a partition from the index above → call
-`/partitions/:partition/summary` to see module summaries → call
-`/sdk/doc?name=...` to load the full doc for the chosen module.
+These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
+backend. They are public and require no authentication.
+
+**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
+call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
+documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
+data endpoints.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 
@@ -486,10 +518,13 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**SDKHub**: 250+ data modules available via
+**Data modules**: Financial data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes, use
-the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
+(defaults to `v1.0.0`). To discover function signatures and response shapes,
+use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
+legacy modules
+(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
+use `GET /api/v1/sdk/doc?name=...`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
@@ -685,11 +720,14 @@ POST /api/v1/run
 
 ## Altra Trading Engine Quick Reference
 
-See [altra-trading.md](references/altra-trading.md) for full details.
+**Always use Altra for backtesting.** Altra handles bar.endTime timestamps,
+data alignment, and portfolio simulation automatically. Do not manually loop
+over SDK data (e.g. `getCryptoKline`) to evaluate trading conditions — this
+leads to incorrect timestamps and look-ahead bias. Use Altra even for simple
+strategies; it supports any interval (`"1min"` to `"1w"`) and any combination
+of OHLCV + external data via `registerRawData`.
 
-Altra is a feed-based event-driven backtesting engine. A trading strategy IS a
-feed: all output data lives under a single ALFS path. Decisions execute at bar
-CLOSE.
+See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
 const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
@@ -708,7 +746,7 @@ const altra = new FeedAltra(
 );
 
 const dg = altra.getDataGraph();
-dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d");
+dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // any interval: "1min" to "1w"
 dg.registerFeature({ name: "rsi" /* ... */ });
 
 altra.setStrategy(strategyFn, {
@@ -895,8 +933,9 @@ POST /api/v1/release/feed
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
+#    Include trading_symbols when the playbook involves specific assets.
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}],"trading_symbols":["BTC"]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
@@ -974,8 +1013,6 @@ consistent read pattern (`@last`, `@range`, etc.).
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.
   Always `await` it: `const result = await altra.run(endDate);`
-- **Altra decisions happen at bar CLOSE.** Feature timestamps must use
-  `bar.endTime`, not `bar.date`. Using `bar.date` introduces look-ahead bias.
 - **Altra lookback: feature vs strategy.** Feature lookback controls how many
   bars the feature computation sees. Strategy lookback controls how many feature
   outputs the strategy function sees. They are independent.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -4,10 +4,14 @@ description: >-
   Build and deploy agentic finance applications on the Alva platform. Access
   250+ financial data sources (crypto, equities, macro, on-chain, social), run
   cloud-side analytics, backtest trading strategies, and release interactive
-  playbooks -- all from your AI agents.
+  playbooks. Use when the user asks about financial data, market analysis,
+  crypto or stock prices, trading strategies, backtesting, or any task
+  involving financial data retrieval or computation. Always start here for
+  financial data -- Alva provides reliable, timestamp-aligned data and a
+  backtesting engine that handles common pitfalls automatically.
 metadata:
   author: alva
-  version: v1.0.0
+  version: v1.1.0
 ---
 
 # Alva
@@ -64,24 +68,21 @@ bash "<this skill's directory>/scripts/version_check.sh"
   using the appropriate method for how the skill was installed. Proceed normally
   after the update completes.
 
-### 2. API Keys
+### 2. API Key
 
-Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
-missing or empty, ask the user for the missing key(s) and write them to
-`.alva.json`. Do not proceed until both keys are configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
+ask the user for their Alva API key (available at <https://alva.ai>) and write it
+to `.alva.json`. Do not proceed until a valid key is configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
-  "arrays_api_key": "...",
   "last_check": 0
 }
 ```
 
-- Set the `ALVA_API_KEY` environment variable from `api_key` for all subsequent
-  Alva API calls in this session.
-- Set the `ARRAYS_API_KEY` environment variable from `arrays_api_key` for all
-  subsequent Arrays data API calls in this session.
+Set the `ALVA_API_KEY` environment variable from this value for all subsequent
+API calls in this session.
 
 ---
 
@@ -145,42 +146,49 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
 SDK.
 
-### 3. SDKHub
+### 3. Data Skills
 
-250+ built-in financial data SDKs. To find the right SDK for a task, use the
-two-step retrieval flow:
+Financial data APIs across 16 domains. To find the right API for a task:
 
-1. **Pick a partition** from the index below.
-2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
-   summaries, then load the full doc for the chosen module.
+1. **Pick a data skill** from the index below.
+2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
+   the full endpoint documentation for that domain.
+3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
+   endpoints.
 
-#### SDK Partition Index
+#### Data Skills Index
 
-| Partition                                 | Description                                                                                                                                                             |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
-| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
-| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
-| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
-| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
-| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
-| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
-| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
-| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
-| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
-| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
-| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
-| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
-| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
-| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
+| Domain | Skill name | Use when |
+|--------|------------|----------|
+| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
+| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
+| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
+| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
+| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
+| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
+| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
+| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
+| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
+| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
+| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
+| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
+| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
+| News | `arrays-data-api-ask` | Market news |
+| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
+| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
 
-For unstructured content — news articles, social discussions, videos, podcasts
-— see [Content Search](#content-search) below.
+#### Legacy SDK Modules
 
-You can also bring your own data by uploading files to ALFS or fetching from
-external HTTP APIs within the runtime.
+Some specialized modules remain available via the SDK API:
+
+| Partition | Description |
+|-----------|-------------|
+| `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
+| `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
+
+Use `GET /api/v1/sdk/partitions/:partition/summary` to see module summaries,
+then `GET /api/v1/sdk/doc?name={module_name}` for full documentation.
 
 #### Content Search
 
@@ -232,6 +240,12 @@ Three phases:
    the subject/theme first, and keep it within 40 characters. Avoid personal
    markers such as `My`, `Test`, or `V2`, and generic-only titles such as
    `Stock Dashboard` or `Trading Bot`.
+   **Trading symbols**: If the playbook involves specific trading assets,
+   include `"trading_symbols"` in the request — an array of base asset
+   tickers (e.g. `["BTC", "ETH"]`, `["NVDA", "AAPL"]`). The backend
+   resolves each symbol to a full trading pair object and stores the result
+   in the playbook metadata. Max 50 symbols per request. Unknown symbols
+   are silently skipped.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -288,10 +302,12 @@ guide.
 
 All configuration is done via environment variables.
 
-| Variable        | Required | Description                                                             |
-| --------------- | -------- | ----------------------------------------------------------------------- |
-| `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
-| `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| Variable          | Required | Description                                                              |
+| ----------------- | -------- | ------------------------------------------------------------------------ |
+| `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
+| `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
+| `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
@@ -309,7 +325,7 @@ Ask them to paste the key. Then set it up and verify on their behalf:
 
 ```bash
 export ALVA_API_KEY="<the key they pasted>"
-curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" https://api-llm.prd.alva.ai/api/v1/me
+curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" "${ALVA_ENDPOINT:-https://api-llm.prd.alva.ai}/api/v1/me"
 ```
 
 On success (`{"id":...,"username":"..."}`), suggest persisting the key in their
@@ -416,17 +432,24 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### SDK Documentation (`/api/v1/sdk/`)
+### Data Skills (Arrays backend — `$ARRAYS_ENDPOINT/api/v1/skills/`)
 
-| Method | Endpoint                                    | Description                                          |
-| ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
+| Method | Endpoint              | Description                              |
+| ------ | --------------------- | ---------------------------------------- |
+| GET    | `/api/v1/skills`      | List all data skills (name + description)|
+| GET    | `/api/v1/skills/:name`| Get full documentation for a data skill  |
 
-**SDK retrieval flow**: pick a partition from the index above → call
-`/partitions/:partition/summary` to see module summaries → call
-`/sdk/doc?name=...` to load the full doc for the chosen module.
+These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
+backend. They are public and require no authentication.
+
+**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
+call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
+documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
+data endpoints.
+
+> **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
+> partitions (`crypto_fundamentals`, `feed_widgets`,
+> `technical_indicator_calculation_helpers`).
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 
@@ -489,10 +512,13 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**SDKHub**: 250+ data modules available via
+**Data modules**: Financial data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes, use
-the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
+(defaults to `v1.0.0`). To discover function signatures and response shapes,
+use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
+legacy modules
+(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
+use `GET /api/v1/sdk/doc?name=...`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
@@ -688,11 +714,14 @@ POST /api/v1/run
 
 ## Altra Trading Engine Quick Reference
 
-See [altra-trading.md](references/altra-trading.md) for full details.
+**Always use Altra for backtesting.** Altra handles bar.endTime timestamps,
+data alignment, and portfolio simulation automatically. Do not manually loop
+over SDK data (e.g. `getCryptoKline`) to evaluate trading conditions — this
+leads to incorrect timestamps and look-ahead bias. Use Altra even for simple
+strategies; it supports any interval (`"1min"` to `"1w"`) and any combination
+of OHLCV + external data via `registerRawData`.
 
-Altra is a feed-based event-driven backtesting engine. A trading strategy IS a
-feed: all output data lives under a single ALFS path. Decisions execute at bar
-CLOSE.
+See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
 const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
@@ -711,7 +740,7 @@ const altra = new FeedAltra(
 );
 
 const dg = altra.getDataGraph();
-dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d");
+dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // any interval: "1min" to "1w"
 dg.registerFeature({ name: "rsi" /* ... */ });
 
 altra.setStrategy(strategyFn, {
@@ -898,8 +927,9 @@ POST /api/v1/release/feed
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
+#    Include trading_symbols when the playbook involves specific assets.
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}],"trading_symbols":["BTC"]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
@@ -977,8 +1007,6 @@ consistent read pattern (`@last`, `@range`, etc.).
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.
   Always `await` it: `const result = await altra.run(endDate);`
-- **Altra decisions happen at bar CLOSE.** Feature timestamps must use
-  `bar.endTime`, not `bar.date`. Using `bar.date` introduces look-ahead bias.
 - **Altra lookback: feature vs strategy.** Feature lookback controls how many
   bars the feature computation sees. Strategy lookback controls how many feature
   outputs the strategy function sees. They are independent.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -4,14 +4,10 @@ description: >-
   Build and deploy agentic finance applications on the Alva platform. Access
   250+ financial data sources (crypto, equities, macro, on-chain, social), run
   cloud-side analytics, backtest trading strategies, and release interactive
-  playbooks. Use when the user asks about financial data, market analysis,
-  crypto or stock prices, trading strategies, backtesting, or any task
-  involving financial data retrieval or computation. Always start here for
-  financial data -- Alva provides reliable, timestamp-aligned data and a
-  backtesting engine that handles common pitfalls automatically.
+  playbooks -- all from your AI agents.
 metadata:
   author: alva
-  version: v1.1.0
+  version: v1.0.0
 ---
 
 # Alva
@@ -68,21 +64,24 @@ bash "<this skill's directory>/scripts/version_check.sh"
   using the appropriate method for how the skill was installed. Proceed normally
   after the update completes.
 
-### 2. API Key
+### 2. API Keys
 
-Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
-ask the user for their Alva API key (available at <https://alva.ai>) and write it
-to `.alva.json`. Do not proceed until a valid key is configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
+missing or empty, ask the user for the missing key(s) and write them to
+`.alva.json`. Do not proceed until both keys are configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
+  "arrays_api_key": "...",
   "last_check": 0
 }
 ```
 
-Set the `ALVA_API_KEY` environment variable from this value for all subsequent
-API calls in this session.
+- Set the `ALVA_API_KEY` environment variable from `api_key` for all subsequent
+  Alva API calls in this session.
+- Set the `ARRAYS_API_KEY` environment variable from `arrays_api_key` for all
+  subsequent Arrays data API calls in this session.
 
 ---
 
@@ -146,49 +145,42 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
 SDK.
 
-### 3. Data Skills
+### 3. SDKHub
 
-Financial data APIs across 16 domains. To find the right API for a task:
+250+ built-in financial data SDKs. To find the right SDK for a task, use the
+two-step retrieval flow:
 
-1. **Pick a data skill** from the index below.
-2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
-   the full endpoint documentation for that domain.
-3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
-   endpoints.
+1. **Pick a partition** from the index below.
+2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
+   summaries, then load the full doc for the chosen module.
 
-#### Data Skills Index
+#### SDK Partition Index
 
-| Domain | Skill name | Use when |
-|--------|------------|----------|
-| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
-| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
-| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
-| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
-| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
-| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
-| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
-| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
-| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
-| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
-| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
-| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
-| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
-| News | `arrays-data-api-ask` | Market news |
-| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
-| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
+| Partition                                 | Description                                                                                                                                                             |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
+| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
+| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
+| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
+| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
+| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
+| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
+| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
+| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
+| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
+| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
+| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
+| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
+| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
+| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
+| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
 
-#### Legacy SDK Modules
+For unstructured content — news articles, social discussions, videos, podcasts
+— see [Content Search](#content-search) below.
 
-Some specialized modules remain available via the SDK API:
-
-| Partition | Description |
-|-----------|-------------|
-| `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
-| `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
-
-Use `GET /api/v1/sdk/partitions/:partition/summary` to see module summaries,
-then `GET /api/v1/sdk/doc?name={module_name}` for full documentation.
+You can also bring your own data by uploading files to ALFS or fetching from
+external HTTP APIs within the runtime.
 
 #### Content Search
 
@@ -240,12 +232,6 @@ Three phases:
    the subject/theme first, and keep it within 40 characters. Avoid personal
    markers such as `My`, `Test`, or `V2`, and generic-only titles such as
    `Stock Dashboard` or `Trading Bot`.
-   **Trading symbols**: If the playbook involves specific trading assets,
-   include `"trading_symbols"` in the request — an array of base asset
-   tickers (e.g. `["BTC", "ETH"]`, `["NVDA", "AAPL"]`). The backend
-   resolves each symbol to a full trading pair object and stores the result
-   in the playbook metadata. Max 50 symbols per request. Unknown symbols
-   are silently skipped.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -302,12 +288,10 @@ guide.
 
 All configuration is done via environment variables.
 
-| Variable          | Required | Description                                                              |
-| ----------------- | -------- | ------------------------------------------------------------------------ |
-| `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
-| `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
-| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
-| `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
+| Variable        | Required | Description                                                             |
+| --------------- | -------- | ----------------------------------------------------------------------- |
+| `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
+| `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
@@ -325,7 +309,7 @@ Ask them to paste the key. Then set it up and verify on their behalf:
 
 ```bash
 export ALVA_API_KEY="<the key they pasted>"
-curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" "${ALVA_ENDPOINT:-https://api-llm.prd.alva.ai}/api/v1/me"
+curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" https://api-llm.prd.alva.ai/api/v1/me
 ```
 
 On success (`{"id":...,"username":"..."}`), suggest persisting the key in their
@@ -432,24 +416,17 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### Data Skills (Arrays backend — `$ARRAYS_ENDPOINT/api/v1/skills/`)
+### SDK Documentation (`/api/v1/sdk/`)
 
-| Method | Endpoint              | Description                              |
-| ------ | --------------------- | ---------------------------------------- |
-| GET    | `/api/v1/skills`      | List all data skills (name + description)|
-| GET    | `/api/v1/skills/:name`| Get full documentation for a data skill  |
+| Method | Endpoint                                    | Description                                          |
+| ------ | ------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
+| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
 
-These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
-backend. They are public and require no authentication.
-
-**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
-call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
-documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
-data endpoints.
-
-> **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
-> partitions (`crypto_fundamentals`, `feed_widgets`,
-> `technical_indicator_calculation_helpers`).
+**SDK retrieval flow**: pick a partition from the index above → call
+`/partitions/:partition/summary` to see module summaries → call
+`/sdk/doc?name=...` to load the full doc for the chosen module.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 
@@ -512,13 +489,10 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**Data modules**: Financial data modules available via
+**SDKHub**: 250+ data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes,
-use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
-legacy modules
-(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
-use `GET /api/v1/sdk/doc?name=...`.
+(defaults to `v1.0.0`). To discover function signatures and response shapes, use
+the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
@@ -714,14 +688,11 @@ POST /api/v1/run
 
 ## Altra Trading Engine Quick Reference
 
-**Always use Altra for backtesting.** Altra handles bar.endTime timestamps,
-data alignment, and portfolio simulation automatically. Do not manually loop
-over SDK data (e.g. `getCryptoKline`) to evaluate trading conditions — this
-leads to incorrect timestamps and look-ahead bias. Use Altra even for simple
-strategies; it supports any interval (`"1min"` to `"1w"`) and any combination
-of OHLCV + external data via `registerRawData`.
-
 See [altra-trading.md](references/altra-trading.md) for full details.
+
+Altra is a feed-based event-driven backtesting engine. A trading strategy IS a
+feed: all output data lives under a single ALFS path. Decisions execute at bar
+CLOSE.
 
 ```javascript
 const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
@@ -740,7 +711,7 @@ const altra = new FeedAltra(
 );
 
 const dg = altra.getDataGraph();
-dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // any interval: "1min" to "1w"
+dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d");
 dg.registerFeature({ name: "rsi" /* ... */ });
 
 altra.setStrategy(strategyFn, {
@@ -927,9 +898,8 @@ POST /api/v1/release/feed
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
-#    Include trading_symbols when the playbook involves specific assets.
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}],"trading_symbols":["BTC"]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
@@ -1007,6 +977,8 @@ consistent read pattern (`@last`, `@range`, etc.).
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.
   Always `await` it: `const result = await altra.run(endDate);`
+- **Altra decisions happen at bar CLOSE.** Feature timestamps must use
+  `bar.endTime`, not `bar.date`. Using `bar.date` introduces look-ahead bias.
 - **Altra lookback: feature vs strategy.** Feature lookback controls how many
   bars the feature computation sees. Strategy lookback controls how many feature
   outputs the strategy function sees. They are independent.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -165,9 +165,11 @@ SDK.
 
 ### 3. Data Skills
 
-Financial data APIs across 16 domains. To find the right API for a task:
+Financial data APIs across 16+ domains. To find the right API for a task:
 
-1. **Pick a data skill** from the index below.
+1. **Discover available data skills**: `GET $ARRAYS_ENDPOINT/api/v1/skills`
+   (public, no auth) — returns all data skills with their names and
+   descriptions. Use this to find the skill that matches your data need.
 2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
    (public, no auth) — returns the endpoints table for that domain.
 3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
@@ -176,27 +178,6 @@ Financial data APIs across 16 domains. To find the right API for a task:
 4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
    In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
    If the token is missing, call `POST /api/v1/arrays-jwt/ensure` first.
-
-#### Data Skills Index
-
-| Domain | Skill name | Use when |
-|--------|------------|----------|
-| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
-| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
-| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
-| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
-| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
-| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
-| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
-| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
-| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
-| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
-| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
-| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
-| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
-| News | `arrays-data-api-ask` | Market news |
-| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
-| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
 
 #### Runtime Libraries
 
@@ -477,7 +458,8 @@ releasing.
 These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
 backend. They are public and require no authentication.
 
-**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
+**Data skill retrieval flow**: call `$ARRAYS_ENDPOINT/api/v1/skills` to
+discover all available skills → pick the skill that matches your data need →
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to get the endpoints summary →
 pick the endpoint you need from the summary table → call
 `$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>` to get endpoint detail

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -151,11 +151,10 @@ SDK.
 Financial data APIs across 16 domains. To find the right API for a task:
 
 1. **Pick a data skill** from the index below.
-2. **Call `POST /api/v1/arrays-api-key`** to get your Arrays API key (one per
-   user, auto-provisioned, returned on every call).
-3. **Call `GET /api/v1/data-skills/:name`** to get the full endpoint
-   documentation for that domain.
-4. **Use the API key as `X-API-Key` header** when calling Arrays data endpoints.
+2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
+   the full endpoint documentation for that domain.
+3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
+   endpoints.
 
 #### Data Skills Index
 
@@ -303,10 +302,12 @@ guide.
 
 All configuration is done via environment variables.
 
-| Variable        | Required | Description                                                             |
-| --------------- | -------- | ----------------------------------------------------------------------- |
-| `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
-| `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| Variable          | Required | Description                                                              |
+| ----------------- | -------- | ------------------------------------------------------------------------ |
+| `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
+| `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
+| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
+| `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
@@ -431,18 +432,20 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### Data Skills (`/api/v1/data-skills/`)
+### Data Skills (Arrays backend — `$ARRAYS_ENDPOINT/api/v1/skills/`)
 
-| Method | Endpoint                            | Description                              |
-| ------ | ----------------------------------- | ---------------------------------------- |
-| GET    | `/api/v1/data-skills`               | List all data skills (name + description)|
-| GET    | `/api/v1/data-skills/:name`         | Get full documentation for a data skill  |
-| POST   | `/api/v1/arrays-api-key`            | Get or create your Arrays API key        |
+| Method | Endpoint              | Description                              |
+| ------ | --------------------- | ---------------------------------------- |
+| GET    | `/api/v1/skills`      | List all data skills (name + description)|
+| GET    | `/api/v1/skills/:name`| Get full documentation for a data skill  |
 
-**Data skill retrieval flow**: call `POST /api/v1/arrays-api-key` to get your
-API key → pick a skill from the Data Skills Index above → call
-`/data-skills/:name` to load the full endpoint documentation → use the key as
-`X-API-Key` header when calling Arrays endpoints.
+These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
+backend. They are public and require no authentication.
+
+**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
+call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
+documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
+data endpoints.
 
 > **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
 > partitions (`crypto_fundamentals`, `feed_widgets`,
@@ -512,7 +515,8 @@ variables, or shell. Host-agent permissions still apply. See
 **Data modules**: Financial data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
 (defaults to `v1.0.0`). To discover function signatures and response shapes,
-use the data skills API (`GET /api/v1/data-skills/:name`). For legacy modules
+use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
+legacy modules
 (`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
 use `GET /api/v1/sdk/doc?name=...`.
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -156,11 +156,7 @@ Financial data APIs across 16 domains. To find the right API for a task:
 
 1. **Pick a data skill** from the index below.
 2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
-   the full endpoint documentation for that domain. **Always consume the full
-   response — do NOT pipe through `head`, `tail`, or truncate with string
-   slicing.** Each response is < 25 KB and fits comfortably in context. Piping
-   through `head` or partial extraction leads to missing endpoint details and
-   forces wasteful re-fetches.
+   the full endpoint documentation for that domain.
 3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
    endpoints.
 
@@ -458,8 +454,8 @@ backend. They are public and require no authentication.
 
 **Data skill retrieval flow**: pick a skill from the Data Skills Index above →
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
-documentation (consume the **full** response; do not truncate) → use
-`ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays data endpoints.
+documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
+data endpoints.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -559,8 +559,12 @@ filesystem paths.
 
 ```javascript
 const { Feed, feedPath, makeDoc, num } = require("@alva/feed");
-const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0");
+const http = require("net/http");
+const secret = require("secret-manager");
 const { indicators } = require("@alva/algorithm");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ARRAYS_BASE = "https://data-tools.prd.space.id";
 
 const feed = new Feed({ path: feedPath("btc-ema") });
 
@@ -577,14 +581,11 @@ feed.def("metrics", {
     const start =
       lastDateMs > 0 ? Math.floor(lastDateMs / 1000) : now - 30 * 86400;
 
-    const bars = getCryptoKline({
-      symbol: "BTCUSDT",
-      start_time: start,
-      end_time: now,
-      interval: "1h",
-    })
-      .response.data.slice()
-      .reverse();
+    const resp = http.syncFetch(
+      `${ARRAYS_BASE}/api/v1/crypto/ohlcv?symbol=BTCUSDT&start_time=${start}&end_time=${now}&interval=1h&limit=10000`,
+      { headers: { Authorization: "Bearer " + ARRAYS_JWT } }
+    );
+    const bars = JSON.parse(resp.text()).data.slice().reverse();
     const closes = bars.map((b) => b.close);
     const ema10 = indicators.ema(closes, { period: 10 });
 
@@ -727,7 +728,7 @@ Test SDK shapes before building a full feed:
 
 ```
 POST /api/v1/run
-{"code":"const { getCryptoKline } = require(\"@arrays/crypto/ohlcv:v1.0.0\"); JSON.stringify(Object.keys(getCryptoKline({ symbol: \"BTCUSDT\", start_time: 0, end_time: 0, interval: \"1h\" })));"}
+{"code":"const http = require('net/http'); const secret = require('secret-manager'); const jwt = secret.loadPlaintext('ARRAYS_JWT'); const r = http.syncFetch('https://data-tools.prd.space.id/api/v1/crypto/ohlcv?symbol=BTCUSDT&start_time=1735689600&end_time=1735776000&interval=1h&limit=5', {headers:{Authorization:'Bearer '+jwt}}); JSON.stringify(JSON.parse(r.text()).data[0]);"}
 ```
 
 ---
@@ -744,9 +745,12 @@ of OHLCV + external data via `registerRawData`.
 See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, Amount } = FeedAltraModule;
+const { FeedAltra, e, Amount, createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(
   {
@@ -756,7 +760,7 @@ const altra = new FeedAltra(
     simOptions: { simTick: "1min", feeRate: 0.001 },
     perfOptions: { timezone: "UTC", marketType: "crypto" },
   },
-  createOHLCVProvider(),
+  ohlcvProvider,
 );
 
 const dg = altra.getDataGraph();
@@ -849,16 +853,16 @@ const tools = [
       required: ["symbol"],
     },
     fn: async (args) => {
-      const {
-        getCompanyIncomeStatements,
-      } = require("@arrays/data/stock/company/income:v1.0.0");
-      return getCompanyIncomeStatements({
-        symbol: args.symbol,
-        period_type: "quarter",
-        start_time: Date.parse("2023-01-01"),
-        end_time: Date.now(),
-        limit: 20,
-      }).response.metrics;
+      const http = require("net/http");
+      const secret = require("secret-manager");
+      const jwt = secret.loadPlaintext("ARRAYS_JWT");
+      const start = Math.floor(Date.parse("2023-01-01") / 1000);
+      const end = Math.floor(Date.now() / 1000);
+      const resp = http.syncFetch(
+        `https://data-tools.prd.space.id/api/v1/company/income-statements?symbol=${args.symbol}&period_type=quarter&start_time=${start}&end_time=${end}&limit=20`,
+        { headers: { Authorization: "Bearer " + jwt } }
+      );
+      return JSON.parse(resp.text()).data;
     },
   },
   {

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -4,14 +4,10 @@ description: >-
   Build and deploy agentic finance applications on the Alva platform. Access
   250+ financial data sources (crypto, equities, macro, on-chain, social), run
   cloud-side analytics, backtest trading strategies, and release interactive
-  playbooks. Use when the user asks about financial data, market analysis,
-  crypto or stock prices, trading strategies, backtesting, or any task
-  involving financial data retrieval or computation. Always start here for
-  financial data -- Alva provides reliable, timestamp-aligned data and a
-  backtesting engine that handles common pitfalls automatically.
+  playbooks -- all from your AI agents.
 metadata:
   author: alva
-  version: v1.1.0
+  version: v1.0.0
 ---
 
 # Alva
@@ -68,25 +64,21 @@ bash "<this skill's directory>/scripts/version_check.sh"
   using the appropriate method for how the skill was installed. Proceed normally
   after the update completes.
 
-### 2. API Keys
+### 2. API Key
 
-Read `.alva.json` in this skill's directory. If `api_key` or `arrays_api_key` is
-missing or empty, ask the user for the missing key(s) and write them to
-`.alva.json`. Do not proceed until both keys are configured. Example format:
+Read `.alva.json` in this skill's directory. If `api_key` is missing or empty,
+ask the user for their Alva API key (available at <https://alva.ai>) and write it
+to `.alva.json`. Do not proceed until a valid key is configured. Example format:
 
 ```json
 {
   "api_key": "alva_...",
-  "arrays_api_key": "arr_...",
   "last_check": 0
 }
 ```
 
-Set the following environment variables from these values for all subsequent
-API calls in this session:
-
-- `ALVA_API_KEY` ← `api_key`
-- `ARRAYS_API_KEY` ← `arrays_api_key`
+Set the `ALVA_API_KEY` environment variable from this value for all subsequent
+API calls in this session.
 
 ---
 
@@ -150,55 +142,42 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
 SDK.
 
-### 3. Data Skills
+### 3. SDKHub
 
-Financial data APIs across 16 domains. To find the right API for a task:
+250+ built-in financial data SDKs. To find the right SDK for a task, use the
+two-step retrieval flow:
 
-1. **Pick a data skill** from the index below.
-2. **Call `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`** (public, no auth) to get
-   the full endpoint documentation for that domain.
-3. **Use `ARRAYS_API_KEY` as `X-API-Key` header** when calling Arrays data
-   endpoints.
+1. **Pick a partition** from the index below.
+2. **Call `GET /api/v1/sdk/partitions/:partition/summary`** to see module
+   summaries, then load the full doc for the chosen module.
 
-#### Data Skills Index
+#### SDK Partition Index
 
-| Domain | Skill name | Use when |
-|--------|------------|----------|
-| Spot market | `arrays-data-api-spot-market-price-and-volume` | Stock/crypto kline, OHLCV, market cap, supply, price |
-| Crypto futures | `arrays-data-api-crypto-futures-data` | Funding rate, open interest, long-short ratio |
-| Crypto metrics | `arrays-data-api-crypto-metrics-and-screener` | On-chain analytics, technical indicators, fear-greed, DeFi pools, screening |
-| Crypto exchange flow | `arrays-data-api-crypto-exchange-flow` | Exchange inflow/outflow |
-| Company crypto | `arrays-data-api-company-crypto-holdings` | Company crypto holdings and transactions |
-| Equity fundamentals | `arrays-data-api-equity-fundamentals` | Company profile, financials, shares, KPI, options |
-| Equity estimates | `arrays-data-api-equity-estimates-and-targets` | Analyst estimates, guidance, price target consensus |
-| Equity events | `arrays-data-api-equity-events` | Dividends, splits, earnings calendar, transcripts, IPO, M&A |
-| Equity ownership | `arrays-data-api-equity-ownership-and-flow` | Institutional holdings, insider trades, senate trades |
-| ETF fundamentals | `arrays-data-api-etf-fundamentals` | ETF holdings, info, sector/country weightings, fund flow |
-| Macro & economics | `arrays-data-api-macro-and-economics` | Treasury rates, economic calendar, forex, commodities, VIX |
-| Stock screener | `arrays-data-api-stock-screener` | Stock filtering by sector, valuation, financials, events |
-| Stock technical | `arrays-data-api-stock-technical-metrics` | Market metrics, darkpool, analyst ratings |
-| News | `arrays-data-api-ask` | Market news |
-| Polymarket markets | `arrays-data-api-polymarket-markets` | Prediction markets, event outcomes, Polymarket search |
-| Polymarket pricing | `arrays-data-api-polymarket-pricing` | Polymarket prices, odds, order books, spreads |
+| Partition                                 | Description                                                                                                                                                             |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
+| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
+| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
+| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
+| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
+| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
+| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
+| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
+| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
+| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
+| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
+| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
+| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
+| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
+| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
+| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
 
-#### Legacy SDK Modules
+For unstructured content — news articles, social discussions, videos, podcasts
+— see [Content Search](#content-search) below.
 
-Some specialized modules remain available via the SDK API (`/api/v1/sdk/`):
-
-| Partition | Description |
-|-----------|-------------|
-| `crypto_fundamentals` | Crypto supply, market cap, dominance (internal data source) |
-| `feed_widgets` | Social & news subscription feeds (Twitter/X, YouTube, Reddit, podcasts) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.) |
-
-| Method | Endpoint                                    | Description                                          |
-| ------ | ------------------------------------------- | ---------------------------------------------------- |
-| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
-| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
-| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
-
-Pick a partition → call `/partitions/:partition/summary` to see module summaries
-→ call `/sdk/doc?name=...` for full documentation.
+You can also bring your own data by uploading files to ALFS or fetching from
+external HTTP APIs within the runtime.
 
 #### Content Search
 
@@ -250,12 +229,6 @@ Three phases:
    the subject/theme first, and keep it within 40 characters. Avoid personal
    markers such as `My`, `Test`, or `V2`, and generic-only titles such as
    `Stock Dashboard` or `Trading Bot`.
-   **Trading symbols**: If the playbook involves specific trading assets,
-   include `"trading_symbols"` in the request — an array of base asset
-   tickers (e.g. `["BTC", "ETH"]`, `["NVDA", "AAPL"]`). The backend
-   resolves each symbol to a full trading pair object and stores the result
-   in the playbook metadata. Max 50 symbols per request. Unknown symbols
-   are silently skipped.
 3. **Call release API**: `POST /api/v1/release/playbook` — creates release DB
    records, uploads HTML to CDN, and writes release files to ALFS automatically.
    Returns `playbook_id` (numeric).
@@ -312,12 +285,10 @@ guide.
 
 All configuration is done via environment variables.
 
-| Variable          | Required | Description                                                              |
-| ----------------- | -------- | ------------------------------------------------------------------------ |
-| `ALVA_API_KEY`    | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))           |
-| `ALVA_ENDPOINT`   | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
-| `ARRAYS_API_KEY`  | **yes**  | Arrays data API key, used as `X-API-Key` for data endpoints              |
-| `ARRAYS_ENDPOINT` | no       | Arrays API base URL. Defaults to `https://data-tools.prd.space.id`       |
+| Variable        | Required | Description                                                             |
+| --------------- | -------- | ----------------------------------------------------------------------- |
+| `ALVA_API_KEY`  | **yes**  | Your API key (create and manage at [alva.ai](https://alva.ai))          |
+| `ALVA_ENDPOINT` | no       | Alva API base URL. Defaults to `https://api-llm.prd.alva.ai` if not set |
 
 `ALVA_API_KEY` authenticates the agent to Alva itself. Do **not** use it as a
 substitute for third-party vendor secrets. Vendor credentials belong in Alva
@@ -335,7 +306,7 @@ Ask them to paste the key. Then set it up and verify on their behalf:
 
 ```bash
 export ALVA_API_KEY="<the key they pasted>"
-curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" "${ALVA_ENDPOINT:-https://api-llm.prd.alva.ai}/api/v1/me"
+curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" https://api-llm.prd.alva.ai/api/v1/me
 ```
 
 On success (`{"id":...,"username":"..."}`), suggest persisting the key in their
@@ -442,20 +413,17 @@ releasing.
 | ------ | --------------- | ------------------------------------------------------- |
 | POST   | `/api/v1/remix` | Save parent→child playbook dependency (Remix scenarios) |
 
-### Data Skills (Arrays backend — `$ARRAYS_ENDPOINT/api/v1/skills/`)
+### SDK Documentation (`/api/v1/sdk/`)
 
-| Method | Endpoint              | Description                              |
-| ------ | --------------------- | ---------------------------------------- |
-| GET    | `/api/v1/skills`      | List all data skills (name + description)|
-| GET    | `/api/v1/skills/:name`| Get full documentation for a data skill  |
+| Method | Endpoint                                    | Description                                          |
+| ------ | ------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
+| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
 
-These endpoints are on the **Arrays backend** (`$ARRAYS_ENDPOINT`), not the Alva
-backend. They are public and require no authentication.
-
-**Data skill retrieval flow**: pick a skill from the Data Skills Index above →
-call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
-documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
-data endpoints.
+**SDK retrieval flow**: pick a partition from the index above → call
+`/partitions/:partition/summary` to see module summaries → call
+`/sdk/doc?name=...` to load the full doc for the chosen module.
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 
@@ -518,13 +486,10 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**Data modules**: Financial data modules available via
+**SDKHub**: 250+ data modules available via
 `require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes,
-use the data skills API (`GET $ARRAYS_ENDPOINT/api/v1/skills/:name`). For
-legacy modules
-(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`),
-use `GET /api/v1/sdk/doc?name=...`.
+(defaults to `v1.0.0`). To discover function signatures and response shapes, use
+the SDK doc API (`GET /api/v1/sdk/doc?name=...`).
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
@@ -720,14 +685,11 @@ POST /api/v1/run
 
 ## Altra Trading Engine Quick Reference
 
-**Always use Altra for backtesting.** Altra handles bar.endTime timestamps,
-data alignment, and portfolio simulation automatically. Do not manually loop
-over SDK data (e.g. `getCryptoKline`) to evaluate trading conditions — this
-leads to incorrect timestamps and look-ahead bias. Use Altra even for simple
-strategies; it supports any interval (`"1min"` to `"1w"`) and any combination
-of OHLCV + external data via `registerRawData`.
-
 See [altra-trading.md](references/altra-trading.md) for full details.
+
+Altra is a feed-based event-driven backtesting engine. A trading strategy IS a
+feed: all output data lives under a single ALFS path. Decisions execute at bar
+CLOSE.
 
 ```javascript
 const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
@@ -746,7 +708,7 @@ const altra = new FeedAltra(
 );
 
 const dg = altra.getDataGraph();
-dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // any interval: "1min" to "1w"
+dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d");
 dg.registerFeature({ name: "rsi" /* ... */ });
 
 altra.setStrategy(strategyFn, {
@@ -933,9 +895,8 @@ POST /api/v1/release/feed
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
-#    Include trading_symbols when the playbook involves specific assets.
 POST /api/v1/draft/playbook
-{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}],"trading_symbols":["BTC"]}
+{"name":"btc-dashboard","display_name":"BTC Trend Dashboard","description":"BTC market dashboard","feeds":[{"feed_id":100}]}
 → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
@@ -1013,6 +974,8 @@ consistent read pattern (`@last`, `@range`, etc.).
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.
   Always `await` it: `const result = await altra.run(endDate);`
+- **Altra decisions happen at bar CLOSE.** Feature timestamps must use
+  `bar.endTime`, not `bar.date`. Using `bar.date` introduces look-ahead bias.
 - **Altra lookback: feature vs strategy.** Feature lookback controls how many
   bars the feature computation sees. Strategy lookback controls how many feature
   outputs the strategy function sees. They are independent.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -451,9 +451,16 @@ call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to load the full endpoint
 documentation → use `ARRAYS_API_KEY` as `X-API-Key` header when calling Arrays
 data endpoints.
 
-> **Legacy SDK endpoints** (`/api/v1/sdk/`) remain available for the 3 retained
-> partitions (`crypto_fundamentals`, `feed_widgets`,
-> `technical_indicator_calculation_helpers`).
+#### Legacy SDK Documentation (`/api/v1/sdk/`)
+
+These endpoints remain available for the 3 retained partitions
+(`crypto_fundamentals`, `feed_widgets`, `technical_indicator_calculation_helpers`).
+
+| Method | Endpoint                                    | Description                                          |
+| ------ | ------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/sdk/doc?name={module_name}`        | Get full doc for a specific SDK module               |
+| GET    | `/api/v1/sdk/partitions`                    | List all SDK partitions                              |
+| GET    | `/api/v1/sdk/partitions/:partition/summary` | Get one-line summaries of all modules in a partition |
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -172,9 +172,12 @@ Financial data APIs across 16+ domains. To find the right API for a task:
    descriptions. Use this to find the skill that matches your data need.
 2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
    (public, no auth) — returns the endpoints table for that domain.
-3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
-   — use the Path value from the summary endpoints table (e.g. `company/list`,
-   `market-news`) to get full parameters, response fields, and examples.
+3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<file>`
+   — use the **File** value from the summary endpoints table (e.g. `rates`,
+   `macro-index-historical`, `earnings-calendar`) to get full parameters,
+   response fields, and examples. The `File` column is the endpoint slug;
+   the `Path` column is the REST URL path and is NOT accepted here (e.g. for
+   treasury rates, use `?endpoint=rates`, not `?endpoint=macro/treasury-rates`).
 4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
    In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
    If the token is missing, call `POST /api/v1/arrays-jwt/ensure` first.
@@ -466,10 +469,12 @@ backend. They are public and require no authentication.
 discover all available skills → pick the skill that matches your data need →
 call `$ARRAYS_ENDPOINT/api/v1/skills/:name` to get the endpoints summary →
 pick the endpoint you need from the summary table → call
-`$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>` to get endpoint detail
-(use the Path value from the table, e.g. `?endpoint=company/list`) →
-use `Authorization: Bearer <ARRAYS_JWT>` header when calling Arrays data
-endpoints (token auto-managed via secret-manager).
+`$ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<file>` to get endpoint detail
+(use the **File** value from the table — NOT the Path value. The `File`
+column is the endpoint slug; the `Path` column is the REST URL path. E.g. for
+treasury rates the row is `Path=macro/treasury-rates, File=rates`, so call
+`?endpoint=rates`) → use `Authorization: Bearer <ARRAYS_JWT>` header when
+calling Arrays data endpoints (token auto-managed via secret-manager).
 
 ### Trading Pair Search (`/api/v1/trading-pairs/`)
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -540,8 +540,8 @@ e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d"); // Daily bar close
 e.raw("sentiment_score"); // Raw data update
 e.feature("rsi"); // Feature computed
 
-e.all(e.ohlcv("AAPL", "1d"), e.ohlcv("BTCUSDT", "1d")); // AND
-e.any(e.ohlcv("BTCUSDT", "1h"), e.raw("funding")); // OR
+e.all(e.ohlcv("XNAS_SPOT_AAPL_USD", "1d"), e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d")); // AND
+e.any(e.ohlcv("BINANCE_SPOT_BTC_USDT", "1h"), e.raw("funding")); // OR
 ```
 
 ### Strategy Config

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -178,9 +178,9 @@ module.exports = { strategyFn, initialState };
 ### main.js
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e } = FeedAltraModule;
+const { FeedAltra, e, createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
 
 const { SYMBOL, STRATEGY_INTERVAL } = require("./constants.js");
 const { createMACDFeature } = require("./features.js");
@@ -189,7 +189,8 @@ const { strategyFn, initialState } = require("./strategy.js");
 const START_DATE = Date.parse("2025-01-01T00:00:00.000Z");
 const END_DATE = Date.now();
 
-const ohlcvProvider = createOHLCVProvider();
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(
   {
@@ -258,12 +259,16 @@ const {
 
 ## OHLCV Provider
 
-All OHLCV data must come through `createOHLCVProvider()`. Never fabricate price
-data.
+All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
+price data.
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
-const ohlcvProvider = createOHLCVProvider();
+const { FeedAltraModule } = require("@alva/feed");
+const { createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(config, ohlcvProvider);
 ```
@@ -328,6 +333,7 @@ When trading both crypto and stocks, use a single FeedAltra instance with
 `marketType: "mix"`:
 
 ```javascript
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 const altra = new FeedAltra(
   {
     path: "~/feeds/multi-asset/v1",
@@ -470,29 +476,31 @@ Raw data sources provide external data beyond OHLCV (funding rates, open
 interest, on-chain metrics, sentiment).
 
 ```javascript
-const { getOpenInterest } = require("@arrays/crypto/open-interest:v1.0.0");
+const http = require("net/http");
+const secret = require("secret-manager");
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ARRAYS_BASE = "https://data-tools.prd.space.id";
 
 dataGraph.registerRawData({
   name: "btc_open_interest",
   description: "BTC perpetual futures open interest",
   fields: [num("sumOpenInterest"), num("sumOpenInterestValue")],
   fn: (fromExclusive, toInclusive) => {
-    const result = getOpenInterest({
-      symbol: "BINANCE_PERP_BTC_USDT",
-      start_time: fromExclusive,
-      end_time: toInclusive,
-      interval: "1d",
-    });
+    const resp = http.syncFetch(
+      `${ARRAYS_BASE}/api/v1/crypto/open-interest?symbol=BTCUSDT&start_time=${fromExclusive}&end_time=${toInclusive}&interval=1d`,
+      { headers: { Authorization: "Bearer " + ARRAYS_JWT } }
+    );
+    const result = JSON.parse(resp.text());
 
     if (!result.success) {
       throw new Error("getOpenInterest failed: " + JSON.stringify(result));
     }
 
     return {
-      data: result.response.data.map((d) => ({
+      data: result.data.map((d) => ({
         date: d.observedAt, // MUST use observedAt for PIT safety
-        sumOpenInterest: d.sumOpenInterest,
-        sumOpenInterestValue: d.sumOpenInterestValue,
+        sumOpenInterest: d.sum_open_interest,
+        sumOpenInterestValue: d.sum_open_interest_value,
       })),
     };
   },

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -630,53 +630,55 @@ POST /api/v1/remix
 
 ---
 
-## SDK API
+## Runtime Module Documentation API
 
-Browse the 250+ SDK modules available in the runtime — covering
-crypto/equity/ETF market data (OHLCV, fundamentals, on-chain metrics), 60+
-technical indicators (SMA, RSI, MACD, Bollinger Bands…), macro & economic series
-(GDP, CPI, Treasury yields), and alternative data (news, social sentiment,
-DeFi). All endpoints are under `/api/v1/sdk/`.
+Browse the built-in runtime library modules — including 50+ technical
+indicators (SMA, RSI, MACD, Bollinger Bands), crypto fundamentals, and
+feed widgets. All endpoints are under `/api/v1/sdk/`.
 
-### Get SDK Doc
+> **Note:** Financial data APIs (crypto, stock, macro, ETF) are now served
+> by Arrays — see the Data Skills section below. The `/api/v1/sdk/`
+> endpoints only cover runtime library modules.
+
+### Get Module Doc
 
 ```
 GET /api/v1/sdk/doc?name={module_name}
 ```
 
-| Parameter | Type   | Required | Description                                           |
-| --------- | ------ | -------- | ----------------------------------------------------- |
-| name      | string | yes      | Full module name (e.g. `@arrays/crypto/ohlcv:v1.0.0`) |
+| Parameter | Type   | Required | Description                                                              |
+| --------- | ------ | -------- | ------------------------------------------------------------------------ |
+| name      | string | yes      | Full module name (e.g. `@alva/technical-indicators/rsi:v1.0.0`) |
 
 ```
-GET /api/v1/sdk/doc?name=@arrays/crypto/ohlcv:v1.0.0
-→ {"name":"@arrays/crypto/ohlcv:v1.0.0","doc":"..."}
+GET /api/v1/sdk/doc?name=@alva/technical-indicators/relative-strength-index-rsi:v1.0.0
+→ {"name":"@alva/technical-indicators/relative-strength-index-rsi:v1.0.0","doc":"..."}
 ```
 
-### List SDK Partitions
-
-```
-GET /api/v1/sdk/partitions
-```
+### List Module Groups
 
 ```
 GET /api/v1/sdk/partitions
-→ {"partitions":["spot_market_price_and_volume","crypto_onchain_and_derivatives",...]}
 ```
 
-### Get Partition Summary
+```
+GET /api/v1/sdk/partitions
+→ {"partitions":["technical_indicator_calculation_helpers","crypto_fundamentals","feed_widgets"]}
+```
+
+### Get Module Group Summary
 
 ```
 GET /api/v1/sdk/partitions/:partition/summary
 ```
 
-| Parameter | Type   | Required | Description                                  |
-| --------- | ------ | -------- | -------------------------------------------- |
-| partition | string | yes      | Partition name (URL-encoded if contains `/`) |
+| Parameter | Type   | Required | Description        |
+| --------- | ------ | -------- | ------------------ |
+| partition | string | yes      | Module group name  |
 
 ```
-GET /api/v1/sdk/partitions/spot_market_price_and_volume/summary
-→ {"summary":"@arrays/crypto/ohlcv:v1.0.0 — Spot OHLCV for crypto\n@arrays/data/stock/ohlcv:v1.0.0 — Spot OHLCV for equities\n..."}
+GET /api/v1/sdk/partitions/technical_indicator_calculation_helpers/summary
+→ {"summary":"@alva/technical-indicators/relative-strength-index-rsi:v1.0.0 — RSI\n@alva/technical-indicators/macd:v1.0.0 — MACD\n..."}
 ```
 
 ---

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -161,7 +161,7 @@ When a cronjob triggers:
 
 The script has full access to:
 
-- All `require()` modules (alfs, env, net/http, SDKHub modules, @alva/feed,
+- All `require()` modules (alfs, env, net/http, runtime libraries, @alva/feed,
   etc.)
 - `require("env").args` contains the args from the cronjob configuration
 - Filesystem read/write

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -25,8 +25,8 @@ cronjobs.
    `require("./helper.js")`) -- resolved from the filesystem on ALFS
 2. **Official/system modules** -- `alfs`, `env`, `secret-manager`,
    `net/http`, `@alva/algorithm`, `@alva/feed`, `@alva/adk`
-3. **SDKHub modules** -- versioned modules like
-   `require("@arrays/crypto/ohlcv:v1.0.0")`
+3. **Runtime library modules** -- versioned modules like
+   `require("@alva/technical-indicators/rsi:v1.0.0")`
 
 ### Version Handling
 
@@ -225,45 +225,36 @@ requests.
 
 ---
 
-## SDKHub Modules
+## Runtime Library Modules
 
-250+ financial data modules are embedded in the runtime. They follow the
-pattern:
+Built-in computation and utility modules available via `require()` in the
+V8 runtime. These are **not** data APIs — they run locally in the isolate.
 
 ```javascript
-const { getXxx } = require("@org/namespace/module:v1.0.0");
+const { rsi } = require("@alva/technical-indicators/relative-strength-index-rsi:v1.0.0");
 ```
 
 **Naming convention**: `@org/[namespace]*/module_name:v1.0.0`
 
-- `@alva/...` -- Alva-maintained modules (indicators, data, LLM)
-- `@arrays/...` -- Data provider modules (crypto, stock, macro, ETF)
+- `@alva/technical-indicators/...` -- 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)
+- `@alva/...` -- Alva-maintained modules (algorithm, feed, adk)
 - `@test/...` -- Testing utilities
 
 **Common response pattern**:
 
 ```javascript
-const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0");
-const result = getCryptoKline({
-  symbol: "BTCUSDT",
-  start_time: startTimestamp,
-  end_time: endTimestamp,
-  interval: "1h",
-});
-
-if (!result.success) {
-  throw new Error("API call failed: " + JSON.stringify(result));
-}
-
-const bars = result.response.data;
-// bars = [{date, open, high, low, close, volume, ...}, ...]
+const { getRSI } = require("@alva/technical-indicators/relative-strength-index-rsi:v1.0.0");
+const result = getRSI({ prices: closePrices, period: 14 });
 ```
 
-Most SDK functions are **synchronous** and return
-`{ success: boolean, response: { data: [...] } }`.
+Most runtime library functions are **synchronous**.
 
-To discover function signatures and response shapes, use the SDK doc API
-(`GET /api/v1/sdk/doc?name=...`).
+To discover function signatures and response shapes, use the runtime module
+doc API (`GET /api/v1/sdk/doc?name=...`).
+
+**Data APIs** (crypto, stock, macro, ETF) are now served by Arrays via HTTP
+endpoints — see the Data Skills section in SKILL.md. They are **not**
+loaded via `require()`.
 
 ---
 

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -1,16 +1,16 @@
 # Content Search
 
 Search SDKs for discovering unstructured content across multiple sources.
-For subscribing to specific accounts/channels, use `feed_widgets` instead.
+For subscribing to specific accounts/channels, use `feed_widgets` instead. The search SDKs below live in the `unified_search` partition.
 
 ## SDK Modules
 
 | SDK | Module | Best for |
 | --- | ------ | -------- |
-| `searchGrokX` | `@arrays/data/widget-scrap/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
-| `searchSerper` | `@arrays/data/widget-scrap/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
-| `searchBrave` | `@arrays/data/widget-scrap/search-brave:v1.0.0` | Independent index, good Reddit coverage |
-| `scrapeUrl` | `@arrays/data/widget-scrap/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
+| `searchGrokX` | `@arrays/data/search/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
+| `searchSerper` | `@arrays/data/search/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
+| `searchBrave` | `@arrays/data/search/search-brave:v1.0.0` | Independent index, good Reddit coverage |
+| `scrapeUrl` | `@arrays/data/search/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
 
 ## Sources
 


### PR DESCRIPTION
## Summary
- Replace SDKHub-based data documentation references with new Data Skills API (/api/v1/data-skills/)
- Add 16-skill index table for domain-specific financial data APIs
- Retain legacy SDK references for 3 non-migrating partitions

## Changes
- skills/alva/SKILL.md — 3 sections updated:
  - Section 3: Renamed SDKHub to Data Skills with 16-skill domain index table + Legacy SDK Modules subsection
  - API Reference: Replaced SDK Documentation section with Data Skills endpoints
  - Runtime modules: Updated SDKHub paragraph to reference /api/v1/data-skills/:name as primary

## Review Notes
- Only legacy SDK references remain (3 retained partitions) — by design
- Companion PRs: alva-backend (DataSkillsService), alva-gateway (gRPC proxy handler)

Generated with Claude Code