### PR TITLE
docs(alva): improve design specs — feed fixes, YouTube embed, trim ex…

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1128,11 +1128,8 @@ alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id"
 
 ## Alva Design System
 
-All Alva playbook pages, dashboards, and widgets must follow the Alva Design
-System. **Always read
-[design-system.md](references/design-system.md) first** — it covers visual
-identity, design principles, do/don't guardrails, tokens, typography, and
-page-level layout. Then read only the spec you need:
+**Always read [design-system.md](references/design-system.md) first** — it covers tokens,
+typography, theme, and page-level layout. Then read only the spec you need:
 
 1. **Generating a widget or chart** →
    [design-widgets.md](references/design-widgets.md)

--- a/skills/alva/references/design-components.md
+++ b/skills/alva/references/design-components.md
@@ -58,7 +58,7 @@
   display: flex;
   align-items: center;
   padding: 7px var(--spacing-m);
-  gap: 8px;
+  gap: var(--spacing-xs);
 }
 
 .list-item-text {
@@ -208,7 +208,7 @@ tags, and scoped CSS maps them to the Alva design spec.
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-m);
 }
 .markdown-container * {
   box-sizing: border-box;
@@ -273,7 +273,7 @@ tags, and scoped CSS maps them to the Alva design spec.
 .markdown-container ol {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-xs);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -363,15 +363,15 @@ tags, and scoped CSS maps them to the Alva design spec.
   height: 1px;
   background: var(--line-l07);
   border: none;
-  margin: 4px 0;
+  margin: var(--spacing-xxs) 0;
 }
 
 /* ── Table ── follows Table Card rules (design-widgets.md) */
 .markdown-container table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 16px 0;
