### PR TITLE
Add alva-playbook-eval skill

### DIFF
--- a/skills/alva-playbook-eval/SKILL.md
+++ b/skills/alva-playbook-eval/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: alva-playbook-eval
+description: >-
+  Evaluate playbooks produced with the Alva skill. Use when you need to find
+  infrastructure issues in SDK/doc usage, API flow, content legitimacy,
+  runtime/data/release quality, or convert real user examples into reusable
+  eval cases and coverage gaps.
+---
+
+# Alva Playbook Eval
+
+Use this skill when the job is to evaluate output from the `alva` skill, not to
+build the environment itself.
+
+## What This Skill Owns
+
+- Find infra issues in generated Alva playbooks and feeds
+- Separate infra bugs from `coverage_gap` cases
+- Report findings with structured evidence and health score
+- Sync all findings to Notion (single source of truth for tracking)
+- On user confirmation: fix issues via PR to `alva-ai/mono-meta` (routed to the right subdirectory)
+- Turn useful user examples into reusable eval cases
+
+## Runtime Context
+
+This skill typically runs in the same Forge session immediately after the
+`alva` skill completes. When that is the case, the full execution trace is
+already in your conversation context — use it directly instead of re-fetching.
+
+**Trace available in same-session runs:**
+
+- The original user prompt
+- Every API request and response (SDK doc lookups, feed creation, deploy,
+  grant, release)
+- Generated feed script source (`index.js`)
+- Generated playbook HTML (`index.html`)
+- Test execution output from `/api/v1/run` (`status`, `result`, `logs`,
+  `stats.duration_ms`)
+- Final `published_url` from `/api/v1/release/playbook`
+
+**Fallback for async / follow-up evals:**
+
+If the session trace is missing (async triage, rerun, or issue follow-up),
+you cannot judge checks that depend on the API call sequence (`sdk_doc`,
+`api_contract`). In async mode, only run checks against static artifacts:
+
+| Check scope | Categories | Requires |
+|---|---|---|
+| **Full** (same-session only) | `sdk_doc`, `api_contract`, `content_legitimacy` (trace checks) | API trace in context |
+| **Post-run observable** (async-safe) | `deploy_release` | Published URL + public read paths |
+| **Post-run observable** (async-safe) | `rendering` | Playbook HTML + optionally published URL |
+| **Static artifact** (async-safe) | `runtime`, `data_quality`, `content_legitimacy` (script + HTML checks) | Feed script + feed data + playbook HTML |
+| **Blocker log** (async-safe if trace has blockers) | `error_handling` | Trace blocker list or span error outputs |
+
+All API call ordering checks (deploy before release, grant before public read,
+draft before release) belong to `api_contract` and require the trace.
+`deploy_release` only checks post-run observable state: URL resolves, data is
+publicly readable, cronjob is active.
+
+Fetch these artifacts before running static checks:
+
+1. The user prompt or replay prompt (ask the caller if not provided)
+2. Feed script: `GET /api/v1/fs/read?path=~/feeds/{name}/v1/src/index.js`
+3. Playbook HTML: `GET /api/v1/fs/read?path=~/playbooks/{name}/index.html`
+4. Feed data sample: `GET /api/v1/fs/read?path=~/feeds/{name}/v1/data/{group}/{output}/@last/100`
+5. Feed latest point: `GET /api/v1/fs/read?path=~/feeds/{name}/v1/data/{group}/{output}/@now` (for freshness check)
+6. Cronjob status: `GET /api/v1/deploy/cronjob/{id}`
+7. Published URL existence: check if `published_url` resolves
+8. Screenshot: extract URL from trace's `screenshot_playbook` span output,
+   then `Read` the image for visual verification (see rubric § Rendering)
+
+If a run transcript or API trace log is available (e.g. persisted by Forge),
+also fetch it — this upgrades the eval to full scope.
+
+Do not guess or hallucinate evidence. Do not attempt `sdk_doc` or
+`api_contract` checks without the API trace.
+
+**JSON trace vs same-session trace:**
+
+A persisted JSON trace (e.g. from Forge trace export) typically records API
+spans but may lack:
+
+- Feed script and playbook HTML source code (only `bytes_written` recorded)
+- Agent's own tool calls (WebSearch/WebFetch) — critical for content
+  legitimacy trace checks
+- Model reasoning about why decisions were made
+
+When evaluating from a JSON trace, explicitly note which checks are degraded
+due to missing artifact content. If the published URL is accessible, fetch the
+HTML via WebFetch to partially compensate. Feed scripts cannot be recovered
+without authenticated API access.
+
+## Workflow
+
+### 1. Reconstruct the intended Alva flow
+
+Read the main `alva` skill and only the relevant references for this case. Map
+the request to the expected path:
+
+- Data/dashboard: SDK doc lookup -> runtime/feed -> grant -> deploy -> release
+- Strategy/backtest: Altra/feed flow -> output validation -> release
+- Content routing: refer to the main `alva` skill's SKILL.md § Content Search
+  and § SDK Partition Index for current routing rules. Do not hardcode routing
+  expectations here — the main skill is the source of truth
+- Remix: source read -> child creation -> lineage registration
+
+### 2. Run deterministic checks
+
+Use these categories exactly:
+
+- `sdk_doc`
+- `api_contract`
+- `content_legitimacy`
+- `runtime`
+- `error_handling`
+- `data_quality`
+- `deploy_release`
+- `rendering`
+- `coverage_gap`
+
+For the detailed checklist and severity rules, read
+[references/eval-rubric.md](references/eval-rubric.md).
+
+### 3. Attribute the result
+
+Prefer explicit attribution over vague failure summaries.
+
+- `infra issue`: the skill chose the wrong doc, wrong API order, wrong runtime pattern, bad data, bad release behavior, or injected illegitimate content
+- `coverage_gap`: the request is not reliably supported by the current skill/tool surface
+- `needs more evidence`: there is not enough trace or artifact evidence to decide yet
+
+Never mark an unsupported request as a success.
+
+### 4. Report findings
+
+The default eval output is a **findings report**. Do not auto-fix or auto-file
+issues unless the user explicitly asks. The eval's primary value is accurate
+diagnosis, not immediate action — misidentifying a root cause and pushing a
+wrong fix is worse than leaving a finding open.
+
+#### After reporting: fix on request
+
+When the user confirms a finding should be fixed, submit a PR. All findings
+(fixed or not) are tracked in Notion — GitHub is only for PRs that fix issues,
+not for tracking.
+
+| Attribution | Action |
+|---|---|
+| `infra issue` — fixable in code/docs | **Fix → PR** to `alva-ai/mono-meta` (user must confirm) |
+| `coverage_gap` | **Notion only** (tracked as expansion opportunity) |
+| `needs more evidence` | **Notion only** (Action = Pending) |
+
+**PR target** — route to the right subdirectory in `alva-ai/mono-meta`:
+
+| Problem area | Path in mono-meta |
+|---|---|
+| Skill docs, workflow, references | `code/public/skills/` |
+| Forge (agent execution, trace) | `code/forge/forge/` |
+| Frontend (playbook rendering, design system) | `code/frontend/frontend-monorepo/` |
+| Backend (API contract, deploy/release logic) | `code/backend/alva-backend/` |
+| Jagent runtime | `code/backend/jagent/` |
+| SDKHub (SDK docs, modules) | `code/backend/sdkhub/` |
+
+Only submit a PR when **all three** conditions are met:
+1. The root cause is locatable in the mono-meta codebase
+2. The evidence is high-confidence (not inferred from partial trace)
+3. The user explicitly confirms the fix direction
+
+If unsure, don't PR — just let it sit in Notion.
+
+#### Fix → PR workflow (on confirmation)
+
+1. Clone `alva-ai/mono-meta` (or reuse existing clone)
+2. Create a branch: `fix/<root-cause-key>` (e.g. `fix/cronjob-limit-error-handling`)
+3. Edit the relevant skill files to address the root cause
+4. Commit with a message that references the eval finding and trace
+5. Push and create a PR with:
+   - Summary of what was broken and why
+   - Link to the eval trace or playbook that exposed the issue
+   - Test plan describing how to verify the fix
+6. Update the Notion page: Action → `PR submitted`, Action Link → PR URL
+
+#### Output discipline
+
+- 1 PR per distinct root cause
+- prefer the top 1-3 important findings over long checklists
+- include category, severity, symptom, evidence, and action taken (PR link if any)
+
+### 5. Sync findings to Notion
+
+Every eval run automatically syncs its findings to the **Alva Eval Tracker**
+Notion database. This is the single source of truth for all eval findings —
+every finding goes here regardless of whether a PR is submitted.
+
+#### Notion config
+
+Stored locally at `~/.claude/skills/alva-playbook-eval/.notion-config` (not
+checked into version control). Read this file at runtime to get the values.
+
+```
+NOTION_API_KEY=ntn_...
+NOTION_DATABASE_ID=32fc6bac30df807cad33c161b9ef9da8
+```
+
+#### What to sync
+
+Create **one Notion page per finding** (not per eval run). Each finding becomes
+a row in the table.
+
+#### Notion database schema (8 columns)
+
+| Column | Notion Type | Content |
+|---|---|---|
+| `Name` | title | `[category][severity] root-cause-key` |
+| `Category` | select | `sdk_doc` / `api_contract` / `content_legitimacy` / `runtime` / `error_handling` / `data_quality` / `deploy_release` / `rendering` / `coverage_gap` |
+| `Severity` | select | `critical` / `high` / `medium` / `low` |
+| `Playbook Link` | url | playbook published URL |
+| `Symptom` | rich_text | one-sentence description |
+| `Action` | select | `PR submitted` / `Issue filed` / `Report only` / `Pending` |
+| `Action Link` | rich_text | PR or issue URL |
+| `Eval Date` | date | ISO date of the eval |
+
+#### Dedup before creating
+
+Query the Notion database for existing pages where `Name` matches the
+`root-cause-key`. Same slug = same finding.
+
+- **Match found, same playbook**: update the existing page (bump eval date,
+  update action/link if changed)
+- **Match found, different playbook**: this is the same root cause appearing
+  in a new playbook — create a new page (append playbook name to title for
+  disambiguation)
+- **No match**: create a new page
+
+#### Sync implementation
+
+```bash
+python3 -c "
+import json
+payload = {
+    'parent': {'database_id': '<DATABASE_ID>'},
+    'properties': {
+        'Name': {'title': [{'text': {'content': '<NAME>'}}]},
+        'Category': {'select': {'name': '<CATEGORY>'}},
+        'Severity': {'select': {'name': '<SEVERITY>'}},
+        'Playbook Link': {'url': '<PLAYBOOK_URL>'},
+        'Symptom': {'rich_text': [{'text': {'content': '<SYMPTOM>'}}]},
+        'Action': {'select': {'name': '<ACTION>'}},
+        'Action Link': {'rich_text': [{'text': {'content': '<ACTION_LINK>'}}]},
+        'Eval Date': {'date': {'start': '<DATE>'}}
+    }
+}
+print(json.dumps(payload))
+" | curl -s -X POST "https://api.notion.com/v1/pages" \
+  -H "Authorization: Bearer <NOTION_API_KEY>" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d @-
+```
+
+Replace `<PLACEHOLDER>` values with actual finding data. Run once per finding.
+
+#### Update existing pages (after PR or issue is filed)
+
+When an action is taken on a finding (PR submitted, issue filed), update the
+corresponding Notion page. Query by `Name` to find the page ID, then patch:
+
+```bash
+# 1. Find the page ID by querying the database
+curl -s -X POST "https://api.notion.com/v1/databases/<DATABASE_ID>/query" \
+  -H "Authorization: Bearer <NOTION_API_KEY>" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d '{"filter": {"property": "Name", "title": {"contains": "<ROOT_CAUSE_KEY>"}}}' \
+  # → extract page_id from results[0].id
+
+# 2. Update the page
+curl -s -X PATCH "https://api.notion.com/v1/pages/<PAGE_ID>" \
+  -H "Authorization: Bearer <NOTION_API_KEY>" \
+  -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -d '{"properties": {
+    "Action": {"select": {"name": "PR submitted"}},
+    "Action Link": {"rich_text": [{"text": {"content": "<PR_URL>"}}]}
+  }}'
+```
+
+#### Sync timing
+
+- Sync happens **after** the report is output to the user
+- When a PR is submitted or issue is filed, **update** the Notion page's
+  `Action` and `Action Link` using the update flow above
+- Sync failures should be logged but not block the eval output
+
+### 6. Expand the eval corpus
+
+When a real user example reveals a new blind spot, convert it into a normalized
+eval case stub. Use the case template in
+[references/eval-templates.md](references/eval-templates.md).
+
+Every case should capture:
+
+- `id`
+- `prompt`
+- `scenario_type`: `infra_regression` or `coverage_probe`
+- `minimum_acceptable_behavior`
+- the checks that should fire next time
+
+## Default Evaluation Priorities
+
+If you need to prioritize, do it in this order:
+
+1. Release path correctness
+2. Content legitimacy (all content from Alva pipeline or user BYOD)
+3. Error handling (blockers resolved before proceeding)
+4. Wrong SDK/doc or routing choice
+5. Runtime contract violations
+6. Data emptiness, NaN, timestamp/order issues
+7. Rendering issues
+8. Coverage expansion opportunities
+
+## Good Output Shape
+
+A strong eval response usually has:
+
+- A one-paragraph run summary
+- **Health score** (see rubric for scoring rules) — always include this
+- A short findings list ordered by severity, each with action taken:
+  - `infra issue` fixable in skill → PR link (e.g. `alva-ai/skills#69`)
+  - `infra issue` requiring platform change → GitHub issue link
+  - `coverage_gap` → GitHub issue link
+- A separate `Coverage Gaps` list when applicable
+- One or two proposed new eval cases if the example exposed a new blind spot

