### PR TITLE
docs(alva): add invoke API reference and run path restriction

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -222,7 +222,7 @@ guide.
 
 | Document                                                | Contents                                                                                                   |
 | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [api-reference.md](references/api-reference.md)         | Full REST API reference (filesystem, run, deploy, user info, time series paths)                            |
+| [api-reference.md](references/api-reference.md)         | Full REST API reference (filesystem, run, invoke, deploy, user info, time series paths)                   |
 | [jagent-runtime.md](references/jagent-runtime.md)       | Writing jagent scripts: module system, built-in modules, async model, constraints                          |
 | [feed-sdk.md](references/feed-sdk.md)                   | Feed SDK guide: creating data feeds, time series, upstreams, state management                              |
 | [altra-trading.md](references/altra-trading.md)         | Altra backtesting engine: strategies, features, signals, testing, debugging                                |
@@ -331,6 +331,58 @@ Paths: `~/data/file.json` (home-relative) or `/alva/home/<username>/...`
 | Method | Endpoint      | Description                                                                  |
 | ------ | ------------- | ---------------------------------------------------------------------------- |
 | POST   | `/api/v1/run` | Execute JavaScript (inline `code` or `entry_path` to a script on filesystem) |
+
+`entry_path` and `working_dir` must resolve within **your own** home directory.
+Absolute paths pointing to another user's home are rejected with
+`PERMISSION_DENIED`. To execute another user's script, use the Invoke API.
+
+### Invoke (`/api/v1/invoke`)
+
+| Method | Endpoint         | Description                                          |
+| ------ | ---------------- | ---------------------------------------------------- |
+| POST   | `/api/v1/invoke` | Execute a script owned by another user on your behalf |
+
+Execute a published script under another user's ALFS home. The script runs with
+the **caller's** identity and credits — the owner only provides the code. The
+caller must have ALFS read/import permission on the script path (typically
+granted via `fs/grant`).
+
+**Authentication**: Invoke requires a JWT token (not an API key). In playbook
+pages embedded on `alva.ai`, the host page sends the viewer's JWT via
+`postMessage`. The playbook must listen for this message and attach the token
+to subsequent invoke requests.
+
+The playbook page must register a `message` event listener to receive the JWT:
+
+| Check                | Expected Value         | Description                           |
+| -------------------- | ---------------------- | ------------------------------------- |
+| `event.origin`       | `"https://alva.ai"`    | Reject messages from other origins    |
+| `event.data.type`    | `"alva-jwt-token"`     | Fixed event key — must match exactly  |
+| `event.data.token`   | `"Bearer eyJ…"`        | The JWT token to use for invoke calls |
+
+```javascript
+// Inside the playbook HTML — listen for JWT from the host page
+let jwtToken = null;
+window.addEventListener("message", (event) => {
+  if (event.origin !== "https://alva.ai") return;
+  if (event.data?.type === "alva-jwt-token" && event.data.token) {
+    jwtToken = event.data.token;
+  }
+});
+
+// Use the token when calling invoke
+async function invokeScript(owner, path, args) {
+  const resp = await fetch(`${ALVA_ENDPOINT}/api/v1/invoke`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": jwtToken,
+    },
+    body: JSON.stringify({ owner, path, args }),
+  });
+  return resp.json();
+}
+```
 
 ### Deploy (`/api/v1/deploy/`)
 

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -280,6 +280,99 @@ POST /api/v1/run
 
 ---
 
+## Invoke API (Cross-User Script Execution)
+
+Execute a script owned by another user. The script runs under the **caller's**
+identity and credits — the owner only provides the code path. The caller must
+have ALFS read/import permission on the script (typically granted via
+`fs/grant`).
+
+```
+POST /api/v1/invoke
+```
+
+### Authentication
+
+Invoke requires a **JWT token** (not an API key). In playbook pages hosted on
+`alva.ai`, the host page delivers the viewer's JWT via `postMessage`. The
+playbook must listen for this event and attach the token to invoke requests:
+
+The playbook page must register a `message` event listener to receive the JWT:
+
+| Check                | Expected Value         | Description                           |
+| -------------------- | ---------------------- | ------------------------------------- |
+| `event.origin`       | `"https://alva.ai"`    | Reject messages from other origins    |
+| `event.data.type`    | `"alva-jwt-token"`     | Fixed event key — must match exactly  |
+| `event.data.token`   | `"Bearer eyJ…"`        | The JWT token to use for invoke calls |
+
+```javascript
+let jwtToken = null;
+window.addEventListener("message", (event) => {
+  if (event.origin !== "https://alva.ai") return;
+  if (event.data?.type === "alva-jwt-token" && event.data.token) {
+    jwtToken = event.data.token;
+  }
+});
+
+async function invokeScript(owner, path, args) {
+  const resp = await fetch(`${ALVA_ENDPOINT}/api/v1/invoke`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": jwtToken,
+    },
+    body: JSON.stringify({ owner, path, args }),
+  });
+  return resp.json();
+}
+```
+
+### Request Fields
+
+| Field | Type   | Required | Description                                                   |
+| ----- | ------ | -------- | ------------------------------------------------------------- |
+| owner | string | yes      | Username of the script owner                                  |
+| path  | string | yes      | Relative path under the owner's home (no leading `/` or `~/`) |
+| args  | object | no       | JSON accessible via `require("env").args`                     |
+
+Path must be **relative** — absolute paths and path traversal (`../`) are
+rejected.
+
+### Response Fields
+
+| Field  | Type   | Description                             |
+| ------ | ------ | --------------------------------------- |
+| result | string | JSON-encoded return value               |
+| logs   | string | Captured stderr output                  |
+| stats  | object | `credits_used` (int64), `duration_ms` (int64) |
+| status | string | `"completed"` or `"failed"`             |
+| error  | string | Error message when status is `"failed"` (absent on success) |
+
+### Examples
+
+```
+# Invoke another user's script
+POST /api/v1/invoke
+{"owner":"luke","path":"feeds/debate/v1/main.js","args":{"question":"Should I buy Bitcoin?"}}
+→ {"result":"{\"answer\":\"42\"}","logs":"debug info","stats":{"credits_used":5,"duration_ms":1200},"status":"completed"}
+
+# Invoke without arguments
+POST /api/v1/invoke
+{"owner":"alice","path":"tools/summarize.js"}
+→ {"result":"\"ok\"","logs":"","stats":{"credits_used":1,"duration_ms":50},"status":"completed"}
+```
+
+### Key Differences from Run API
+
+| Aspect          | Run (`/api/v1/run`)               | Invoke (`/api/v1/invoke`)                |
+| --------------- | --------------------------------- | ---------------------------------------- |
+| Auth            | API key or JWT                    | JWT only (via `postMessage` in playbooks) |
+| Code source     | Inline code or own `entry_path`   | Another user's script path only          |
+| Path restriction | Must be within caller's own home | Relative path under owner's home         |
+| Identity/billing | Caller                           | Caller                                   |
+
+---
+
 ## Deploy API (Cronjobs)
 
 Schedule scripts as cronjobs for automated execution. All endpoints are under


### PR DESCRIPTION
Document the new /api/v1/invoke endpoint for cross-user script execution, including JWT auth via postMessage, request/response schema, and usage examples. Note the run API path restriction to caller's own home directory.

Made-with: Cursor

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
