### PR TITLE
Add cronjob limit error handling and pre-release deploy gate

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -207,6 +207,24 @@ cronjobs on Alva Cloud. They run continuously on your chosen schedule (e.g.
 every hour, every day). All data is private by default; grant public access to
 specific paths so anyone -- or any playbook page -- can read the data.
 
+#### Handling the cronjob limit (max 20)
+
+If `POST /api/v1/deploy/cronjob` returns a rate-limit error (max 20 cronjobs),
+do **not** silently skip deployment and continue to release. Instead:
+
+1. **List** all cronjobs: `GET /api/v1/deploy/cronjobs`
+2. **Identify** candidates for cleanup — look for cronjobs whose feed paths no
+   longer exist on ALFS (`GET /api/v1/fs/stat`), or that belong to playbooks
+   the user is replacing with the current build.
+3. **Ask the user** which cronjobs to delete, showing the list with name, path,
+   and cron expression. If the user confirms, delete them:
+   `DELETE /api/v1/deploy/cronjob/:id`
+4. **Retry** the deploy after freeing slots.
+5. If cleanup is not possible or the user declines, **stop the release flow**
+   and inform the user that the playbook cannot be deployed with scheduled
+   updates. Do not proceed to release a playbook that claims to update on a
+   schedule when no cronjob exists.
+
 ### 6. Build the Playbook Web App
 
 After your data pipelines are deployed and producing data, build the playbook's
@@ -217,6 +235,18 @@ default to a live playbook. A live playbook may mix live and static sections;
 only widgets that need fresh data must read cronjob-backed feeds at runtime.
 
 ### 7. Release
+
+**Pre-release gate**: Before starting the release sequence, verify that all
+feeds have active cronjobs (if the playbook is intended to show live data). If
+any feed's cronjob deploy failed and was not resolved, do **not** proceed with
+release. A released playbook with no data refresh mechanism will show stale
+data and mislead users.
+
+**Metadata accuracy**: Any update-frequency text in the playbook HTML (e.g.
+"updates every 4 hours") must reflect the actual deployed cron schedule. If no
+cronjob is active, the HTML must not claim any update frequency. Hardcoded
+frequency claims that do not match the real deployment state are a release
+blocker.
 
 Three phases:
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -292,3 +292,8 @@ GET /api/v1/fs/read?path=/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/
   first, update the script file, test it, then resume.
 - **Check execution results**: Read the feed's time series data to verify the
   cronjob is producing expected output.
+- **Handle the 20-cronjob limit gracefully**: If `POST /api/v1/deploy/cronjob`
+  returns a rate-limit error, list existing cronjobs, identify unused ones
+  (orphaned feeds, replaced playbooks), ask the user before deleting, then
+  retry. Never silently skip deployment and continue to release — a playbook
+  claiming scheduled updates with no active cronjob misleads users.


### PR DESCRIPTION
## Summary
- When cronjob deploy hits the 20-job rate limit, the agent now has step-by-step instructions to list existing cronjobs, identify orphaned/unused ones, ask the user before deleting, and retry deploy
- Adds a **pre-release gate**: block release if any feed's cronjob deploy failed and was not resolved
- Adds a **metadata accuracy rule**: update-frequency text in playbook HTML must match the actual cron schedule — no false operational claims

## Context
Discovered via `/alva-playbook-eval` on the `ai-pulse-tracker` trace ([trace](../digital-work/traces/ai-pulse-trace-2036749066696458240.json)). Both feeds' cronjob deploys failed (max 20 cronjobs) but the agent silently continued and released the playbook claiming "updates every 4-6 hours" with zero active cronjobs. The playbook went live with no data refresh mechanism.

## Changes
- `skills/alva/SKILL.md` — Section 5 (Deploy): added "Handling the cronjob limit" subsection with 5-step recovery flow. Section 7 (Release): added pre-release gate and metadata accuracy rule.
- `skills/alva/references/deployment.md` — Added tip about graceful limit handling.

## Test plan
- [ ] Build a playbook when user already has 20 active cronjobs — verify agent attempts cleanup instead of skipping
- [ ] Verify agent does not release a playbook when deploy failed and was unresolved
- [ ] Verify playbook HTML does not claim update frequency when no cronjob is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)