### PR TITLE
alva: backtest always produces playbook + communication rule

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -140,6 +140,11 @@ or implementation details in user-facing responses. Say what it DOES, not how it
 works. These details are operating instructions for you, not content for the
 user.
 
+Lead with the result, not the process. The first thing the user reads should be
+what they got ("Your dashboard is live at …"), not what you did ("I deployed
+3 feeds and wrote the HTML"). During multi-step builds, give a short status
+update at each milestone so the user knows work is progressing.
+
 ## Request Routing
 
 | Request Type | Core Objectives |


### PR DESCRIPTION
## Summary
- **Backtest → Playbook**: Change backtest routing from "optionally produce a playbook" to always produce a visual playbook (equity curve, trade log, metrics) alongside text summary
- **Communication section**: Add rule preventing agent from leaking internal details (ALFS paths, cronjob IDs, API payloads) in user-facing responses — aligned with gstack skills' AskUserQuestion pattern

## Test plan
- [ ] Run a backtest request and verify it produces a playbook, not just text
- [ ] Verify agent responses don't include ALFS paths or cronjob IDs after enabling push notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)