### PR TITLE
fix(alva): use height instead of min-height for body scroll

### DIFF
--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -80,7 +80,7 @@ html {
   overflow: hidden;   /* html never scrolls */
 }
 body {
-  min-height: 100%;
+  height: 100%;
   overflow-y: auto;   /* sole page-level scroll entry point */
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary
- Fix page-level scroll rule: `body { height: 100% }` instead of `min-height: 100%`
- `min-height` lets body grow with content so `overflow-y: auto` never triggers; `height: 100%` constrains body to viewport, enabling proper scroll

## Test plan
- [ ] Open playbook in iframe, verify page scrolls on `<body>`
- [ ] Verify `position: sticky` elements (tab bar) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)