### PR TITLE
[jaxon] docs: Pattern E — AlvaAsk + notify/message

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -406,6 +406,24 @@ To make a feed push-capable:
 The platform reads `/data/signal/targets/@last/1` after each successful
 execution and pushes the signal content to all eligible followers.
 
+**AlvaAsk + owner notifications:** Feeds can use `@alva/alvaask` to call
+Alva's agent and push the result to the feed owner — useful for scheduled
+reports, heartbeat monitoring, and proactive alerts. Write to
+`notify/message` (see [feed-sdk.md](references/feed-sdk.md) Pattern E):
+
+```javascript
+const result = ask("Brief crypto market update with key levels.");
+await ctx.self.ts("notify", "message").append([{
+  date: Date.now(),
+  title: "Daily Briefing",
+  text: result.text,
+}]);
+```
+
+The platform reads `/data/notify/message/@last/1` and pushes `title` + `text`
+to the owner on all connected channels (Telegram, Discord, Web). No playbook
+or followers required.
+
 See **Step 9** below for the full post-release subscription flow.
 
 ### 6. Build the Playbook Web App

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -230,6 +230,63 @@ When this feed runs as a cronjob, the platform reads
 - Altra strategies write to this path automatically. Use this pattern only for
   non-Altra feeds that want to produce push-worthy signals.
 
+### Pattern E: AlvaAsk + Owner Notification (notify/message)
+
+For feeds that use `@alva/alvaask` to call Alva's agent and push the result
+to the feed owner. Common use cases: scheduled market reports, periodic
+research summaries, heartbeat monitoring, and proactive alerts.
+
+Write the agent's response to the **`notify`** group with a **`message`**
+output. When the cronjob completes, the platform reads this path and pushes
+the content to the owner on all connected channels (Telegram, Discord, Web).
+
+```javascript
+const { ask } = require("@alva/alvaask");
+const { Feed, feedPath, makeDoc, str } = require("@alva/feed");
+
+const feed = new Feed({ path: feedPath("daily-briefing") });
+feed.def("notify", {
+  message: makeDoc("Notification", "Agent-generated push content", [
+    str("title"),
+    str("text"),
+  ]),
+});
+
+(async () => {
+  const result = ask("Give a brief crypto market update with key levels.");
+
+  await feed.run(async (ctx) => {
+    await ctx.self.ts("notify", "message").append([
+      {
+        date: Date.now(),
+        title: "Daily Crypto Briefing",
+        text: result.text,
+      },
+    ]);
+  });
+})();
+```
+
+Deploy as a scheduled cronjob with `push_notify: true`:
+
+```bash
+alva deploy create --name daily-briefing \
+  --path ~/feeds/daily-briefing/v1/scripts/main.js \
+  --cron "0 8 * * *" --push-notify
+```
+
+**Key points:**
+
+- The group **must** be named `notify` and the output **must** be named
+  `message` — this is the path the notification system looks for.
+- `title` is optional — if provided, the notification renders as
+  `**title**\n\ncontent`.
+- `text` is the notification body (required for content push).
+- If `notify/message` has no data, the owner receives a generic
+  "Feed completed." notification instead.
+- Does **not** require a playbook or followers — works for any feed.
+- Combine with Pattern D if you want to push to both owner AND followers.
+
 ### Deduplication
 
 `append()` deduplicates by `date` -- re-appending a record with an existing


### PR DESCRIPTION
## Summary
Add Pattern E documentation for AlvaAsk + owner push notifications.

- **feed-sdk.md**: New Pattern E section — using `@alva/alvaask` to call the agent and writing results to `notify/message` for push to the feed owner. Use cases: scheduled reports, heartbeat monitoring, proactive alerts.
- **SKILL.md**: Add AlvaAsk owner notification alongside existing follower push docs.

## Dependencies
- Backend PR #601 (notify/message Pattern E backend support)