### PR TITLE
docs(alva): add page-level scroll rule and theme section to design sy…

### DIFF
--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -61,11 +61,39 @@ text-rendering: optimizeLegibility;
 <a href="https://example.com" target="_blank" rel="noopener noreferrer">Example</a>
 ```
 
-## Background
+## Theme
 
 **The page background color must use `--b0-page`**
 
+**Default mode** → Light Mode
+
 ## Playbook Container
+
+### Page-Level Scroll Rule
+
+Playbook HTML runs inside an iframe. The **only** element that may carry
+page-level vertical scroll is `<body>`:
+
+```css
+html {
+  height: 100%;
+  overflow: hidden;   /* html never scrolls */
+}
+body {
+  min-height: 100%;
+  overflow-y: auto;   /* sole page-level scroll entry point */
+  overflow-x: hidden;
+}
+```
+
+**Rules:**
+1. `<body>` is the sole page-level scroll container — never add
+   `overflow-y: auto/scroll` to `.playbook-container`, `.main-wrapper`, or any
+   other outer wrapper.
+2. Inner widget scroll (table/feed body) is allowed per widget spec, but must
+   not compete with the page scroll.
+3. `position: sticky` elements (e.g. `.tab-bar-wrapper`) anchor to the `<body>`
+   scroll context — this only works when body is the scroller.
 
 ```css
 /* Hide all persistent scrollbars globally */


### PR DESCRIPTION
…stem

Add body-level scroll rule for iframe playbooks and consolidate background/theme settings under a new "Theme" section with light mode default.

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
