### PR TITLE
[jaxxjj] fix: remove selector/xpath from screenshot docs

### DIFF
--- a/skills/alva/references/api/screenshot.md
+++ b/skills/alva/references/api/screenshot.md
@@ -1,16 +1,14 @@
 # Screenshot
 
-Capture a screenshot of any Alva page.
+Capture a full-page screenshot of any Alva page.
 
 ```
-GET /api/v1/screenshot?url={url}&selector={selector}
+GET /api/v1/screenshot?url={url}
 ```
 
 | Parameter | Type   | Required | Description                                  |
 | --------- | ------ | -------- | -------------------------------------------- |
 | url       | string | yes      | Target URL (use `$ALVA_ENDPOINT` as the base) |
-| selector  | string | no       | CSS selector to capture a specific element    |
-| xpath     | string | no       | XPath expression to capture a specific element |
 
 Auth: `X-Alva-Api-Key` header (required for authenticated content).
 
@@ -21,11 +19,8 @@ to a file.
 # Full-page screenshot
 GET /api/v1/screenshot?url=$ALVA_ENDPOINT/u/alice/playbooks/btc-dashboard
 → (raw PNG bytes)
-
-# Specific element
-GET /api/v1/screenshot?url=$ALVA_ENDPOINT/u/alice/playbooks/btc-dashboard&selector=.chart-container
-→ (raw PNG bytes)
 ```
 
-Save to a file with `curl -s -o screenshot.png`, then view or present the path
-to the user.
+Save to a file with `curl -sf -o screenshot.png` (`-f` fails on HTTP errors
+instead of saving the error response as the file). Check the exit code before
+reading the file.


### PR DESCRIPTION
## Summary
- Remove `selector` and `xpath` parameters from screenshot API docs
- Change `curl -s -o` to `curl -sf -o` to prevent saving error responses as images
- Root cause: zero-height elements produce corrupted images that poison JSONL history