### PR TITLE
docs(alva): unify letter-spacing rule, add Input component, normalize…

### DIFF
--- a/skills/alva/references/design-components.md
+++ b/skills/alva/references/design-components.md
@@ -9,6 +9,7 @@
 - [Switch](#switch)
 - [Modal](#modal)
 - [Select](#select)
+- [Input](#input)
 - [Tab](#tab)
 - [Tooltip](#tooltip)
 
@@ -29,7 +30,7 @@
   flex-direction: column;
   padding: var(--spacing-xs) 0;
   position: relative;
-  border-radius: var(--radius-pop-dropdown); /* 8px */
+  border-radius: var(--radius-pop-dropdown);
   width: 100%;
   box-shadow: var(--shadow-s);
 }
@@ -37,7 +38,7 @@
 .dropdown-border {
   position: absolute;
   border: 0.5px solid var(--line-l2);
-  border-radius: var(--radius-pop-dropdown); /* 8px */
+  border-radius: var(--radius-pop-dropdown);
   inset: 0;
   pointer-events: none;
 }
@@ -323,7 +324,7 @@ tags, and scoped CSS maps them to the Alva design spec.
 .markdown-container code,
 .markdown-container pre {
   background: var(--b-r02);
-  border-radius: var(--radius-ct-xs); /* 2px */
+  border-radius: var(--radius-ct-xs);
   font-family: "JetBrains Mono", monospace;
   color: var(--text-n7);
 }
@@ -683,7 +684,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
 }
 
 .btn-secondary:hover:not(.btn-disabled) {
-  border-color: var(--text-n9);
+  border-color: var(--line-l9);
 }
 
 .btn-secondary:active:not(.btn-disabled) {
@@ -702,7 +703,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
   height: 48px;
   padding: 11px var(--spacing-l);
   gap: var(--spacing-xs);
-  border-radius: var(--radius-btn-m); /* 8px */
+  border-radius: var(--radius-btn-m);
   font-size: 16px;
   line-height: 26px;
   letter-spacing: 0.16px;
@@ -713,7 +714,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
   height: 40px;
   padding: 9px var(--spacing-l);
   gap: var(--spacing-xs);
-  border-radius: var(--radius-btn-m); /* 8px */
+  border-radius: var(--radius-btn-m);
   font-size: 14px;
   line-height: 22px;
   letter-spacing: 0.14px;
@@ -724,7 +725,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
   height: 32px;
   padding: 6px var(--spacing-m);
   gap: 6px;
-  border-radius: var(--radius-btn-s); /* 6px */
+  border-radius: var(--radius-btn-s);
   font-size: 12px;
   line-height: 20px;
   letter-spacing: 0.12px;
@@ -735,7 +736,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
   height: 28px;
   padding: var(--spacing-xxs) var(--spacing-s);
   gap: var(--spacing-xxs);
-  border-radius: var(--radius-btn-s); /* 6px */
+  border-radius: var(--radius-btn-s);
   font-size: 12px;
   line-height: 20px;
   letter-spacing: 0.12px;
@@ -770,7 +771,7 @@ The button component system contains **2 types** x **4 sizes** x **4 states** =
 }
 
 .btn-secondary.btn-loading::after {
-  border-color: var(--text-n9);
+  border-color: var(--line-l9);
   border-top-color: transparent;
 }
 
@@ -1168,7 +1169,7 @@ Dropdown. Arrow icon always points down and does not rotate.
 }
 
 .select:hover .select-border {
-  border-color: var(--text-n9);
+  border-color: var(--line-l9);
 }
 
 .select-text {
@@ -1197,7 +1198,7 @@ Dropdown. Arrow icon always points down and does not rotate.
   height: 48px;
   padding: 11px var(--spacing-m);
   gap: var(--spacing-xs);
-  border-radius: var(--radius-btn-m); /* 8px */
+  border-radius: var(--radius-btn-m);
   font-size: 16px;
   line-height: 26px;
   letter-spacing: 0.16px;
@@ -1208,7 +1209,7 @@ Dropdown. Arrow icon always points down and does not rotate.
   height: 40px;
   padding: var(--spacing-xs) var(--spacing-s);
   gap: var(--spacing-xs);
-  border-radius: var(--radius-btn-m); /* 8px */
+  border-radius: var(--radius-btn-m);
   font-size: 14px;
   line-height: 22px;
   letter-spacing: 0.14px;
@@ -1219,7 +1220,7 @@ Dropdown. Arrow icon always points down and does not rotate.
   height: 28px;
   padding: var(--spacing-xxs) var(--spacing-xs);
   gap: var(--spacing-xxs);
-  border-radius: var(--radius-btn-s); /* 6px */
+  border-radius: var(--radius-btn-s);
   font-size: 12px;
   line-height: 20px;
   letter-spacing: 0.12px;
@@ -1340,6 +1341,113 @@ document.addEventListener("click", function () {
 
 ---
 
+## Input
+
+Same container style and sizes as [Select](#select), without the arrow icon.
+Uses a native `<input>` element. Placeholder color matches Select's placeholder
+state; typed text matches the filled state.
+
+### CSS
+
+```css
+.input {
+  display: flex;
+  align-items: center;
+  background-color: var(--b0-container);
+  position: relative;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 400;
+  transition: border-color 0.12s ease;
+}
+
+.input-border {
+  position: absolute;
+  inset: 0;
+  border: 0.5px solid var(--line-l3);
+  border-radius: inherit;
+  pointer-events: none;
+  transition: border-color 0.12s ease;
+}
+
+.input:hover .input-border,
+.input:focus-within .input-border {
+  border-color: var(--line-l9);
+}
+
+.input-field {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-n9);
+}
+
+.input-field::placeholder {
+  color: var(--text-n3);
+}
+
+/* Size — Large */
+.input-lg {
+  height: 48px;
+  padding: 11px var(--spacing-m);
+  border-radius: var(--radius-btn-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Size — Medium (default) */
+.input {
+  height: 40px;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border-radius: var(--radius-btn-m);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* Size — Small */
+.input-sm {
+  height: 28px;
+  padding: var(--spacing-xxs) var(--spacing-xs);
+  border-radius: var(--radius-btn-s);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+```
+
+### HTML Template
+
+```html
+<!-- Medium Input (default) -->
+<div class="input">
+  <div class="input-border"></div>
+  <input type="text" class="input-field" placeholder="Enter value" />
+</div>
+
+<!-- Large Input -->
+<div class="input input-lg">
+  <div class="input-border"></div>
+  <input type="text" class="input-field" placeholder="Enter value" />
+</div>
+
+<!-- Small Input -->
+<div class="input input-sm">
+  <div class="input-border"></div>
+  <input type="text" class="input-field" placeholder="Enter value" />
+</div>
+```
+
+---
+
 ## Tab
 
 2 styles (Pill, Underline) × 2 sizes (M, S) = 4 variants.
@@ -1388,7 +1496,7 @@ border through their transparent border.
 }
 .tab-pill .tab-item {
   padding: 6px var(--spacing-m);
-  border-radius: var(--radius-btn-s); /* 6px */
+  border-radius: var(--radius-btn-s);
   font-size: 14px;
   line-height: 22px;
   letter-spacing: 0.14px;

--- a/skills/alva/references/design-playbook-trading-strategy.md
+++ b/skills/alva/references/design-playbook-trading-strategy.md
@@ -265,11 +265,11 @@ markPoint: {
 ```html
 <div style="display:flex;flex-direction:column;gap:4px;">
   <div
-    style="font-size:11px;color:var(--text-n7);letter-spacing:0.12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
+    style="font-size:11px;color:var(--text-n7);letter-spacing:0.11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
   >
     Label
   </div>
-  <div style="font-size:18px;letter-spacing:0.2px;color:var(--main-m3);">
+  <div style="font-size:18px;letter-spacing:0.18px;color:var(--main-m3);">
     +18.4%
   </div>
   <div id="sparkline-xxx" style="width:100%;height:52px;"></div>
@@ -278,8 +278,8 @@ markPoint: {
 
 | Element         | Spec                                                                                         |
 | --------------- | -------------------------------------------------------------------------------------------- |
-| Label           | 11px, Regular 400, `--text-n7`, letter-spacing 0.12px, single-line ellipsis                  |
-| Value           | 18px, Regular 400, letter-spacing 0.2px                                                      |
+| Label           | 11px, Regular 400, `--text-n7`, letter-spacing 0.11px, single-line ellipsis                  |
+| Value           | 18px, Regular 400, letter-spacing 0.18px                                                     |
 | Value Color     | Positive `--main-m3`, negative `--main-m4`                                                   |
 | Sparkline       | ECharts mini line chart, height 52px, full-width, no axis/labels/grid/tooltip                |
 | Sparkline Color | Positive `--main-m3`, negative `--main-m4`                                                   |

--- a/skills/alva/references/design-system.md
+++ b/skills/alva/references/design-system.md
@@ -134,6 +134,7 @@ applied as `margin-bottom` on `.playbook-title`. **Do not add any margin to
   line-height: 34px;
   font-weight: 400;
   color: var(--text-n9);
+  letter-spacing: 0.24px;
   margin: 0 0 var(--spacing-xl) 0; /* 24px bottom = gap to .playbook-desc */
 }
 

--- a/skills/alva/references/design-tokens.css
+++ b/skills/alva/references/design-tokens.css
@@ -125,6 +125,7 @@
     --line-l12: rgba(0, 0, 0, 0.12); /* Card Border */
     --line-l2: rgba(0, 0, 0, 0.2); /* Popup/Dropdown Border */
     --line-l3: rgba(0, 0, 0, 0.3); /* Button/Input/Select Border */
+    --line-l9: rgba(0, 0, 0, 0.9); 
 
     /* Shadow */
     --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.05);
@@ -158,11 +159,12 @@
     --b-r1: rgba(255, 255, 255, 0.1);
 
     /* Line & Border */
-    --line-l07: rgba(255, 255, 255, 0.08);
+    --line-l07: rgba(255, 255, 255, 0.07);
     --line-l05: rgba(255, 255, 255, 0.05);
-    --line-l12: rgba(255, 255, 255, 0.1);
-    --line-l2: rgba(255, 255, 255, 0.15);
-    --line-l3: rgba(255, 255, 255, 0.25);
+    --line-l12: rgba(255, 255, 255, 0.12);
+    --line-l2: rgba(255, 255, 255, 0.2);
+    --line-l3: rgba(255, 255, 255, 0.3);
+    --line-l9: rgba(255, 255, 255, 0.9);
 
     /* Shadow */
     --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.25);

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -311,6 +311,7 @@ width). Do not use `border-bottom` / `border-right` for widget dividers.
   align-items: center;
   gap: var(--spacing-xxs);
   font-size: 10px;
+  letter-spacing: 0.1px;
   color: var(--text-n5);
 }
 
@@ -575,10 +576,10 @@ No `shadowBlur`, no `focus: 'series'`.
     style="background:var(--grey-g01);padding:var(--spacing-l);flex-direction:column;align-items:flex-start;"
   >
     <!-- Single Metric -->
-    <div style="font-size:11px;color:var(--text-n7);letter-spacing:0.12px;">
+    <div style="font-size:11px;color:var(--text-n7);letter-spacing:0.11px;">
       Label
     </div>
-    <div style="font-size:24px;color:var(--main-m3);">+18.4%</div>
+    <div style="font-size:24px;letter-spacing:0.24px;color:var(--main-m3);">+18.4%</div>
     <!-- Watermark -->
     <div class="alva-watermark">
       <img
@@ -1433,11 +1434,12 @@ Not a widget-card; a page-level section separator.
   font-size: 22px;
   font-weight: 400;
   color: var(--text-n9);
-  letter-spacing: 0.3px;
+  letter-spacing: 0.22px;
 }
 
 .section-title-sub {
   font-size: 12px;
+  letter-spacing: 0.12px;
   color: var(--text-n5);
   padding-left: 8px;
   border-left: 1px solid var(--line-l07);


### PR DESCRIPTION
… tokens

- Apply 1% letter-spacing rule across all font sizes (fix 11/18/22/24px drift)
- Add Input component spec (mirrors Select without arrow icon)
- Rename --text-n9 to --line-l9 for border hover colors; add missing --line-l9 token in light/dark
- Align dark mode --line-l07/l12/l2/l3 values with light mode
- Strip redundant /* 8px */ comments after radius tokens

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