--- a/skills/alva-playbook-eval/references/eval-rubric.md
+++ b/skills/alva-playbook-eval/references/eval-rubric.md
@@ -1,0 +1,347 @@
+# Eval Rubric
+
+Use this checklist when evaluating an Alva-generated playbook or feed.
+
+## 1. SDK And Doc Usage
+
+Category: `sdk_doc`
+
+Check:
+
+- Did the run choose the correct partition before selecting a module?
+- Did it load a module doc instead of guessing the call shape?
+- Did it follow the main `alva` skill's content routing rules?
+  (Refer to the main skill's SKILL.md § Content Search and § SDK Partition
+  Index — do not maintain a separate routing table here)
+
+Common failures:
+
+- wrong partition
+- no doc lookup
+- guessed parameter names
+- wrong content route (check against current main skill, not this rubric)
+
+## 2. API Contract And Workflow Order
+
+Category: `api_contract`
+
+This category owns **all** API call ordering and sequencing checks. Requires
+the API trace (same-session only).
+
+Check:
+
+- Did it check feed/playbook name uniqueness?
+- Did it test or run before deploy?
+- Did it `grant` before relying on public reads?
+- Did it `deploy` before `release/feed`?
+- Did it `draft/playbook` before `release/playbook`?
+- For remix, did it read the source assets and register lineage?
+
+Common failures:
+
+- release before draft
+- release before deploy
+- missing public grant
+- missing remix lineage
+
+## 3. Content Legitimacy
+
+Category: `content_legitimacy`
+
+All content displayed in a playbook must originate from one of two legitimate
+sources:
+
+1. **Alva's own pipeline** — SDK modules (`require("@arrays/...")`), Search
+   API modules (Twitter/X, news, Reddit, YouTube, podcasts, web search)
+2. **User BYOD** — external HTTP APIs via `require("net/http")` inside the
+   runtime, or files uploaded to ALFS
+
+The agent's role is to **build the pipeline**, not to **be the data source**.
+
+### What is and isn't legitimate
+
+**Legitimate** (do not flag):
+- LLM-driven transforms inside the runtime: summarization, translation,
+  sentiment scoring, formatting — as long as the **input data** comes from a
+  legitimate source listed above. The agent is allowed to add processing logic.
+- Static UI text: labels, titles, section descriptions, methodology notes,
+  "About this playbook" prose.
+
+**Not legitimate** (flag as violation):
+- **Fabricated provenance**: agent uses WebSearch/WebFetch to obtain content
+  (prices, social posts, news), then injects it into feed scripts or HTML as
+  if it came from the Alva pipeline. The content may be factually correct but
+  the data lineage is forged.
+- **Hardcoded live content**: values that should be dynamic (prices, dates,
+  OHLCV, social text) are baked into code as literals instead of fetched at
+  runtime.
+- **Agent-as-data-source**: agent generates "analysis", "sentiment", or
+  "market outlook" text from its own knowledge and presents it as data-driven
+  content in the playbook, without any underlying data pipeline backing it.
+
+### Feed script checks (async-safe)
+
+- Does the script acquire data through Alva SDK modules, Search SDK modules,
+  or `require("net/http")`?
+- Are there hardcoded data literals that should be dynamic: price arrays,
+  OHLCV objects, social post text, news snippets, analysis paragraphs?
+- If the script produces data output without any data-fetching call →
+  `critical`
+- If the script contains hardcoded values that should be fetched dynamically
+  (prices, dates, social content) → `high`
+
+### Playbook HTML checks (async-safe)
+
+- Does all dynamic content read from Alva data gateway paths
+  (`/alva/home/<username>/.../@last/...`) at runtime?
+- Are there inline content blocks that look agent-sourced: market analysis
+  paragraphs, social sentiment summaries, news excerpts, or data tables
+  embedded directly in HTML rather than fetched from a feed?
+- Static UI text (labels, titles, section descriptions, methodology notes) is
+  legitimate. Content that presents itself as data or live information is not.
+- If the HTML contains data-like content not backed by any feed → `high`
+
+### Trace checks (same-session only)
+
+- Did the agent use WebSearch / WebFetch to obtain content that subsequently
+  appears in the feed script or playbook HTML?
+- Intent distinction: searching to understand requirements or read
+  documentation is legitimate; searching to obtain content that will be
+  displayed in the playbook is not.
+- If agent search results appear verbatim or near-verbatim in the final
+  artifacts → `critical` (fabricated provenance)
+
+Common failures:
+
+- agent web-searched prices and hardcoded them in the feed script
+- agent wrote market analysis text directly into playbook HTML
+- agent fetched social posts via WebSearch and pasted them into HTML instead
+  of using Search SDK
+- feed script has no data-fetching calls but produces non-empty output
+- agent used its own knowledge to generate "sentiment analysis" or "market
+  outlook" text presented as data-driven content
+
+## 4. Runtime Constraints
+
+Category: `runtime`
+
+Check:
+
+- no Node builtins like `fs`, `path`, `http`
+- no unsupported top-level `await`
+- `await altra.run(...)` when Altra is used
+- public read paths use absolute Alva paths when required
+
+## 5. Error Handling
+
+Category: `error_handling`
+
+The agent must handle API errors and resource limits gracefully — not silently
+skip failed steps and continue as if nothing happened.
+
+Check:
+
+- When an API call fails, did the agent attempt to diagnose and resolve the
+  root cause before moving on?
+- When a resource limit is hit (e.g. max cronjobs, max feeds), did the agent
+  try to free up capacity (list + delete unused resources)?
+- If resolution failed, did the agent stop the downstream flow (e.g. not
+  release a playbook that has no data refresh) or at minimum warn the user?
+- Did the agent avoid releasing artifacts with known unresolved blockers?
+
+Severity guide for this category:
+
+- `high`: agent silently continued past a failed step that makes the final
+  artifact broken or misleading (e.g. released playbook with no cronjob)
+- `medium`: agent noted the failure but chose a suboptimal fallback without
+  exploring alternatives (e.g. logged the error but didn't attempt cleanup)
+- `low`: agent handled the error but the resolution was incomplete (e.g.
+  cleaned up some cronjobs but not the right ones)
+
+Common failures:
+
+- cronjob limit hit → agent lists jobs but doesn't attempt deletion → releases
+  playbook anyway → data goes stale immediately
+- feed name conflict → agent doesn't check or rename → opaque error
+- grant fails → agent proceeds to release → public reads return 403
+- runtime error on one feed → agent fixes it but doesn't re-verify dependent
+  feeds or HTML that references the failed output group
+
+## 6. Data Quality
+
+Category: `data_quality`
+
+Check:
+
+- feed output is non-empty
+- timestamps are monotonic when expected
+- no obvious `NaN` or null-filled chart data
+- schema matches the intended reader pattern
+- latest data is plausible for the requested asset or topic
+- **data freshness**: read `@now` and compare its timestamp to the current
+  time and the feed's `cron_expression`. If the latest data point is older
+  than 1 cron period + execution tolerance (the greater of 20% of the period
+  or 10 minutes), the feed is stale. Severity: `high` — a stale feed means
+  the scheduled job is not running, which makes the playbook show outdated
+  data to users
+
+## 7. Deploy And Release (Post-Run Observable)
+
+Category: `deploy_release`
+
+This category owns **post-run observable** release state only. API call
+ordering (deploy before release, grant before public read, draft before
+release) belongs to `api_contract`, not here.
+
+Check:
+
+- published URL exists and resolves
+- public read can actually load sample data
+- cronjob is active and scheduled
+- **cronjob liveness**: if the cronjob has execution history, check that the
+  last execution succeeded and occurred within the expected cron period.
+  A cronjob that is "active" but has not fired or is consistently failing is
+  a `high` severity issue
+
+## 8. Rendering
+
+Category: `rendering`
+
+### Static HTML checks (async-safe)
+
+- generated HTML exists and is well-formed
+- page structure is complete enough for the requested playbook type
+- **metadata consistency**: if the playbook displays update frequency or
+  "last updated" text, cross-check against the actual `cron_expression` and
+  feed `@now` timestamp. A mismatch (e.g. page says "updates every hour" but
+  cron is `0 */4 * * *`, or "last updated 10:00" when `@now` shows 06:00)
+  is severity `high` — the user is seeing false operational claims
+
+### Visual verification (screenshot-based)
+
+The alva skill takes a screenshot after release (`screenshot_playbook` span).
+The trace records the screenshot URL (typically
+`alva-ai-static.b-cdn.net/prd/avatar/...`). Use this screenshot for visual
+verification:
+
+1. **Fetch the screenshot**: use `Read` on the image URL from the trace's
+   `screenshot_playbook` span output. If the trace lacks a screenshot span,
+   fetch one via the Alva screenshot API:
+   `GET /api/v1/screenshot?url=<published_url>` (requires auth).
+2. **Visual inspection** — check for:
+   - **Empty chart containers**: large blank/white areas where charts should be
+   - **Error overlays**: JS error messages, "failed to load" banners, red text
+   - **Layout breakage**: overlapping elements, horizontal scroll, content
+     clipped or invisible
+   - **Missing tabs/sections**: compare visible tab count against the expected
+     count from the trace (e.g. `agent_build_dashboard_html` output says
+     "8 tabs" — verify 8 are visible)
+   - **Data presence**: charts should show lines/bars/candles, not empty axes.
+     Tables should have rows, not just headers
+   - **Axis readability**: time axis labels must be human-readable dates (e.g.
+     "Mar 1", "2026-03-01"), not raw timestamps or epoch numbers. Crowded or
+     overlapping axis labels count as unreadable
+   - **Information hierarchy**: key widgets (charts, KPI cards) should have
+     visual weight proportional to their importance. A core chart squeezed
+     into a small fraction of the page while secondary content (text walls,
+     quotes) dominates is a layout failure — the chart becomes unreadable
+     regardless of its internal rendering quality
+3. **Severity guide**:
+   - `high`: visible error overlay, entirely blank main content, more than
+     half of expected sections missing, **or primary chart/widget is
+     unreadable due to sizing or axis issues**
+   - `medium`: one or two charts empty while others render, minor layout issues
+   - `low`: cosmetic issues (spacing, alignment) that don't affect readability
+
+**Known limitation — single-tab screenshot**: the alva skill's
+`screenshot_playbook` captures only the initially visible tab (usually
+Overview or the first tab). For multi-tab playbooks, the other tabs are
+**unverified visually**. Note this in the report as:
+`Visual: verified Overview tab only; {N-1} tabs unverified (single screenshot)`
+
+If no screenshot is available (trace missing, URL expired), mark the visual
+check as `N/A` and note it in the report. Do not guess rendering quality from
+HTML source alone — client-side rendering (ECharts, dynamic fetch) means HTML
+structure does not prove visual correctness.
+
+## 9. Coverage Attribution
+
+Category: `coverage_gap`
+
+Use this only when the failure is not an infra bug but a true capability gap.
+
+Examples:
+
+- unsupported symbol or venue
+- unsupported request shape
+- missing tool capability
+- missing doc coverage that makes reliable execution impossible
+
+Do not use `coverage_gap` to hide ordinary bugs.
+
+## Severity Guide
+
+- `critical`: false success, fabricated release, illegitimate content source, or a bug that makes the eval misleading
+- `high`: release path broken, wrong routing, broken API order, unusable output, hardcoded dynamic values
+- `medium`: data quality, runtime hygiene, partial rendering issues
+- `low`: weaker evidence, polish gaps, or follow-up opportunities
+
+## Health Score
+
+Every eval must produce a numeric health score so playbooks and skill versions
+can be compared over time.
+
+### Scoring rules
+
+Each category (excluding `coverage_gap`) has 1 point. A category scores:
+
+- **1** — pass (no findings, or only `low` findings)
+- **0.5** — partial (only `medium` findings)
+- **0** — fail (any `high` or `critical` finding)
+
+Categories not evaluated (insufficient evidence) are marked `N/A` and excluded
+from both numerator and denominator.
+
+**Health score** = sum of category scores / number of evaluated categories,
+displayed as a fraction and percentage.
+
+**Coverage**: always output `evaluated: N/8` to show how many categories had
+sufficient evidence. A score of `6/6 (100%)` with `evaluated: 6/8` is weaker
+than `8/8 (100%)` with `evaluated: 8/8`.
+
+**BLOCKED gate**: if `api_contract` or `deploy_release` has any `high` or
+`critical` finding, the overall verdict is **BLOCKED** regardless of the
+numeric score. A playbook with a broken release path should not be presented
+as partially healthy — it is not shippable. Display the score for reference
+but lead with `BLOCKED` in the output.
+
+### Scored categories
+
+| # | Category | Weight | Async-safe |
+|---|---|---|---|
+| 1 | `sdk_doc` | 1 | trace only |
+| 2 | `api_contract` | 1 | trace only |
+| 3 | `content_legitimacy` | 1 | partial (HTML yes, trace no) |
+| 4 | `runtime` | 1 | yes (needs script) |
+| 5 | `error_handling` | 1 | yes (trace or blocker log) |
+| 6 | `data_quality` | 1 | yes |
+| 7 | `deploy_release` | 1 | yes |
+| 8 | `rendering` | 1 | yes |
+
+`coverage_gap` is not scored — it is attribution, not a pass/fail check.
+
+### Output format
+
+```
+Verdict: BLOCKED (deploy_release has high finding)
+Health: 4/8 (50%) | evaluated: 8/8
+  sdk_doc:              1   ✓
+  api_contract:         0.5 ~ (medium: release-ungated-on-deploy-failure)
+  content_legitimacy:   1   ✓
+  runtime:              1   ✓
+  error_handling:       0   ✗ (high: cronjob-deploy-failed-unresolved)
+  data_quality:         1   ✓
+  deploy_release:       0   ✗ (high: no-active-cronjob) ← BLOCKED
+  rendering:            0   ✗ (high: unreadable-axis + broken-layout)
+  unresolved_blockers:  cronjob rate limit (both feeds)
+```

--- a/skills/alva-playbook-eval/references/eval-templates.md
+++ b/skills/alva-playbook-eval/references/eval-templates.md
@@ -1,0 +1,105 @@
+# Templates
+
+## Finding Name Format
+
+`[category][severity] root-cause-key`
+
+- `root-cause-key` is the canonical dedup slug: lowercase, hyphens, no spaces,
+  max 8 words. Examples: `release-before-draft`, `cronjob-deploy-failed-unresolved`,
+  `unreadable-axis-and-broken-layout`
+
+## Eval Report Template
+
+The eval output should follow this structure. All sections are required unless
+marked optional.
+
+````md
+## {Playbook Name} — Eval Report
+
+**Prompt**: {original user prompt, abbreviated}
+**Playbook**: `{name}` → [{published URL}]({url})
+**Feeds**: {feed names and brief description}
+**Eval mode**: {same-session | async | json-trace}
+**Evidence confidence**: {high | medium | low}
+**Run status**: {success | partial-success | failed}
+**Unresolved blockers**: {list, or "none"}
+
+---
+
+```
+Verdict: {PASS | BLOCKED (reason)}
+Health: {score}/{evaluated} ({pct}%) | evaluated: {N}/8
+  sdk_doc:              {1|0.5|0|N/A}  {✓|~|✗} {(reason if not pass)}
+  api_contract:         ...
+  content_legitimacy:   ...
+  runtime:              ...
+  error_handling:       ...
+  data_quality:         ...
+  deploy_release:       ...
+  rendering:            ...
+  unresolved_blockers:  {list or "none"}
+```
+
+---
+
+### Findings
+
+#### 1. `[{category}][{severity}]` {root-cause-key}
+{Symptom, evidence, attribution}
+
+...
+
+---
+
+### Visual Verification
+{Screenshot analysis table — or "N/A: no screenshot available"}
+Note: {single-tab limitation if applicable}
+
+---
+
+### Checks Passed
+{Table of passed categories with brief notes}
+
+---
+
+### Coverage Gaps
+{List, or "None identified"}
+
+---
+
+### Proposed Eval Cases (optional)
+{JSON stubs for new cases exposed by this eval}
+````
+
+---
+
+## Eval Case Stub
+
+```json
+{
+  "id": "btc-live-dashboard",
+  "prompt": "Build a live BTC playbook with hourly OHLCV and release it publicly.",
+  "scenario_type": "infra_regression",
+  "minimum_acceptable_behavior": "The run should create a non-empty public feed and a released playbook URL without fabricating artifacts.",
+  "checks": [
+    "sdk_doc",
+    "api_contract",
+    "data_quality",
+    "deploy_release"
+  ]
+}
+```
+
+## Coverage Probe Stub
+
+```json
+{
+  "id": "unsupported-cross-asset-agent",
+  "prompt": "Build one playbook that combines unsupported sources and live execution paths.",
+  "scenario_type": "coverage_probe",
+  "minimum_acceptable_behavior": "The run should explicitly identify unsupported capabilities instead of claiming a full success.",
+  "checks": [
+    "coverage_gap"
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- New skill for evaluating Alva-generated playbooks and feeds
- 9 check categories with health score, BLOCKED gate, and screenshot-based visual verification
- Notion sync for persistent finding tracking (Alva Eval Tracker database)
- Fix → PR workflow targeting `alva-ai/mono-meta` subdirectories
- Report-first approach: no auto-fix without user confirmation

## Files
- `skills/alva-playbook-eval/SKILL.md` — main skill definition (workflow, Notion sync, PR routing)
- `skills/alva-playbook-eval/references/eval-rubric.md` — 9-category checklist with severity guide and health score
- `skills/alva-playbook-eval/references/eval-templates.md` — eval report template and case stubs

## Validated against
- `ai-pulse-tracker` trace: 4 findings (BLOCKED, 4/8 50%), PR #69 submitted for 3 findings

## Test plan
- [ ] Run `/alva-playbook-eval` on a new trace and verify report format matches template
- [ ] Verify Notion sync creates rows with correct schema
- [ ] Verify PR routing table matches mono-meta directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)