### PR TITLE
docs(alva): add visual identity, design principles, and disable dark …

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1211,19 +1211,18 @@ POST /api/v1/release/playbook
 ## Alva Design System
 
 All Alva playbook pages, dashboards, and widgets must follow the Alva Design
-System. Start with [design-system.md](references/design-system.md): it is the
-single global entry point for tokens, typography, page-level layout rules, and
-the reading path to the more detailed design references.
+System. **Always read
+[design-system.md](references/design-system.md) first** — it covers visual
+identity, design principles, do/don't guardrails, tokens, typography, and
+page-level layout. Then read only the spec you need:
 
-Read only what you need:
-
-- **Global rules only** → [design-system.md](references/design-system.md)
-- **Widget and chart implementation** →
-  [design-widgets.md](references/design-widgets.md)
-- **Component behavior and templates** →
-  [design-components.md](references/design-components.md)
-- **Trading strategy playbooks** →
-  [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md)
+1. **Generating a widget or chart** →
+   [design-widgets.md](references/design-widgets.md)
+2. **Using a component** (Button, Tag, Dropdown, Tab, etc.) →
+   [design-components.md](references/design-components.md)
+3. **Building a trading strategy playbook** →
+   [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md)
+4. **Only need global rules** → stay in design-system.md
 
 ---
 

--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -1,23 +1,42 @@
 # Alva Design System
 
-This file is the global entry point for Alva design rules. It summarizes the
-rules that apply everywhere and points to the more detailed widget, component,
-and trading-strategy specs when you need them.
+This file is the global entry point for Alva design rules. Read this first to
+understand what Alva looks and feels like, then follow the progressive reading
+path at the bottom for implementation details.
+
+## Visual Identity
+
+Alva is a playbook marketplace for investors — build, share, remix, and trade
+on collaborative investing strategies powered by AI agents.
+
+## Design Principles
+
+1. **Signal first** — every element must serve analysis. If it doesn't help the
+   user read data, compare metrics, or make decisions, remove it.
+2. **Density with restraint** — pack information tightly but maintain clear
+   visual hierarchy. Whitespace is structure, not waste.
+3. **Color is state, not decoration** — green means bullish, red means bearish,
+   yellow means alert. Never use semantic colors for backgrounds, accents, or
+   branding.
+4. **Typography over ornament** — hierarchy comes from font size and opacity,
+   not bold weights, colors, or decorative elements.
+5. **Components support analysis** — Table = scanability, KPI = comparison,
+   Chart = context-rich but visually quiet, Feed = chronology and relevance.
 
 ## Design Tokens
 
 Full token definitions (colors, spacing, radius, theme) are in
-[design-tokens.css](./design-tokens.css). Read it when you need exact values.
-Below is a quick reference for the most common categories:
+[design-tokens.css](./design-tokens.css). Always reference tokens — never
+hardcode hex or rgba values. Below is a quick reference:
 
 | Category     | Tokens                                         | Notes                                   |
 | ------------ | ---------------------------------------------- | --------------------------------------- |
 | Brand        | `--main-m1` ~ `--main-m7`                      | m3=Bullish, m4=Bearish                  |
 | Chart colors | `--chart-{color}-main/1/2`                     | Grey only when ≥ 3 series               |
 | Text         | `--text-n9/n7/n5/n3/n2`                        | n9=primary, n7=secondary, n5=supporting |
-| Background   | `--b0-page`, `--grey-g01`~`g1`, `--b-r02`~`r1` | g01 for dashboard cards                 |
+| Background   | `--b0-page`, `--grey-g01`~`g1`, `--b-r02`~`r1` | g01 for card backgrounds                |
 | Line         | `--line-l05/l07/l12/l2/l3`                     | l07=default                             |
-| Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only                  |
+| Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only (dropdown/modal/tooltip) |
 | Spacing      | `--spacing-xxxs`(2) ~ `--spacing-xxxxxxl`(56)  | Common: xs=8, m=16, xl=24               |
 | Radius       | `--radius-ct-xs`(2) ~ `--radius-ct-l`(8)       | xs=Tag, s=Card, l=Page                  |
 

--- a/skills/alva/references/design-tokens.css
+++ b/skills/alva/references/design-tokens.css
@@ -132,8 +132,8 @@
     --shadow-l: 0 10px 20px 0 rgba(0, 0, 0, 0.08);
   }
 
-  /* Dark Mode */
-  [data-theme="dark"] {
+  /* Dark Mode (disabled — kept for future use) */
+  [data-theme="dark-disabled"] {
     /* Text */
     --text-n9: rgba(255, 255, 255, 0.9);
     --text-n7: rgba(255, 255, 255, 0.7);

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -103,7 +103,8 @@
   background-size: 3px 3px;
 }
 
-[data-theme="dark"] .chart-dotted-background {
+/* Dark Mode (disabled — kept for future use) */
+[data-theme="dark-disabled"] .chart-dotted-background {
   background-image: radial-gradient(
     circle,
     rgba(255, 255, 255, 0.12) 0.6px,
@@ -570,16 +571,13 @@ function mkFmt(valueFn) {
   };
 }
 
-// Theme-aware color constants — set once per page based on data-theme
-var isDark = document.documentElement.getAttribute("data-theme") === "dark";
-
-// Shared tooltip config (theme-aware)
+// Shared tooltip config (light mode)
 var TT_COLORS = {
-  bg: isDark ? "rgba(30,31,35,0.96)" : "rgba(255,255,255,0.96)",
-  border: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)",
-  title: isDark ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.7)",
-  text: isDark ? "rgba(255,255,255,0.9)" : "rgba(0,0,0,0.9)",
-  pointer: isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)",
+  bg: "rgba(255,255,255,0.96)",
+  border: "rgba(0,0,0,0.08)",
+  title: "rgba(0,0,0,0.7)",
+  text: "rgba(0,0,0,0.9)",
+  pointer: "rgba(0,0,0,0.1)",
 };
 
 const TT = {


### PR DESCRIPTION
…mode

Add agent-first intent layer (Visual Identity, Design Principles) to design-system.md, update SKILL.md design routing, disable dark mode in design tokens and simplify tooltip colors to light-mode only.

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
