### PR TITLE
docs(alva): update configuration file references and API endpoint usage

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -69,11 +69,11 @@ bash "<this skill's directory>/scripts/version_check.sh"
 | `ALVA_API_KEY`  | **yes**  | Your API key ([alva.ai](https://alva.ai))                |
 | `ALVA_ENDPOINT` | no       | API base URL. Defaults to `https://api-llm.prd.alva.ai`  |
 
-Read `.alva.json` in this skill's directory. If `api_key` is present, set
+Read `.env` in this skill's directory. If `api_key` is present, set
 `ALVA_API_KEY` from it. If missing or empty, **ask the user whether they already
 have a key**:
 
-- **Has a key** — ask them to paste it, write it to `.alva.json`, and verify:
+- **Has a key** — ask them to paste it, write it to `.env`, and verify:
 
   ```bash
   export ALVA_API_KEY="<key>"
@@ -88,10 +88,10 @@ have a key**:
 - **No key** — sign up at [alva.ai](https://alva.ai), create a key under
   Settings → API Keys, paste it back, then verify as above.
 
-`.alva.json` format:
+`.env` format:
 
-```json
-{ "api_key": "alva_...", "last_check": 0 }
+```dotenv
+api_key=alva_...
 ```
 
 `ALVA_API_KEY` authenticates to Alva itself. Third-party vendor secrets belong
@@ -382,7 +382,7 @@ outputs read at runtime (no inline literals for data).
 3. **Screenshot**: Take a screenshot to verify the playbook renders correctly:
 
    ```
-   GET /api/v1/screenshot?url=https://alva.ai/u/<username>/playbooks/<playbook_name>
+   GET /api/v1/screenshot?url=$ALVA_ENDPOINT/u/<username>/playbooks/<playbook_name>
    ```
 
    Pass `X-Alva-Api-Key` header so the screenshot service can access
@@ -808,7 +808,7 @@ webhook secret.
   UI at <https://alva.ai/apikey>. Assume this page is available.
 - **Do not ask the user to paste sensitive third-party secrets into chat** when
   the web upload flow is feasible.
-- **Do not hardcode secrets** in source code, ALFS files, `.alva.json`, shell
+- **Do not hardcode secrets** in source code, ALFS files, `.env`, shell
   snippets, or released playbook assets.
 - **Runtime access**: load secrets inside Alva Cloud code with
   `require("secret-manager").loadPlaintext("NAME")`.

--- a/skills/alva/references/api/screenshot.md
+++ b/skills/alva/references/api/screenshot.md
@@ -8,7 +8,7 @@ GET /api/v1/screenshot?url={url}&selector={selector}
 
 | Parameter | Type   | Required | Description                                   |
 | --------- | ------ | -------- | --------------------------------------------- |
-| url       | string | yes      | Target URL (must be `alva.ai` or a subdomain) |
+| url       | string | yes      | Target URL (use `$ALVA_ENDPOINT` as the base)  |
 | selector  | string | no       | CSS selector to capture a specific element     |
 | xpath     | string | no       | XPath expression to capture a specific element |
 
@@ -25,14 +25,14 @@ Response:
 
 ```
 # Screenshot a playbook page
-GET /api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard
+GET /api/v1/screenshot?url=$ALVA_ENDPOINT/u/alice/playbooks/btc-dashboard
 
 # Screenshot a specific chart element
-GET /api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard&selector=.chart-container
+GET /api/v1/screenshot?url=$ALVA_ENDPOINT/u/alice/playbooks/btc-dashboard&selector=.chart-container
 ```
 
 ```bash
 # curl example
 curl -s -H "X-Alva-Api-Key: $ALVA_API_KEY" \
-  "$ALVA_ENDPOINT/api/v1/screenshot?url=https://alva.ai/u/alice/playbooks/btc-dashboard"
+  "$ALVA_ENDPOINT/api/v1/screenshot?url=$ALVA_ENDPOINT/u/alice/playbooks/btc-dashboard"
 ```

--- a/skills/alva/scripts/version_check.sh
+++ b/skills/alva/scripts/version_check.sh
@@ -7,17 +7,17 @@ SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 REPO="alva-ai/skills"
 SKILL_MD="$SKILL_DIR/SKILL.md"
-CONFIG_FILE="$SKILL_DIR/.alva.json"
+CONFIG_FILE="$SKILL_DIR/.env"
 CHECK_INTERVAL=28800 # 8 hours in seconds
 
-# Read a field from .alva.json (portable JSON parsing without jq)
+# Read a field from .env (KEY=VALUE format)
 read_field() {
   if [ ! -f "$CONFIG_FILE" ]; then
     echo ""
     return
   fi
   local key="$1"
-  sed -n "s/.*\"${key}\": *\"\{0,1\}\([^\",}]*\)\"\{0,1\}.*/\1/p" "$CONFIG_FILE" 2>/dev/null | head -1
+  sed -n "s/^${key}=\(.*\)/\1/p" "$CONFIG_FILE" 2>/dev/null | head -1
 }
 
 # Read version from SKILL.md frontmatter (metadata.version)
@@ -29,16 +29,14 @@ read_local_version() {
   sed -n 's/^[[:space:]]*version:[[:space:]]*\(.*\)/\1/p' "$SKILL_MD" 2>/dev/null | head -1
 }
 
-# Write last_check to .alva.json, preserving api_key
+# Write last_check to .env, preserving api_key
 write_check() {
   local ts="$1"
   local api_key
   api_key=$(read_field "api_key")
   cat >"$CONFIG_FILE" <<EOF
-{
-  "api_key": "${api_key}",
-  "last_check": $ts
-}
+api_key=${api_key}
+last_check=${ts}
 EOF
 }
 


### PR DESCRIPTION
- Changed references from `.alva.json` to `.env` for API key and configuration management in SKILL.md and version_check.sh.
- Updated API endpoint examples in screenshot.md to utilize `$ALVA_ENDPOINT` for better flexibility and consistency.
- Enhanced instructions for reading configuration values and writing to the new `.env` format, ensuring clarity in secret management practices.

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
