### PR TITLE
fix(docs): rename task_id to cronjob_id in release/feed API

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -409,7 +409,7 @@ Paths: `~/data/file.json` (home-relative) or `/alva/home/<username>/...`
 
 | Method | Endpoint                   | Description                                                              |
 | ------ | -------------------------- | ------------------------------------------------------------------------ |
-| POST   | `/api/v1/release/feed`     | Register feed (DB + link to cronjob task). Call after deploying cronjob. |
+| POST   | `/api/v1/release/feed`     | Register feed (DB + link to cronjob). Call after deploying cronjob.      |
 | POST   | `/api/v1/release/playbook` | Release playbook for public hosting. Call after writing playbook HTML.   |
 
 **Name uniqueness**: Both `name` in releaseFeed and releasePlaybook must be
@@ -650,7 +650,7 @@ Every feed follows a 6-step lifecycle including every newly created feed or re-c
    (specific user).
 5. **Deploy** -- `POST /api/v1/deploy/cronjob` for scheduled execution
 6. **Release** -- `POST /api/v1/release/feed` to register the feed in the
-   database (requires the `task_id` from the deploy step)
+   database (requires the `cronjob_id` from the deploy step)
 
 | Data Type                     | Recommended Schedule     | Rationale                           |
 | ----------------------------- | ------------------------ | ----------------------------------- |
@@ -904,7 +904,7 @@ conflicts.
 ```
 # 1. Release feed (register in DB, link to cronjob)
 POST /api/v1/release/feed
-{"name":"btc-ema","version":"1.0.0","task_id":42}
+{"name":"btc-ema","version":"1.0.0","cronjob_id":42}
 → {"feed_id":100,"name":"btc-ema","feed_major":1}
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)

--- a/skills/alva/references/api-reference.md
+++ b/skills/alva/references/api-reference.md
@@ -499,8 +499,8 @@ POST /api/v1/release/feed
 ```
 
 Register a feed in the database after deploying its cronjob. **Must be called
-after** `POST /api/v1/deploy/cronjob` -- the `task_id` comes from the cronjob
-response.
+after** `POST /api/v1/deploy/cronjob` -- the `cronjob_id` comes from the
+cronjob response.
 
 **Name uniqueness**: The `name` must be unique within your user space. Use
 `GET /api/v1/fs/readdir?path=~/feeds` to check existing feed names before
@@ -510,7 +510,7 @@ releasing.
 | ----------- | ------ | -------- | ------------------------------------------------------------ |
 | name        | string | yes      | URL-safe feed name (e.g. `btc-ema`), must be unique per user |
 | version     | string | yes      | SemVer (e.g. `1.0.0`)                                        |
-| task_id     | int64  | yes      | Cronjob task ID from deploy/cronjob                          |
+| cronjob_id  | int64  | yes      | Cronjob ID from deploy/cronjob response                      |
 | view_json   | object | no       | View configuration JSON                                      |
 | description | string | no       | Feed description                                             |
 
@@ -519,7 +519,7 @@ POST /api/v1/release/feed
 {
   "name": "btc-ema",
   "version": "1.0.0",
-  "task_id": 42,
+  "cronjob_id": 42,
   "description": "BTC exponential moving average"
 }
 → {"feed_id": 100, "name": "btc-ema", "feed_major": 1}


### PR DESCRIPTION
## Summary
- `POST /api/v1/release/feed` 实际要求字段名为 `cronjob_id`，传 `task_id` 会返回 `INVALID_ARGUMENT` 错误
- 更新 `SKILL.md` 和 `references/api-reference.md` 中共 5 处 `task_id` → `cronjob_id`

## Changes
1. `SKILL.md`: deploy step 描述、示例请求体
2. `references/api-reference.md`: 字段说明、参数表、示例请求体

## Test plan
- [ ] 按更新后的文档调用 `POST /api/v1/release/feed` 传 `cronjob_id` 验证成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)