### PR TITLE
docs(alva): rename KPI Card → Metric Card

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -204,7 +204,7 @@ playbook builds.
 
 ### Data Sourcing
 
-1. **All quantitative data displayed in charts, tables, or KPI cards MUST
+1. **All quantitative data displayed in charts, tables, or metric cards MUST
    originate from Alva feeds** (SDK modules or BYOD via `require("net/http")`).
    Never hardcode data as inline JavaScript literals in playbook HTML.
 
@@ -393,7 +393,7 @@ styling, layout, and component guidelines. Unless the user explicitly asks for a
 static snapshot, default to a live playbook.
 **Data fetching requirement**: Apply the
 [Content Legitimacy Rules](#content-legitimacy-rules) when building the UI.
-All quantitative data in charts, tables, or KPI cards must come from feed
+All quantitative data in charts, tables, or metric cards must come from feed
 outputs read at runtime (no inline literals for data).
 
 ### 7. Release
@@ -1096,7 +1096,7 @@ consistent read pattern (`@last`, `@range`, etc.).
   around chart initialization with a fallback message if rendering fails.
 - **ECharts sizing: allocate sufficient height.** Heatmaps need
   `height = max(300px, numRows * 40px)`. Primary charts on overview tabs should
-  be at least 400px tall and visually dominant over KPI cards. Do not compress
+  be at least 400px tall and visually dominant over metric cards. Do not compress
   charts to fit everything above the fold.
 - **Separate `lastDate` watermarks per data source.** When a feed combines
   multiple data sources with different update frequencies (e.g. ETF OHLCV +

--- a/skills/alva/references/design-playbook-trading-strategy.md
+++ b/skills/alva/references/design-playbook-trading-strategy.md
@@ -233,7 +233,7 @@ markPoint: {
 ┌────────────────────────────────────────────────────┐
 │  Meta Info Bar (4 fields)                          │
 ├────────────────────────────────────────────────────┤
-│  Performance Metrics (6 × KPI Cards)               │
+│  Performance Metrics (6 × Metric Cards)             │
 ├────────────────────────────────────────────────────┤
 │  Equity Curve Chart                                │
 ├────────────────────────────────────────────────────┤
@@ -249,7 +249,7 @@ markPoint: {
 
 ### 2.1 Performance Metrics
 
-6 equal-width KPI cards in a horizontal row.
+6 equal-width metric cards in a horizontal row.
 
 #### Layout
 

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -6,7 +6,7 @@
 - [Widget Base CSS](#widget-base-css)
 - [Widget Layout](#widget-layout)
 - [Chart Card](#chart-card)
-- [KPI Card](#kpi-card)
+- [Metric Card](#metric-card)
 - [Table Card](#table-card)
 - [Free Text Card](#free-text-card)
 - [Feed Card](#feed-card)
@@ -17,7 +17,7 @@
 > These are the most common sources of error. Read before generating any widget
 > code.
 
-1. **Widget-internal layout uses `flex-wrap`** (KPI rows, metric groups,
+1. **Widget-internal layout uses `flex-wrap`** (metric rows, metric groups,
    side-by-side elements). Never `grid-cols-N` — grid is only for page-level
    `.widget-grid`. → [Details](#content-reflow)
 2. **No border/outline on widgets** — use `--grey-g01` or `--line-l05` dividers.
@@ -311,14 +311,14 @@
   }
 }
 
-/* ── KPI Column (for stacking KPI cards beside a chart) ── */
-.kpi-column {
+/* ── Metric Column (for stacking metric cards beside a chart) ── */
+.metric-column {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-s);
 }
 
-.kpi-column .kpi-card {
+.metric-column .metric-card {
   flex: 1;
   background: var(--grey-g01);
   border-radius: var(--radius-ct-m);
@@ -424,7 +424,7 @@ never wrap — always `width: 100%`.
 
 | Widget Type    | Default Height        | Overflow Behavior        |
 | -------------- | --------------------- | ------------------------ |
-| KPI Card       | auto (content-driven) | Wrap via flex-wrap       |
+| Metric Card    | auto (content-driven) | Wrap via flex-wrap       |
 | Chart Card     | 320px                 | Chart scales internally  |
 | Table Card     | auto, capped at 560px | Scroll within table body |
 | Free Text Card | auto (content-driven) | Scroll or truncate       |
@@ -659,12 +659,12 @@ No `shadowBlur`, no `focus: 'series'`.
 
 ---
 
-## KPI Card
+## Metric Card
 
 ### Template
 
 ```html
-<!-- KPI Card — copy this structure exactly -->
+<!-- Metric Card — copy this structure exactly -->
 <div class="widget-card">
   <div class="widget-title">
     <span class="widget-title-text">KPI Title</span>
@@ -689,7 +689,7 @@ No `shadowBlur`, no `focus: 'series'`.
 </div>
 ```
 
-### KPI Rules
+### Metric Card Rules
 
 - Key metric font size: 24px or 28px
 - When multiple metrics share one card, use `.divider-v` / `.divider-h` to

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -73,7 +73,7 @@ GET /api/v1/fs/read?path=/alva/home/{owner}/playbooks/{name}/index.html
 ```
 
 This returns the full HTML source of the playbook dashboard — the ECharts
-charts, KPI cards, layout, and data-fetching logic. Use this as the template for
+charts, metric cards, layout, and data-fetching logic. Use this as the template for
 the new playbook's UI.
 
 ---


### PR DESCRIPTION
## Summary
- Rename "KPI Card" to "Metric Card" across all alva skill files (SKILL.md, design-widgets.md, design-playbook-trading-strategy.md, remix-workflow.md)
- Rename CSS classes: `.kpi-column` → `.metric-column`, `.kpi-card` → `.metric-card`
- "KPI" was misleading — the widget displays general numeric values (valuation multiples, financial ratios, analyst targets), not just KPIs. "Metric Card" is semantically accurate and consistent with the existing naming pattern (Chart Card, Table Card, Free Text Card)

## Test plan
- [ ] Verify no remaining references to "KPI Card" in skill files
- [ ] Confirm playbook generation uses new `metric-card` / `metric-column` CSS classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)