### PR TITLE
chore: publish design-tokens.css to GCS CDN on push to main

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -1,0 +1,39 @@
+name: Publish design tokens to GCS
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/alva/references/design-tokens.css'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: GCP Auth
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCS_ALVA_AI_INTERNAL_ARTIFACTS_SA_JSON }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: '>= 363.0.0'
+
+      - name: Upload design tokens to GCS
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: skills/alva/references/design-tokens.css
+          destination: alva-ai-stg-ssr-cdn-bucket/design-system/
+          parent: false
+          headers: |
+            cache-control: public,max-age=3600


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that publishes `skills/alva/references/design-tokens.css` to GCS on every push to `main` that touches that file
- Result URL: `https://alva-ai-static.b-cdn.net/design-system/design-tokens.css`
- Also supports `workflow_dispatch` for manual republish (e.g. after initial secret setup)

## Breaking Changes

None

## Database Migrations

None

## Merge Order

None

## Setup Required

Before merging, add `GCS_ALVA_AI_INTERNAL_ARTIFACTS_SA_JSON` to this repo's GitHub secrets (same SA JSON already used in `frontend-monorepo`).

## Test Plan

- [x] Add `GCS_ALVA_AI_INTERNAL_ARTIFACTS_SA_JSON` secret to skills repo settings
- [ ] Trigger `workflow_dispatch` from this branch via GHA UI → job succeeds
- [ ] `curl -sI https://alva-ai-static.b-cdn.net/design-system/design-tokens.css` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)