### PR TITLE
docs(alva): remove Browser SDK section from SKILL.md for clarity

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -132,15 +132,6 @@ Use the loaded memory to tailor your responses to the user's profile,
 preferences, and investment style. See the [Memory](#memory) section below for
 reading and writing rules.
 
-The API key is passed via the `_t` query parameter in the page URL. Playbook
-pages hosted on Alva receive this automatically.
-
-### Browser SDK Resources
-
-`client.user`, `client.fs`, `client.run`, `client.deploy`, `client.release`,
-`client.secrets`, `client.sdk`, `client.comments`, `client.remix`,
-`client.screenshot`
-
 ---
 
 ## Communication


### PR DESCRIPTION
Eliminated the Browser SDK section and associated example code to streamline documentation. This change focuses on essential content and enhances clarity in the remaining sections.

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