-  margin: 0 -16px;
+  border-spacing: var(--spacing-m) 0;
+  margin: 0 calc(var(--spacing-m) * -1);
 }
 .markdown-container th,
 .markdown-container td {
@@ -426,13 +426,13 @@ tags, and scoped CSS maps them to the Alva design spec.
     no-repeat;
   display: inline-block;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: var(--spacing-xxs);
   flex-shrink: 0;
 }
 
 /* ── Medium ── */
 .markdown-container--m {
-  gap: 8px;
+  gap: var(--spacing-xs);
 }
 .markdown-container--m h1 {
   font-size: 18px;
@@ -479,7 +479,7 @@ tags, and scoped CSS maps them to the Alva design spec.
 }
 .markdown-container--m ul,
 .markdown-container--m ol {
-  gap: 4px;
+  gap: var(--spacing-xxs);
 }
 .markdown-container--m th,
 .markdown-container--m td {
@@ -504,7 +504,7 @@ tags, and scoped CSS maps them to the Alva design spec.
 
 /* ── Small ── */
 .markdown-container--s {
-  gap: 4px;
+  gap: var(--spacing-xxs);
 }
 .markdown-container--s h1 {
   font-size: 14px;
@@ -555,7 +555,7 @@ tags, and scoped CSS maps them to the Alva design spec.
 }
 .markdown-container--s ul,
 .markdown-container--s ol {
-  gap: 4px;
+  gap: var(--spacing-xxs);
 }
 .markdown-container--s code {
   font-size: 10px;
@@ -1063,14 +1063,14 @@ Modal                        ← Overlay
 | Border Radius | `var(--radius-pop-dialog)` / `12px`|
 | Border        | `0.5px solid var(--line-l2)`       |
 | Padding       | `var(--spacing-xxl)` / `28px` (all sides)|
-| Gap           | `16px` (between title and content) |
+| Gap           | `var(--spacing-m)` / `16px` (between title and content) |
 
 ### Modal Title
 
 | Property       | Value                                   |
 | -------------- | --------------------------------------- |
 | Layout         | `flex` / `row` / `space-between`        |
-| Gap            | `12px` (between title and close button) |
+| Gap            | `var(--spacing-s)` / `12px` (between title and close button) |
 | Font Family    | `Delight`                               |
 | Font Weight    | `500`                                   |
 | Font Size      | `18px`                                  |
@@ -1414,7 +1414,7 @@ border through their transparent border.
 
 /* Underline */
 .tab-underline {
-  gap: 16px;
+  gap: var(--spacing-m);
 }
 .tab-underline .tab-item {
   padding-bottom: var(--spacing-xxs);
@@ -1432,7 +1432,7 @@ border through their transparent border.
 
 /* Underline — Size S */
 .tab-underline.tab-s {
-  gap: 12px;
+  gap: var(--spacing-s);
 }
 .tab-underline.tab-s .tab-item {
   font-size: 12px;

--- a/skills/alva/references/design-playbook-trading-strategy.md
+++ b/skills/alva/references/design-playbook-trading-strategy.md
@@ -1,13 +1,7 @@
 # Trading Strategy Playbook
 
-> **This is the authoritative spec for all trading strategy playbooks.** When
-> generating or modifying a trading strategy playbook, follow this document
-> strictly — page structure, tab layout, module order, component references, and
-> data schema must all match exactly. Do not invent alternative layouts.
->
-> Use [design-system.md](./design-system.md) as the global design entry point.
-> This document only adds trading-strategy-specific page structure,
-> interactions, and UI data requirements.
+> Follow this spec strictly for all trading strategy playbooks. Do not invent
+> alternative layouts. Global tokens and rules: [design-system.md](./design-system.md).
 
 ---
 
@@ -38,10 +32,8 @@ switches content based on the active tab.
 | Padding  | `0`                                              |
 | Layout   | `display: flex; flex-direction: column; flex: 1` |
 
-`.main-wrapper` has **no padding of its own** — all page-edge spacing comes from
-the parent `.playbook-container` (28px left/right on web, 16px on mobile). The
-**top padding is intentionally 0** because it is owned by `.tab-bar-wrapper`
-(see §1.1), which ensures the 24px top gap scrolls with the sticky tab bar.
+`.main-wrapper` has no padding. Page-edge spacing comes from `.playbook-container`.
+Top padding is 0 — owned by `.tab-bar-wrapper` (see §1.1).
 
 #### Mobile Override (≤ 768px)
 
@@ -89,7 +81,7 @@ first child or extra `margin-bottom`/`padding-bottom` on `.tab-bar-wrapper`.
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Items          | Overview · Analytics · Strategy · Feed                                                                                                                                                                                                                                                 |
 | Style          | [Underline M](./design-components.md#tab) — class `.tab .tab-underline`                                                                                                                                                                                                                |
-| Position       | `.tab-bar-wrapper`: `position: sticky`, `top: 0`, `z-index: 100`, `background: var(--b0-page)`, `padding-top: var(--spacing-xl)` (24px) — the wrapper **owns the top padding** so it travels with the sticky element; when pinned at `top: 0` the 24px gap above the tabs is preserved |
+| Position       | `.tab-bar-wrapper`: `position: sticky`, `top: 0`, `z-index: 100`, `background: var(--b0-page)`, `padding-top: var(--spacing-xl)` (24px) |
 | Bottom Divider | 1px solid var(--line-l07) on `.tab-bar-wrapper`. Active indicator and container border sit on the **same line** — apply `margin-bottom: -1px` to `.tab-item` so the 2px indicator overlaps the 1px border                                                                              |
 | URL Routing    | Each tab has a unique URL hash (`#overview`, `#analytics`, `#strategy`, `#feed`); on load, activate tab matching hash. Use `history.replaceState()` (not `window.location.hash`) to update the hash without triggering a scroll jump                                                   |
 
@@ -421,8 +413,7 @@ All charts follow [Chart Card](./design-widgets.md#chart-card) spec.
 | ≥ 1280px   | 2 cards per row (`grid-template-columns: repeat(2, 1fr)`, gap: 24px) |
 | < 1280px   | 1 card per row (single column stack, gap: 24px)                      |
 
-> Analytics container uses `flex: none` to prevent parent flex stretching. Cards
-> keep intrinsic height (`align-items: start`).
+> Analytics container: `flex: none`. Cards: `align-items: start`.
 
 ### Requirements
 

--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -1,27 +1,8 @@
 # Alva Design System
 
-This file is the global entry point for Alva design rules. Read this first to
-understand what Alva looks and feels like, then follow the progressive reading
-path at the bottom for implementation details.
-
-## Visual Identity
-
-Alva is a playbook marketplace for investors — build, share, remix, and trade
-on collaborative investing strategies powered by AI agents.
-
-## Design Principles
-
-1. **Signal first** — every element must serve analysis. If it doesn't help the
-   user read data, compare metrics, or make decisions, remove it.
-2. **Density with restraint** — pack information tightly but maintain clear
-   visual hierarchy. Whitespace is structure, not waste.
-3. **Color is state, not decoration** — green means bullish, red means bearish,
-   yellow means alert. Never use semantic colors for backgrounds, accents, or
-   branding.
-4. **Typography over ornament** — hierarchy comes from font size and opacity,
-   not bold weights, colors, or decorative elements.
-5. **Components support analysis** — Table = scanability, KPI = comparison,
-   Chart = context-rich but visually quiet, Feed = chronology and relevance.
+This file is the global entry point for Alva design rules — tokens, typography,
+theme, and page-level layout. Read this first, then follow the reading path at
+the bottom for widget and component specs.
 
 ## Design Tokens
 
@@ -36,7 +17,7 @@ hardcode hex or rgba values. Below is a quick reference:
 | Text         | `--text-n9/n7/n5/n3/n2`                        | n9=primary, n7=secondary, n5=supporting |
 | Background   | `--b0-page`, `--grey-g01`~`g1`, `--b-r02`~`r1` | g01 for card backgrounds                |
 | Line         | `--line-l05/l07/l12/l2/l3`                     | l07=default                             |
-| Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only (dropdown/modal/tooltip) |
+| Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only (dropdown/tooltip) |
 | Spacing      | `--spacing-xxxs`(2) ~ `--spacing-xxxxxxl`(56)  | Common: xs=8, m=16, xl=24               |
 | Radius       | `--radius-ct-xs`(2) ~ `--radius-ct-l`(8)       | xs=Tag, s=Card, l=Page                  |
 
@@ -45,7 +26,7 @@ hardcode hex or rgba values. Below is a quick reference:
 ### General Rules
 
 1. **The default font for Alva must be Delight**;
-2. Backup fonts: `-apple-system`, `BlinkMacSystemFont`, `sans-serif`;
+2. Backup fonts: `-apple-system`, `OPPO Sans 4.0`, `BlinkMacSystemFont`, `sans-serif`;
 
 ### Font Weight
 
@@ -186,8 +167,7 @@ applied as `margin-bottom` on `.playbook-title`. **Do not add any margin to
 3. **Building a Trading Strategy Playbook** → read
    [design-playbook-trading-strategy.md](./design-playbook-trading-strategy.md).
    This spec defines the complete page structure, tab layout, module order,
-   component usage, and data schema. Do not deviate from it or invent
-   alternative layouts.
+   component usage, and data schema.
 4. **Only need global rules** → stay in this file. Open
    [design-tokens.css](./design-tokens.css) only when you need exact token
    values.

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -3,7 +3,7 @@
 ## Widget Types
 
 - [Critical Rules (TL;DR)](#critical-rules-tldr)
-- [Widget Base CSS](#widget-base-css)
+- [Shared Styles](#shared-styles)
 - [Widget Layout](#widget-layout)
 - [Chart Card](#chart-card)
 - [Metric Card](#metric-card)
@@ -29,15 +29,15 @@
 5. **Same-row widgets must equal height** — `.widget-body.fill` + `flex: 1`.
    ECharts: `height:100%; min-height:180px`. → [Details](#equal-height-fill)
 6. **Table columns require JS `initTableAlignment`** — proportional widths based
-   on content, horizontal scroll when overflow. `gap:16px` on rows,
+   on content, horizontal scroll when overflow. `gap:var(--spacing-m)` on rows,
    `border-bottom` on rows not cells. → [Details](#column-alignment)
 
 ---
 
-## Widget Base CSS
+## Shared Styles
 
-> **Include this entire block in every playbook / dashboard page.** It contains
-> all shared widget styles. Do not rewrite or partially recreate these classes.
+> **Include this block in every playbook page.** Then add each widget type's CSS
+> block as needed.
 
 ```css
 /* ── Widget Card ── */
@@ -47,11 +47,6 @@
   flex-direction: column;
   position: relative;
   overflow: visible;
-}
-
-/* Chart cards clip canvas overflow; table/feed cards must not clip scroll */
-.widget-card:has(.chart-body) {
-  overflow: hidden;
 }
 
 .widget-title {
@@ -93,7 +88,191 @@
   line-height: 0;
 }
 
-/* ── Chart Card ── */
+/* ── Dividers ── */
+.divider-v {
+  width: 1px;
+  flex-shrink: 0;
+  margin-block: var(--spacing-l);
+  background-color: var(--line-l05);
+}
+
+.divider-h {
+  height: 1px;
+  margin-inline: var(--spacing-l);
+  background-color: var(--line-l05);
+}
+
+/* ── Equal Height Fill ── */
+.widget-card .widget-body.fill {
+  flex: 1;
+  height: 0;
+}
+
+/* ── Widget Grid ── */
+.widget-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: var(--spacing-xl);
+  align-items: stretch;
+}
+
+.col-2 {
+  grid-column: span 2;
+}
+.col-3 {
+  grid-column: span 3;
+}
+.col-4 {
+  grid-column: span 4;
+}
+.col-5 {
+  grid-column: span 5;
+}
+.col-6 {
+  grid-column: span 6;
+}
+.col-8 {
+  grid-column: span 8;
+}
+
+.col-thirds {
+  grid-column: span 8;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-xl);
+  align-items: stretch;
+}
+
+@media (max-width: 768px) {
+  .widget-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--spacing-l);
+  }
+  .col-2 {
+    grid-column: span 2;
+  }
+  .col-3,
+  .col-4,
+  .col-5,
+  .col-6,
+  .col-8 {
+    grid-column: span 4;
+  }
+  .col-thirds {
+    grid-column: span 4;
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Content Reflow ── */
+.widget-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.widget-row > * {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
+```
+
+> **Watermark SVG**: Always use the CDN URL via `<img>` tag. Do not inline SVG.
+
+---
+
+## Widget Layout
+
+### Grid System
+
+| Platform | Total Columns | Gap                   |
+| -------- | ------------- | --------------------- |
+| Web      | 8 columns     | 24px (`--spacing-xl`) |
+| Mweb     | 4 columns     | 16px (`--spacing-l`)  |
+
+### Column Spans
+
+| Class    | Web Proportion | Mweb Behavior               | Use Case                   |
+| -------- | -------------- | --------------------------- | -------------------------- |
+| `.col-2` | 25% (2/8)      | Stays 2/4 (half-width)      | Small KPI, up to 4 per row |
+| `.col-3` | 37.5% (3/8)    | Expands to 4/4 (full-width) | Narrow column widget       |
+| `.col-4` | 50% (4/8)      | Expands to 4/4 (full-width) | Equal two-column split     |
+| `.col-5` | 62.5% (5/8)    | Expands to 4/4 (full-width) | Main column (wide)         |
+| `.col-6` | 75% (6/8)      | Expands to 4/4 (full-width) | Large widget               |
+| `.col-8` | 100% (8/8)     | Expands to 4/4 (full-width) | Full width                 |
+
+### Line Break Rules
+
+Each row's col spans must total exactly 8; shortfalls leave empty space.
+
+| Combination              | Col Spans       | Width Ratio         |
+| ------------------------ | --------------- | ------------------- |
+| Equal two-column         | `4 + 4`         | 50% + 50%           |
+| Left narrow, right wide  | `3 + 5`         | 37.5% + 62.5%       |
+| Left wide, right narrow  | `5 + 3`         | 62.5% + 37.5%       |
+| Large + small two-column | `6 + 2`         | 75% + 25%           |
+| Near-equal three-column  | `3 + 3 + 2`     | 37.5% + 37.5% + 25% |
+| One main + two small     | `4 + 2 + 2`     | 50% + 25% + 25%     |
+| Four-column KPI          | `2 + 2 + 2 + 2` | 25% x 4             |
+| Full width               | `8`             | 100%                |
+
+For true equal-width three columns, use `.col-thirds` (see Shared Styles).
+
+### Solo Widget Rule
+
+Non-KPI widget alone on a row must use `col-8`.
+
+### Equal-Height Fill
+
+Same-row widgets with different content heights: add `.fill` to `.widget-body`
+(`flex:1; height:0`). ECharts containers: `height:100%; min-height:180px`.
+
+### Content Reflow
+
+Use `.widget-row` for widget-internal horizontal layouts. Charts and tables
+never wrap — always `width: 100%`.
+
+### Widget Height
+
+| Widget Type    | Default Height        | Overflow Behavior        |
+| -------------- | --------------------- | ------------------------ |
+| Metric Card    | auto (content-driven) | Wrap via flex-wrap       |
+| Chart Card     | 320px                 | Chart scales internally  |
+| Table Card     | auto, capped at 680px | Scroll within table body |
+| Free Text Card | auto (content-driven) | Scroll or truncate       |
+| Feed Card      | auto, capped at 680px | Scroll within feed body  |
+
+Table / Feed: content < 320px → auto; ≥ 320px → 320px body + internal scroll. Do
+not exceed 680px total height. Max for all widgets: **960px**
+(`overflow-y: auto` on widget body, not card).
+
+### Widget Background
+
+No border/outline on widgets (only Tag elements may have borders). Background:
+
+| Widget Type | Background                 |
+| ----------- | -------------------------- |
+| Chart Card  | `.chart-dotted-background` |
+| Table Card  | None (transparent)         |
+| Others      | `var(--grey-g01)`          |
+
+### Divider
+
+Use `.divider-v` / `.divider-h` — both ends align with content padding (not full
+width). Do not use `border-bottom` / `border-right` for widget dividers.
+
+---
+
+## Chart Card
+
+### CSS
+
+```css
+/* Chart cards clip canvas overflow */
+.widget-card:has(.chart-body) {
+  overflow: hidden;
+}
+
 .chart-dotted-background {
   background-image: radial-gradient(
     circle,
@@ -153,306 +332,12 @@
   border-radius: 50%;
 }
 
-/* ── Table Card ── */
-.table-card {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  border-radius: 4px;
-  isolation: isolate;
-  overflow-x: auto;
-}
-
-.table-row {
-  display: flex;
-  width: 100%;
-  gap: 16px; /* column spacing between cells */
-  border-bottom: 1px solid var(--line-l07); /* row divider — on the row, not cells */
-  /* min-width is set by initTableAlignment JS — do NOT use CSS min-width here */
-}
-.table-row:last-child {
-  border-bottom: none;
-}
-
-.table-cell {
-  font-size: 14px;
-  line-height: 22px;
-  letter-spacing: 0.14px;
-  font-weight: 400;
-  white-space: nowrap;
-  display: flex;
-  align-items: center;
-}
-
-/* ── Free Text Card ── */
-.free-text-body {
-  padding: var(--spacing-l);
-}
-
-/* ── Feed Card ── */
-.feed-body {
-  padding: var(--spacing-xxs) 0;
-}
-
-.feed-item {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-xs);
-  padding: var(--spacing-m);
-  position: relative;
-}
-
-.feed-item::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: var(--spacing-m);
-  right: var(--spacing-m);
-  height: 1px;
-  background: var(--line-l05);
-}
-
-.feed-item:last-child::after {
-  display: none;
-}
-
-.feed-item-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.feed-thumb {
-  width: 88px;
-  height: 70px;
-  border-radius: var(--radius-ct-s);
-  flex-shrink: 0;
-  order: 1;
-  object-fit: cover;
-}
-
-/* ── Dividers ── */
-.divider-v {
-  width: 1px;
-  flex-shrink: 0;
-  margin-block: var(--spacing-l);
-  background-color: var(--line-l05);
-}
-
-.divider-h {
-  height: 1px;
-  margin-inline: var(--spacing-l);
-  background-color: var(--line-l05);
-}
-
-/* ── Equal Height Fill ── */
-.widget-card .widget-body.fill {
-  flex: 1;
-  height: 0;
-}
-
 .chart-container {
   width: 100%;
   height: 100%;
   min-height: 180px;
 }
-
-/* ── Widget Grid ── */
-.widget-grid {
-  display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  gap: var(--spacing-xl);
-  align-items: stretch;
-}
-
-.col-2 {
-  grid-column: span 2;
-}
-.col-3 {
-  grid-column: span 3;
-}
-.col-4 {
-  grid-column: span 4;
-}
-.col-5 {
-  grid-column: span 5;
-}
-.col-6 {
-  grid-column: span 6;
-}
-.col-8 {
-  grid-column: span 8;
-}
-
-.col-thirds {
-  grid-column: span 8;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--spacing-xl);
-  align-items: stretch;
-}
-
-@media (max-width: 768px) {
-  .widget-grid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-l);
-  }
-  .col-2 {
-    grid-column: span 2;
-  }
-  .col-3,
-  .col-4,
-  .col-5,
-  .col-6,
-  .col-8 {
-    grid-column: span 4;
-  }
-  .col-thirds {
-    grid-column: span 4;
-    grid-template-columns: 1fr;
-  }
-}
-
-/* ── Metric Column (for stacking metric cards beside a chart) ── */
-.metric-column {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-s);
-}
-
-.metric-column .metric-card {
-  flex: 1;
-  background: var(--grey-g01);
-  border-radius: var(--radius-ct-m);
-  padding: var(--spacing-m);
-}
-
-/* ── Content Reflow ── */
-.widget-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xs);
-}
-
-.widget-row > * {
-  flex: 1 1 auto;
-  min-width: 120px;
-}
-
-/* ── Group Title ── */
-.section-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 8px;
-}
-
-.section-title-icon {
-  font-size: 22px;
-  line-height: 1;
-}
-
-.section-title-text {
-  font-size: 22px;
-  font-weight: 400;
-  color: var(--text-n9);
-  letter-spacing: 0.3px;
-}
-
-.section-title-sub {
-  font-size: 12px;
-  color: var(--text-n5);
-  padding-left: 8px;
-  border-left: 1px solid var(--line-l07);
-}
 ```
-
-> **Watermark SVG**: Always use the CDN URL via `<img>` tag. Do not inline SVG.
-
----
-
-## Widget Layout
-
-### Grid System
-
-| Platform | Total Columns | Gap                   |
-| -------- | ------------- | --------------------- |
-| Web      | 8 columns     | 24px (`--spacing-xl`) |
-| Mweb     | 4 columns     | 16px (`--spacing-l`)  |
-
-### Column Spans
-
-| Class    | Web Proportion | Mweb Behavior               | Use Case                   |
-| -------- | -------------- | --------------------------- | -------------------------- |
-| `.col-2` | 25% (2/8)      | Stays 2/4 (half-width)      | Small KPI, up to 4 per row |
-| `.col-3` | 37.5% (3/8)    | Expands to 4/4 (full-width) | Narrow column widget       |
-| `.col-4` | 50% (4/8)      | Expands to 4/4 (full-width) | Equal two-column split     |
-| `.col-5` | 62.5% (5/8)    | Expands to 4/4 (full-width) | Main column (wide)         |
-| `.col-6` | 75% (6/8)      | Expands to 4/4 (full-width) | Large widget               |
-| `.col-8` | 100% (8/8)     | Expands to 4/4 (full-width) | Full width                 |
-
-### Line Break Rules
-
-Each row's col spans must total exactly 8; shortfalls leave empty space.
-
-| Combination              | Col Spans       | Width Ratio         |
-| ------------------------ | --------------- | ------------------- |
-| Equal two-column         | `4 + 4`         | 50% + 50%           |
-| Left narrow, right wide  | `3 + 5`         | 37.5% + 62.5%       |
-| Left wide, right narrow  | `5 + 3`         | 62.5% + 37.5%       |
-| Large + small two-column | `6 + 2`         | 75% + 25%           |
-| Near-equal three-column  | `3 + 3 + 2`     | 37.5% + 37.5% + 25% |
-| One main + two small     | `4 + 2 + 2`     | 50% + 25% + 25%     |
-| Four-column KPI          | `2 + 2 + 2 + 2` | 25% x 4             |
-| Full width               | `8`             | 100%                |
-
-For true equal-width three columns, use `.col-thirds` (see Base CSS).
-
-### Solo Widget Rule
-
-Non-KPI widget alone on a row must use `col-8`.
-
-### Equal-Height Fill
-
-Same-row widgets with different content heights: add `.fill` to `.widget-body`
-(`flex:1; height:0`). ECharts containers: `height:100%; min-height:180px`.
-
-### Content Reflow
-
-Use `.widget-row` for widget-internal horizontal layouts. Charts and tables
-never wrap — always `width: 100%`.
-
-### Widget Height
-
-| Widget Type    | Default Height        | Overflow Behavior        |
-| -------------- | --------------------- | ------------------------ |
-| Metric Card    | auto (content-driven) | Wrap via flex-wrap       |
-| Chart Card     | 320px                 | Chart scales internally  |
-| Table Card     | auto, capped at 560px | Scroll within table body |
-| Free Text Card | auto (content-driven) | Scroll or truncate       |
-| Feed Card      | auto, capped at 560px | Scroll within feed body  |
-
-Table / Feed: content < 320px → auto; ≥ 320px → 320px body + internal scroll. Do
-not exceed 560px total height. Max for all widgets: **960px**
-(`overflow-y: auto` on widget body, not card).
-
-### Widget Background
-
-No border/outline on widgets (only Tag elements may have borders). Background:
-
-| Widget Type | Background                 |
-| ----------- | -------------------------- |
-| Chart Card  | `.chart-dotted-background` |
-| Table Card  | None (transparent)         |
-| Others      | `var(--grey-g01)`          |
-
-### Divider
-
-Use `.divider-v` / `.divider-h` — both ends align with content padding (not full
-width). Do not use `border-bottom` / `border-right` for widget dividers.
-
----
-
-## Chart Card
 
 ### Template
 
@@ -518,7 +403,7 @@ const AX = {
   axisLabel: {
     fontSize: 10,
     color: "rgba(0,0,0,0.7)",  // --text-n7
-    fontFamily: "'Delight', -apple-system, BlinkMacSystemFont, sans-serif",
+    fontFamily: "'Delight', -apple-system, 'OPPO Sans 4.0', BlinkMacSystemFont, sans-serif",
     margin: 8, // 8px gap from label to axis line
   },
   splitLine: { show: false },
@@ -588,7 +473,7 @@ const TT = {
   borderRadius: 6,
   padding: 12,
   textStyle: {
-    fontFamily: "'Delight',-apple-system,BlinkMacSystemFont,sans-serif",
+    fontFamily: "'Delight', -apple-system, 'OPPO Sans 4.0', BlinkMacSystemFont, sans-serif",
     fontSize: 12,
     fontWeight: 400,
     color: TT_COLORS.text,
@@ -659,6 +544,24 @@ No `shadowBlur`, no `focus: 'series'`.
 
 ## Metric Card
 
+### CSS
+
+```css
+/* ── Metric Column (for stacking metric cards beside a chart) ── */
+.metric-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.metric-column .metric-card {
+  flex: 1;
+  background: var(--grey-g01);
+  border-radius: var(--radius-ct-m);
+  padding: var(--spacing-m);
+}
+```
+
 ### Template
 
 ```html
@@ -671,7 +574,7 @@ No `shadowBlur`, no `focus: 'series'`.
     class="widget-body"
     style="background:var(--grey-g01);padding:var(--spacing-l);flex-direction:column;align-items:flex-start;"
   >
-    <!-- Single KPI -->
+    <!-- Single Metric -->
     <div style="font-size:11px;color:var(--text-n7);letter-spacing:0.12px;">
       Label
     </div>
@@ -705,6 +608,39 @@ No `shadowBlur`, no `focus: 'series'`.
 
 ## Table Card
 
+### CSS
+
+```css
+.table-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  isolation: isolate;
+  overflow-x: auto;
+}
+
+.table-row {
+  display: flex;
+  width: 100%;
+  gap: var(--spacing-m); /* column spacing between cells */
+  border-bottom: 1px solid var(--line-l07); /* row divider — on the row, not cells */
+  /* min-width is set by initTableAlignment JS — do NOT use CSS min-width here */
+}
+.table-row:last-child {
+  border-bottom: none;
+}
+
+.table-cell {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  font-weight: 400;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+}
+```
+
 ### Template
 
 ```html
@@ -734,7 +670,7 @@ No `shadowBlur`, no `focus: 'series'`.
 
 - No background. Delight Regular (400) only.
 - Row-first flex layout. **Do NOT use column-first layout.**
-- Column spacing: `gap: 16px` on `.table-row`. **Do NOT use cell padding for
+- Column spacing: `gap: var(--spacing-m)` on `.table-row`. **Do NOT use cell padding for
   inter-column spacing.**
 - Row divider: `border-bottom: 1px solid var(--line-l07)` on `.table-row` (not
   cells). Last row: no border.
@@ -792,7 +728,7 @@ function initTableAlignment(tableEl) {
   // Phase 3: Resolve — proportional fill, min = content width
   var totalContent = 0;
   for (var i = 0; i < colWidths.length; i++) totalContent += colWidths[i];
-  var gapTotal = (colCount - 1) * 16;
+  var gapTotal = (colCount - 1) * 16; // --spacing-m
   var available = tableEl.clientWidth - gapTotal;
 
   var resolved = [];
@@ -833,6 +769,14 @@ exceed container. No hover effects on rows.
 
 ## Free Text Card
 
+### CSS
+
+```css
+.free-text-body {
+  padding: var(--spacing-l);
+}
+```
+
 ### Template
 
 ```html
@@ -864,10 +808,261 @@ for rich text rendering.
 
 ## Feed Card
 
-### Template
+### CSS
+
+```css
+.feed-body {
+  padding: var(--spacing-xxs) 0;
+}
+
+.feed-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-m);
+  padding: var(--spacing-m);
+  position: relative;
+  border-radius: var(--radius-ct-s);
+  transition: background 0.15s;
+}
+
+.feed-item:hover {
+  background: var(--b-r02);
+  cursor: pointer;
+}
+
+.feed-item::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: var(--spacing-m);
+  right: var(--spacing-m);
+  height: 1px;
+  background: var(--line-l05);
+}
+
+.feed-item:last-child::after {
+  display: none;
+}
+
+/* ── Left column: header + indented content ── */
+.feed-item-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+}
+
+/* Header row — avatar + title / user-info */
+.feed-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+/* ── Avatar / Logo ── */
+.feed-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 100px;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.feed-avatar.has-badge {
+  overflow: visible;
+}
+
+.feed-avatar.no-radius {
+  border-radius: 0;
+  overflow: visible;
+}
+
+.feed-avatar > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 100px;
+}
+
+.feed-avatar.no-radius > img {
+  border-radius: 0;
+}
+
+.feed-avatar-badge {
+  position: absolute;
+  bottom: -1px;
+  right: -3px;
+  width: 14px;
+  height: 14px;
+  background: var(--b0-container);
+  border-radius: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feed-avatar-badge img {
+  width: 12px;
+  height: 12px;
+  border-radius: 100px;
+}
+
+/* ── Header text variants ── */
+
+/* Podcast / Youtube / News: bold single-line title */
+.feed-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* X / Reddit: name + handle + date inline */
+.feed-header-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  white-space: nowrap;
+}
+
+.feed-display-name {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+}
+
+.feed-handle,
+.feed-meta-sep,
+.feed-meta-date {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+}
+
+/* ── Indented content below header ── */
+.feed-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+  padding-left: var(--spacing-xxl); /* 28px = 22px avatar + 6px gap */
+  width: 100%;
+}
+
+.feed-post-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.feed-text {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.feed-text:empty {
+  display: none;
+}
+
+.feed-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+  white-space: nowrap;
+}
+
+/* ── Actions (X / Reddit) ── */
+.feed-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.feed-action {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxxs);
+  overflow: hidden;
+}
+
+.feed-action-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.feed-action span {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+  white-space: nowrap;
+}
+
+/* ── Thumbnail ── */
+.feed-thumb {
+  width: 88px;
+  height: 70px;
+  border-radius: var(--radius-ct-s);
+  border: 1px solid var(--line-l07);
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.feed-thumb img:not(.feed-thumb-play) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.feed-thumb-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 28px;
+  height: 28px;
+}
+```
+
+### Template — Podcast / Youtube / News
+
+These three types share the same layout. Podcast and Youtube use fixed CDN
+platform logos; News uses the source website's favicon. Only Podcast and
+Youtube thumbnails show a play button.
 
 ```html
-<!-- Feed Card — copy this structure exactly -->
+<!-- Feed Card (Podcast / Youtube / News) — copy this structure exactly -->
 <div class="widget-card">
   <div class="widget-title">
     <span class="widget-title-text">Feed Title</span>
@@ -877,13 +1072,96 @@ for rich text rendering.
     style="background:var(--grey-g01);flex-direction:column;align-items:stretch;"
   >
     <div class="feed-body">
+      <!-- Podcast item (avatar = CDN platform logo) -->
       <div class="feed-item">
-        <div class="feed-item-content">
-          <div><!-- headline --></div>
-          <div><!-- description --></div>
+        <div class="feed-item-main">
+          <div class="feed-header">
+            <div class="feed-avatar">
+              <img
+                src="https://alva-ai-static.b-cdn.net/icons/logo-social-podcast.svg"
+                alt=""
+              />
+            </div>
+            <div class="feed-title">Headline text, single line with ellipsis</div>
+          </div>
+          <div class="feed-content">
+            <div class="feed-text">
+              Body text capped at two lines (44px). Overflow is hidden...
+            </div>
+            <div class="feed-info">
+              <span>Podcast</span>
+              <span>·</span>
+              <span>Jan 21</span>
+              <span>·</span>
+              <span>By Danya</span>
+            </div>
+          </div>
         </div>
-        <img class="feed-thumb" src="thumb.jpg" alt="" />
-        <!-- optional -->
+        <!-- optional thumbnail (Podcast / Youtube get play button) -->
+        <div class="feed-thumb">
+          <img src="thumb.jpg" alt="" />
+          <img
+            class="feed-thumb-play"
+            src="https://alva-ai-static.b-cdn.net/icons/play.svg"
+            alt=""
+          />
+        </div>
+      </div>
+      <!-- Youtube item (avatar = CDN platform logo, no-radius) -->
+      <div class="feed-item">
+        <div class="feed-item-main">
+          <div class="feed-header">
+            <div class="feed-avatar no-radius">
+              <img
+                src="https://alva-ai-static.b-cdn.net/icons/logo-social-youtube.svg"
+                alt=""
+              />
+            </div>
+            <div class="feed-title">Headline text, single line with ellipsis</div>
+          </div>
+          <div class="feed-content">
+            <div class="feed-text">Body text...</div>
+            <div class="feed-info">
+              <span>Youtube</span>
+              <span>·</span>
+              <span>Jan 21</span>
+              <span>·</span>
+              <span>By Danya</span>
+            </div>
+          </div>
+        </div>
+        <div class="feed-thumb">
+          <img src="thumb.jpg" alt="" />
+          <img
+            class="feed-thumb-play"
+            src="https://alva-ai-static.b-cdn.net/icons/play.svg"
+            alt=""
+          />
+        </div>
+      </div>
+      <!-- News item (avatar = website favicon, no play button) -->
+      <div class="feed-item">
+        <div class="feed-item-main">
+          <div class="feed-header">
+            <div class="feed-avatar">
+              <img src="https://website.com/favicon.png" alt="" />
+            </div>
+            <div class="feed-title">Headline text, single line with ellipsis</div>
+          </div>
+          <div class="feed-content">
+            <div class="feed-text">Body text...</div>
+            <div class="feed-info">
+              <span>Reuters</span>
+              <span>·</span>
+              <span>Jan 21</span>
+              <span>·</span>
+              <span>By Danya</span>
+            </div>
+          </div>
+        </div>
+        <div class="feed-thumb">
+          <img src="thumb.jpg" alt="" />
+        </div>
       </div>
       <!-- more feed-items... -->
     </div>
@@ -897,14 +1175,274 @@ for rich text rendering.
 </div>
 ```
 
-> Thumbnail (`.feed-thumb`) is always on the right via `order: 1`. Text fills
-> remaining width via `flex: 1`.
+### Template — X (Twitter)
+
+```html
+<!-- Feed Card (X) — copy this structure exactly -->
+<div class="feed-item">
+  <div class="feed-item-main">
+    <div class="feed-header">
+      <div class="feed-avatar has-badge">
+        <img src="user-avatar.jpg" alt="" />
+        <div class="feed-avatar-badge">
+          <img
+            src="https://alva-ai-static.b-cdn.net/icons/logo-feed-x.svg"
+            alt=""
+          />
+        </div>
+      </div>
+      <div class="feed-header-meta">
+        <span class="feed-display-name">Tesla Owners SV</span>
+        <span class="feed-handle">@teslaownersSV</span>
+        <span class="feed-meta-sep">·</span>
+        <span class="feed-meta-date">Jan 21</span>
+      </div>
+    </div>
+    <div class="feed-content">
+      <div class="feed-text">
+        Elon Musk: "It appears that, when civilizations are under stress..."
+      </div>
+      <div class="feed-actions">
+        <div class="feed-action">
+          <img
+            class="feed-action-icon"
+            src="https://alva-ai-static.b-cdn.net/icons/social-reply-l.svg"
+            alt=""
+          />
+          <span>12</span>
+        </div>
+        <div class="feed-action">
+          <img
+            class="feed-action-icon"
+            src="https://alva-ai-static.b-cdn.net/icons/social-repost-l.svg"
+            alt=""
+          />
+          <span>14</span>
+        </div>
+        <div class="feed-action">
+          <img
+            class="feed-action-icon"
+            src="https://alva-ai-static.b-cdn.net/icons/social-like-l.svg"
+            alt=""
+          />
+          <span>285</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- optional thumbnail (no play button) -->
+  <div class="feed-thumb">
+    <img src="thumb.jpg" alt="" />
+  </div>
+</div>
+```
+
+### Template — Reddit
+
+```html
+<!-- Feed Card (Reddit) — copy this structure exactly -->
+<div class="feed-item">
+  <div class="feed-item-main">
+    <div class="feed-header">
+      <div class="feed-avatar has-badge">
+        <img src="user-avatar.jpg" alt="" />
+        <div class="feed-avatar-badge">
+          <img
+            src="https://alva-ai-static.b-cdn.net/icons/logo-feed-reddit.svg"
+            alt=""
+          />
+        </div>
+      </div>
+      <div class="feed-header-meta">
+        <span class="feed-display-name">r/interesting</span>
+        <span class="feed-meta-sep">·</span>
+        <span class="feed-meta-date">Jan 21</span>
+      </div>
+    </div>
+    <div class="feed-content">
+      <div class="feed-post-title">How to I Invest in Silver or Gold?</div>
+      <div class="feed-text">
+        The ishares physical versions are "paper gold/silver"...
+      </div>
+      <div class="feed-actions">
+        <div class="feed-action">
+          <img
+            class="feed-action-icon"
+            src="https://alva-ai-static.b-cdn.net/icons/social-vote-l.svg"
+            alt=""
+          />
+          <span>14</span>
+        </div>
+        <div class="feed-action">
+          <img
+            class="feed-action-icon"
+            src="https://alva-ai-static.b-cdn.net/icons/social-reply-l.svg"
+            alt=""
+          />
+          <span>12</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- optional thumbnail (no play button) -->
+  <div class="feed-thumb">
+    <img src="thumb.jpg" alt="" />
+  </div>
+</div>
+```
+
+### Feed Card Rules
+
+#### Avatar / Logo by Source Type
+
+| Type    | Avatar (22×22)                                       | Badge (14×14)                 | Thumbnail Play |
+| ------- | ---------------------------------------------------- | ----------------------------- | -------------- |
+| Podcast | CDN fixed: `logo-social-podcast.svg`                 | —                             | Yes            |
+| Youtube | CDN fixed: `logo-social-youtube.svg` (**no-radius**) | —                             | Yes            |
+| News    | Website favicon / logo (round)                       | —                             | No             |
+| X       | User avatar (round)                                  | `logo-feed-x.svg` (CDN)      | No             |
+| Reddit  | User avatar (round)                                  | `logo-feed-reddit.svg` (CDN) | No             |
+
+- `.feed-avatar` is always 22×22 with `border-radius: 100px`.
+- **Youtube** logo is rectangular — add `.no-radius` to `.feed-avatar` to
+  remove the circular clip.
+- **Podcast / Youtube** use platform logos from CDN
+  (`https://alva-ai-static.b-cdn.net/icons/logo-social-podcast.svg`,
+  `https://alva-ai-static.b-cdn.net/icons/logo-social-youtube.svg`).
+- **News** uses the source website's favicon or logo image.
+- For X / Reddit, add `.has-badge` to `.feed-avatar` (disables `overflow:hidden`
+  so the badge can overflow the circle).
+- Badge background uses `--b0-container` to mask the avatar edge; inner icon is
+  12×12 with `border-radius: 100px`.
+- X badge: `https://alva-ai-static.b-cdn.net/icons/logo-feed-x.svg`.
+- Reddit badge: `https://alva-ai-static.b-cdn.net/icons/logo-feed-reddit.svg`.
+
+#### Layout Rules
+
+- **Header row** (`.feed-header`): avatar + title or meta, `gap: 6px`.
+- **Content** (`.feed-content`): indented `padding-left: var(--spacing-xxl)`
+  (28px = 22px avatar + 6px gap) to align with header text.
+- **Body text** (`.feed-text`): auto height, max 2 lines via `-webkit-line-clamp: 2`.
+  Collapses via `:empty` when body is blank.
+- **Post title** (`.feed-post-title`): Reddit only; single line, `font-weight: 500`,
+  placed before `.feed-text`.
+- **Info line** (`.feed-info`): for Podcast / Youtube / News — `Source · Date · By Author`.
+- **Actions** (`.feed-actions`): for X / Reddit — icon 14×14 + count, `gap: var(--spacing-xs)`.
+- **Thumbnail** (`.feed-thumb`): 88×70, right side via flex order,
+  `border: 1px solid var(--line-l07)`. Optional for all types.
+- **Play button**: Podcast and Youtube thumbnails show a centered play icon
+  (`.feed-thumb-play`, 28×28).
+- **Divider** (`.feed-item::after`): 1px line between items, inset by
+  `var(--spacing-m)` on both sides. Hidden on `:last-child`. **`.feed-item`
+  must be a direct child of `.feed-body`** — do NOT wrap it in `<a>` or any
+  other element. Wrapping breaks `:last-child` (every item becomes the only
+  child of its wrapper, so all dividers disappear). Use `data-href` +
+  delegated click instead:
+
+  ```html
+  <div class="feed-item" data-href="https://...">...</div>
+  ```
+
+  ```js
+  document.addEventListener("click", function(e) {
+    var el = e.target.closest(".feed-item[data-href]");
+    if (!el) return;
+    var url = el.getAttribute("data-href");
+    var m = url.match(/youtube\.com\/watch\?v=([\w-]+)/);
+    if (m) {
+      document.getElementById("yt-frame").src =
+        "https://www.youtube.com/embed/" + m[1] + "?autoplay=1";
+      document.getElementById("yt-modal").classList.add("open");
+    } else {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  });
+  ```
+
+- **YouTube links open inline** via `youtube.com/embed/{id}` in a modal
+  overlay. Close on backdrop click or close button; set `iframe.src = ""`
+  on close to stop playback.
+
+  ```css
+  .yt-modal {
+    display: none; position: fixed; top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: rgba(0,0,0,0.6); z-index: 9999;
+    align-items: center; justify-content: center;
+  }
+  .yt-modal.open { display: flex; }
+  .yt-modal-inner {
+    position: relative; width: 90%; max-width: 800px;
+    aspect-ratio: 16/9; border-radius: var(--radius-ct-s);
+    overflow: hidden; background: #000;
+  }
+  .yt-modal-inner iframe { width: 100%; height: 100%; border: 0; }
+  .yt-modal-close {
+    position: absolute; top: -32px; right: 0;
+    width: 28px; height: 28px; border: none; background: none;
+    color: #fff; font-size: 20px; cursor: pointer;
+    line-height: 28px; text-align: center;
+  }
+  ```
+
+  ```html
+  <div class="yt-modal" id="yt-modal">
+    <div class="yt-modal-inner">
+      <button class="yt-modal-close" id="yt-close">&times;</button>
+      <iframe id="yt-frame" src="" allow="autoplay; encrypted-media"
+        allowfullscreen></iframe>
+    </div>
+  </div>
+  ```
+
+  ```js
+  document.getElementById("yt-close").addEventListener("click", function() {
+    document.getElementById("yt-modal").classList.remove("open");
+    document.getElementById("yt-frame").src = "";
+  });
+  document.getElementById("yt-modal").addEventListener("click", function(e) {
+    if (e.target === this) {
+      this.classList.remove("open");
+      document.getElementById("yt-frame").src = "";
+    }
+  });
+  ```
 
 ---
 
 ## Group Title
 
 Not a widget-card; a page-level section separator.
+
+### CSS
+
+```css
+.section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.section-title-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.section-title-text {
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--text-n9);
+  letter-spacing: 0.3px;
+}
+
+.section-title-sub {
+  font-size: 12px;
+  color: var(--text-n5);
+  padding-left: 8px;
+  border-left: 1px solid var(--line-l07);
+}
+```
 
 ### Template
 


### PR DESCRIPTION
…planations

- Feed card: .feed-text uses line-clamp instead of fixed 44px height
- Feed card: .feed-text:empty collapses blank body text
- Feed card: .feed-thumb img excludes .feed-thumb-play from stretch
- Feed card: YouTube links open inline via embed modal (COOP workaround)
- Feed card: click handler updated for YouTube embed + window.open fallback
- Trading strategy: trim unnecessary explanatory text
- Components: use CSS variables instead of hardcoded pixel values
- SKILL.md: simplify design system section

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
