### PR TITLE
docs(alva): quote ALFS paths; fix search module paths

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -130,11 +130,11 @@ Session variables:
 If you have **not** read the user's memory in this conversation, read it now.
 
 ```bash
-alva fs read --path ~/memory/MEMORY.md
+alva fs read --path '~/memory/MEMORY.md'
 ```
 
 If the file exists, read each file listed in the index (at minimum `user.md`).
-If `~/memory/` does not exist or is empty, skip — it will be seeded on next
+If `'~/memory/'` does not exist or is empty, skip — it will be seeded on next
 sign-in.
 
 Use the loaded memory to tailor your responses to the user's profile,
@@ -337,6 +337,10 @@ assets, and shared libraries all live on ALFS.
 Key operations: read, write, mkdir, stat, readdir, remove, rename, copy,
 symlink, chmod, grant, revoke.
 
+In shell and documentation, wrap ALFS path arguments in single quotes (e.g.
+`'~/feeds/...'`, `'/alva/home/...'`) so they are not confused with paths on your
+local machine. See [Filesystem](references/api/filesystem.md).
+
 ### 2. JS Runtime
 
 Run JavaScript on Alva Cloud in a sandboxed V8 isolate. Code executed via
@@ -495,7 +499,7 @@ outputs read at runtime (no inline literals for data).
 
 #### Common steps (all users)
 
-1. **Write HTML to ALFS**: `alva fs write --path ~/playbooks/{name}/index.html --file ./index.html --mkdir-parents`
+1. **Write HTML to ALFS**: `alva fs write --path '~/playbooks/{name}/index.html' --file ./index.html --mkdir-parents`
 2. **Create playbook draft**: `alva release playbook-draft` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
    This request must include both the URL-safe `name` and the human-readable
@@ -682,7 +686,7 @@ variables, or shell. Host-agent permissions still apply. See
 
 | Module          | require()                    | Description                                                             |
 | --------------- | ---------------------------- | ----------------------------------------------------------------------- |
-| alfs            | `require("alfs")`            | Filesystem (uses absolute paths `/alva/home/<username>/...`)            |
+| alfs            | `require("alfs")`            | Filesystem (uses absolute paths `'/alva/home/<username>/...'`)            |
 | env             | `require("env")`             | `userId`, `username`, `args` from request                               |
 | secret-manager  | `require("secret-manager")`  | Read user-scoped third-party secrets stored in Alva Secret Manager      |
 | net/http        | `require("net/http")`        | `fetch(url, init)` for async HTTP requests                              |
@@ -760,7 +764,8 @@ feed.def("metrics", {
 })();
 ```
 
-Feed output is readable at: `~/feeds/btc-ema/v1/data/metrics/prices/@last/100`
+Feed output is readable at (ALFS — quote in CLI):
+`'~/feeds/btc-ema/v1/data/metrics/prices/@last/100'`
 
 ---
 
@@ -831,8 +836,8 @@ and deduplication behavior.
 Every feed follows a 6-step lifecycle including every newly created feed or re-created feed:
 
 1. **Write** -- define schema + incremental logic with `ctx.kv`
-2. **Upload** -- write script to `~/feeds/<name>/v1/src/index.js`
-3. **Test** -- `alva run --entry-path ~/feeds/<name>/v1/src/index.js` to verify output.
+2. **Upload** — write script to `'~/feeds/<name>/v1/src/index.js'`
+3. **Test** — `alva run --entry-path '~/feeds/<name>/v1/src/index.js'` to verify output.
    For SDK modules you haven't used before in this session, first run a
    shape-check snippet to verify response structure:
 
@@ -849,7 +854,7 @@ Every feed follows a 6-step lifecycle including every newly created feed or re-c
 4. **Grant** -- make feed data publicly readable:
 
    ```bash
-   alva fs grant --path ~/feeds/<name> --subject "special:user:*" --permission read
+   alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read
    ```
 
    Grant on the feed root path (not on `data/`). Subject format:
@@ -929,13 +934,13 @@ this in production.**
 
 ```bash
 # Clear a specific time series output
-alva fs remove --path ~/feeds/my-feed/v1/data/market/ohlcv --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market/ohlcv' --recursive
 
 # Clear an entire group (all outputs under "market")
-alva fs remove --path ~/feeds/my-feed/v1/data/market --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market' --recursive
 
 # Full reset: clear ALL data + KV state (removes the data mount, re-created on next run)
-alva fs remove --path ~/feeds/my-feed/v1/data --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data' --recursive
 ```
 
 ### Inline Debug Snippets
@@ -950,7 +955,7 @@ alva run --code 'const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0
 
 ## Memory
 
-You have a persistent, file-based memory system on ALFS at `~/memory/`. This
+You have a persistent, file-based memory system on ALFS at `'~/memory/'`. This
 directory is created automatically when the user's account is provisioned. Use
 it to accumulate knowledge about the user across conversations — their identity,
 preferences, investment style, and any context that would be useful in future
@@ -961,6 +966,8 @@ delete any memory file through the Alva dashboard or ALFS API. Write memories
 as if the user will read them.
 
 ### Storage layout
+
+**ALFS paths** — use single quotes in the shell (example: `'~/memory/MEMORY.md'`).
 
 ```
 ~/memory/
@@ -1023,7 +1030,7 @@ changes how you should work with them.
 
 ### Additional topic files
 
-Create new files in `~/memory/` for knowledge that doesn't fit in `user.md` —
+Create new files in `'~/memory/'` for knowledge that doesn't fit in `user.md` —
 market convictions, strategy assumptions, portfolio rules. Add a pointer to
 `MEMORY.md` for each new file.
 
@@ -1038,7 +1045,7 @@ market convictions, strategy assumptions, portfolio rules. Add a pointer to
 
 ### Writing rules
 
-1. **Read `~/memory/MEMORY.md` first** — check if a relevant file already exists
+1. **Read `'~/memory/MEMORY.md'` first** — check if a relevant file already exists
 2. **Update existing file** if the topic matches. Don't create duplicates
 3. **Create new file** only if no existing file covers the topic
 4. **Update `MEMORY.md`** — add a one-line entry for each new file
@@ -1047,13 +1054,13 @@ market convictions, strategy assumptions, portfolio rules. Add a pointer to
 
 ### Reading rules
 
-- **Every conversation start**: Read `~/memory/MEMORY.md` via ALFS. Then read
+- **Every conversation start**: Read `'~/memory/MEMORY.md'` via ALFS. Then read
   `user.md` and any topic files relevant to the user's request.
 - **User references prior work**: "that strategy from last time" / "the rules
   we discussed" → read the relevant memory file.
 - **User explicitly asks**: "do you remember" / "check my profile" → you
   **must** read.
-- **User says to ignore memory**: Proceed as if `~/memory/` is empty.
+- **User says to ignore memory**: Proceed as if `'~/memory/'` is empty.
 
 ### Memory is a claim, not truth
 
@@ -1200,7 +1207,7 @@ See [deployment.md](references/deployment.md) for full details.
 Deploy feed scripts or tasks as cronjobs for scheduled execution:
 
 ```bash
-alva deploy create --name btc-ema-update --path ~/feeds/btc-ema/v1/src/index.js --cron "0 */4 * * *"
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
 Cronjobs execute the script via the same jagent runtime as `alva run`. Max 20
@@ -1212,13 +1219,13 @@ hyphen (DNS label format). Example: `btc-ema-update`, not `BTC EMA Update`.
 
 After deploying a cronjob, register the feed, create a playbook draft, then
 release the playbook for public hosting. The playbook HTML must already be
-written to ALFS at `~/playbooks/{name}/index.html` via `fs/write` before
+written to ALFS at `'~/playbooks/{name}/index.html'` via `fs/write` before
 releasing.
 
 **Important**: Feed names and playbook names must be unique within your user
 space. Before creating a new feed or playbook, use
-`alva fs readdir --path ~/feeds` or
-`alva fs readdir --path ~/playbooks` to check for existing names and avoid
+`alva fs readdir --path '~/feeds'` or
+`alva fs readdir --path '~/playbooks'` to check for existing names and avoid
 conflicts.
 
 ```bash
@@ -1259,14 +1266,14 @@ typography, theme, and page-level layout. Then read only the spec you need:
 
 ## Filesystem Layout Convention
 
-| Path                      | Purpose                                     |
-| ------------------------- | ------------------------------------------- |
-| `~/tasks/<name>/src/`     | Task source code                            |
-| `~/feeds/<name>/v1/src/`  | Feed script source code                     |
-| `~/feeds/<name>/v1/data/` | Feed synth mount (auto-created by Feed SDK) |
-| `~/playbooks/<name>/`     | Playbook web app assets                     |
-| `~/data/`                 | General data storage                        |
-| `~/library/`              | Shared code modules                         |
+| Path (ALFS — quote in CLI)              | Purpose                                     |
+| --------------------------------------- | ------------------------------------------- |
+| `'~/tasks/<name>/src/'`                 | Task source code                            |
+| `'~/feeds/<name>/v1/src/'`              | Feed script source code                     |
+| `'~/feeds/<name>/v1/data/'`             | Feed synth mount (auto-created by Feed SDK) |
+| `'~/playbooks/<name>/'`                 | Playbook web app assets                     |
+| `'~/data/'`                             | General data storage                        |
+| `'~/library/'`                          | Shared code modules                         |
 
 **Prefer using the Feed SDK for all data organization**, including point-in-time
 snapshots. Store snapshots as single-record time series rather than raw JSON
@@ -1287,15 +1294,15 @@ consistent read pattern (`@last`, `@range`, etc.).
   share a timestamp (grouped via `append()`), auto-flatten may return more than
   N individual records.
 - **The `data/` in feed paths is the synth mount.** `feedPath("my-feed")` gives
-  `~/feeds/my-feed/v1`, and the Feed SDK mounts storage at `<feedPath>/data/`.
+  `'~/feeds/my-feed/v1'`, and the Feed SDK mounts storage at `<feedPath>/data/`.
   Don't name your group `"data"` or you'll get `data/data/...`.
 - **Public reads require absolute paths.** Unauthenticated reads must use
-  `/alva/home/<username>/...` (not `~/...`). Discover your username via
+  `'/alva/home/<username>/...'` (not `'~/...'`). Discover your username via
   `alva whoami`.
 - **Top-level `await` is not supported.** Wrap async code in
   `(async () => { ... })();`.
 - **`require("alfs")` uses absolute paths.** Inside the V8 runtime,
-  `alfs.readFile()` needs full paths like `/alva/home/alice/...`. Get your
+  `alfs.readFile()` needs full paths like `'/alva/home/alice/...'`. Get your
   username from `require("env").username`.
 - **No Node.js builtins.** `require("fs")`, `require("path")`, `require("http")`
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
@@ -1306,10 +1313,10 @@ consistent read pattern (`@last`, `@range`, etc.).
   outputs the strategy function sees. They are independent.
 - **Quote `~` paths to prevent shell expansion.** The shell expands bare `~` to
   your local home (e.g. `/Users/alice/`), not the ALFS home
-  (`/alva/home/alice/`). Always quote paths: `--path '~/feeds/...'`.
+  (`'/alva/home/alice/'`). Always quote paths: `--path '~/feeds/...'`.
 - **Home directory not provisioned?** If you get `PERMISSION_DENIED` on all
-  ALFS operations (including `~/`), your home directory was not created during
-  sign-up. Call `alva fs mkdir --path ~/` to provision it. This is idempotent
+  ALFS operations (including `'~/'`), your home directory was not created during
+  sign-up. Call `alva fs mkdir --path '~/'` to provision it. This is idempotent
   and safe to call anytime.
 - **Cronjob path must point to an existing script.** The deploy API validates
   the entry_path exists via filesystem stat before creating the cronjob.

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -299,7 +299,7 @@ const altra = new FeedAltra(
 
 | Field                          | Description                                                                     |
 | ------------------------------ | ------------------------------------------------------------------------------- |
-| `path`                         | ALFS feed path (e.g. `~/feeds/my-strategy/v1`). All output data stored here.   |
+| `path`                         | ALFS feed path (e.g. `'~/feeds/my-strategy/v1'`). All output data stored here.   |
 | `startDate`                    | Backtest start timestamp (ms UTC). Use the exact date, never adjust for warmup. |
 | `portfolioOptions.initialCash` | Starting cash (default: 1,000,000)                                              |
 | `portfolioOptions.currency`    | Quote currency (default: "USDT")                                                |
@@ -717,7 +717,7 @@ The `RunResult` contains:
 - `orders` -- All executed orders with fill details
 - `perf` -- Performance metrics (total return, Sharpe ratio, max drawdown, etc.)
 
-All output data is also persisted under the feed's ALFS path:
+All output data is also persisted under the feed's ALFS path (quote in CLI, e.g. `'~/feeds/my-strategy/v1/data/'`):
 
 ```
 ~/feeds/my-strategy/v1/data/

--- a/skills/alva/references/api/deploy-cronjob.md
+++ b/skills/alva/references/api/deploy-cronjob.md
@@ -14,7 +14,7 @@ alva deploy create --name NAME --path PATH --cron "EXPR" [--args 'JSON'] [--push
 ```bash
 alva deploy create \
   --name btc-ema-update \
-  --path ~/feeds/btc-ema/v1/src/index.js \
+  --path '~/feeds/btc-ema/v1/src/index.js' \
   --cron "0 */4 * * *" \
   --args '{"symbol": "BTC"}' \
   --push-notify

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -1,19 +1,22 @@
 # Filesystem
 
-All filesystem operations use the `alva fs` CLI.
+ALFS is a virual filesystem for Alva. All filesystem operations use the `alva fs` CLI. Always quote **ALFS** paths in the shell (e.g. `--path '~/feeds/...'`).
 
 **Path conventions**:
 
-- `~/data/file.json` -- home-relative, expands to
-  `/alva/home/<username>/data/file.json`
-- `/alva/home/<username>/data/file.json` -- absolute path (required for public
+- `'~/data/file.json'` — home-relative **ALFS** path; expands to
+  `'/alva/home/<username>/data/file.json'`
+- `'/alva/home/<username>/data/file.json'` — absolute **ALFS** path (required for public
   reads)
-- `~` -- your home directory
+- `'~'` — your **ALFS** home directory
+
+In documentation and shell examples, wrap **ALFS** path literals in single quotes so
+they are not mistaken for paths on your **local** machine (e.g. `/Users/...`).
 
 > **Important**: Always quote `~` paths (e.g. `--path '~/feeds/...'`) to
 > prevent shell expansion. An unquoted `~` expands to your local home directory
-> (e.g. `/Users/alice/`), not the ALFS home (`/alva/home/alice/`), causing
-> `PERMISSION_DENIED`. Alternatively, use absolute ALFS paths.
+> (e.g. `/Users/alice/`), not the ALFS home (`'/alva/home/alice/'`), causing
+> `PERMISSION_DENIED`. Alternatively, use absolute ALFS paths (`'...'`).
 
 ## Read File
 
@@ -31,9 +34,9 @@ Response: raw bytes. For time series paths (containing `@last`, `@range`, etc.),
 response is JSON.
 
 ```
-alva fs read --path ~/data/config.json
+alva fs read --path '~/data/config.json'
 
-alva fs read --path /alva/home/alice/feeds/btc-ema/v1/data/prices/@last/10  # public, no auth
+alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/prices/@last/10'  # public, no auth
 ```
 
 ## Write File
@@ -51,10 +54,10 @@ Two modes:
 
 ```
 # Mode 1: Inline data
-alva fs write --path ~/data/config.json --data '{"key":"value"}' --mkdir-parents
+alva fs write --path '~/data/config.json' --data '{"key":"value"}' --mkdir-parents
 
 # Mode 2: File upload
-alva fs write --path ~/data/config.json --file ./config.json --mkdir-parents
+alva fs write --path '~/data/config.json' --file ./config.json --mkdir-parents
 ```
 
 ## Stat
@@ -64,7 +67,7 @@ alva fs stat --path PATH
 ```
 
 ```
-alva fs stat --path ~/data/config.json
+alva fs stat --path '~/data/config.json'
 → {"name":"config.json","size":15,"mode":420,"mod_time":...,"is_dir":false}
 ```
 
@@ -80,7 +83,7 @@ alva fs readdir --path PATH [--recursive]
 | recursive | bool   | no       | If true, list recursively (default: false) |
 
 ```
-alva fs readdir --path ~/data
+alva fs readdir --path '~/data'
 → {"entries":[{"name":"config.json","size":15,"is_dir":false,...},...]}
 ```
 
@@ -93,7 +96,7 @@ alva fs mkdir --path PATH
 Recursive by default (like `mkdir -p`).
 
 ```
-alva fs mkdir --path ~/feeds/my-feed/v1/src
+alva fs mkdir --path '~/feeds/my-feed/v1/src'
 ```
 
 ## Remove
@@ -103,8 +106,8 @@ alva fs remove --path PATH [--recursive]
 ```
 
 ```
-alva fs remove --path ~/data/old.json
-alva fs remove --path ~/data/output --recursive
+alva fs remove --path '~/data/old.json'
+alva fs remove --path '~/data/output' --recursive
 ```
 
 **Clearing feed data (synth mounts):** The remove command also works on synth
@@ -113,13 +116,13 @@ data. **For development use only.**
 
 ```
 # Clear a specific time series output
-alva fs remove --path ~/feeds/my-feed/v1/data/market/ohlcv --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market/ohlcv' --recursive
 
 # Clear all outputs in a group
-alva fs remove --path ~/feeds/my-feed/v1/data/market --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market' --recursive
 
 # Full feed reset: clear ALL data + KV state (removes the data mount, re-created on next run)
-alva fs remove --path ~/feeds/my-feed/v1/data --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data' --recursive
 ```
 
 Clearing time series also removes the associated typedoc (schema metadata).
@@ -131,7 +134,7 @@ alva fs rename --old-path OLD --new-path NEW
 ```
 
 ```
-alva fs rename --old-path ~/data/old.json --new-path ~/data/new.json
+alva fs rename --old-path '~/data/old.json' --new-path '~/data/new.json'
 ```
 
 ## Copy
@@ -141,17 +144,17 @@ alva fs copy --src-path SRC --dst-path DST
 ```
 
 ```
-alva fs copy --src-path ~/data/source.json --dst-path ~/data/dest.json
+alva fs copy --src-path '~/data/source.json' --dst-path '~/data/dest.json'
 ```
 
 ## Symlink / Readlink
 
 ```
 # Create symlink
-alva fs symlink --target-path ~/feeds/my-feed/v1/output --link-path ~/data/latest
+alva fs symlink --target-path '~/feeds/my-feed/v1/output' --link-path '~/data/latest'
 
 # Read symlink target
-alva fs readlink --path ~/data/latest
+alva fs readlink --path '~/data/latest'
 ```
 
 ## Chmod
@@ -161,38 +164,38 @@ alva fs chmod --path PATH --mode MODE
 ```
 
 ```
-alva fs chmod --path ~/data/config.json --mode 644
+alva fs chmod --path '~/data/config.json' --mode 644
 ```
 
 ## Permissions (Grant / Revoke)
 
 ```
 # Make a path publicly readable (no auth needed for subsequent reads)
-alva fs grant --path ~/feeds/btc-ema/v1 --subject "special:user:*" --permission read
+alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
 
 # Grant read access to a specific user
-alva fs grant --path ~/feeds/btc-ema/v1 --subject "user:2" --permission read
+alva fs grant --path '~/feeds/btc-ema/v1' --subject "user:2" --permission read
 
 # Revoke a permission
-alva fs revoke --path ~/feeds/btc-ema/v1 --subject "special:user:*" --permission read
+alva fs revoke --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
 ```
 
 Subject values: `special:user:*` (public/anyone), `special:user:+` (any
 authenticated user), `user:<id>` (specific user).
 
 > **Note**: You cannot grant permissions directly on a Feed synth `data/` path
-> (e.g. `~/feeds/my-feed/v1/data`). This returns PERMISSION_DENIED. Grant on the
+> (e.g. `'~/feeds/my-feed/v1/data'`). This returns PERMISSION_DENIED. Grant on the
 > parent feed directory instead — the permission is inherited by all child paths
 > including the synth data mount:
 >
 > ```
-> alva fs grant --path ~/feeds/my-feed --subject "special:user:*" --permission read
+> alva fs grant --path '~/feeds/my-feed' --subject "special:user:*" --permission read
 > ```
 
 ## Time Series via Filesystem Paths
 
 When a read path crosses a synth mount boundary (e.g.
-`~/feeds/my-feed/v1/data/`), the filesystem returns structured JSON instead of
+`'~/feeds/my-feed/v1/data/'`), the filesystem returns structured JSON instead of
 raw bytes. Virtual path suffixes:
 
 | Suffix                  | Description                    | Example                                                        |
@@ -230,6 +233,6 @@ consumers handle them directly.
 ```
 
 ```
-alva fs read --path ~/feeds/my-feed/v1/data/prices/btc/@last/100
+alva fs read --path '~/feeds/my-feed/v1/data/prices/btc/@last/100'
 → [{"date":1772658000000,"close":73309.72,"ema10":72447.65}, ...]
 ```

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -14,7 +14,7 @@ after** `alva deploy create` -- the `cronjob-id` comes from the
 cronjob response.
 
 **Name uniqueness**: The `name` must be unique within your user space. Use
-`alva fs readdir --path ~/feeds` to check existing feed names before
+`alva fs readdir --path '~/feeds'` to check existing feed names before
 releasing.
 
 | Flag          | Type   | Required | Description                                                  |
@@ -70,7 +70,7 @@ alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' 
 ```
 
 Release an existing playbook for public hosting. Reads the playbook HTML from
-`~/playbooks/{name}/index.html` and uploads it to CDN.
+`'~/playbooks/{name}/index.html'` (ALFS — quote in CLI) and uploads it to CDN.
 
 | Flag        | Type   | Required | Description                                 |
 | ----------- | ------ | -------- | ------------------------------------------- |

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -29,7 +29,7 @@ All cronjob operations use `alva deploy <subcommand>`.
 ### Create Cronjob
 
 ```bash
-alva deploy create --name btc-ema-update --path ~/feeds/btc-ema/v1/src/index.js --cron "0 */4 * * *" --args '{"symbol": "BTC"}' --push-notify
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *" --args '{"symbol": "BTC"}' --push-notify
 ```
 
 | Flag            | Type   | Required | Description                                            |
@@ -183,13 +183,13 @@ This example creates a BTC price feed that runs every 4 hours.
 ### 1. Write the feed script
 
 ```bash
-alva fs mkdir --path ~/feeds/btc-hourly/v1/src
+alva fs mkdir --path '~/feeds/btc-hourly/v1/src'
 ```
 
 Write the script (upload from local file):
 
 ```bash
-alva fs write --path ~/feeds/btc-hourly/v1/src/index.js --file ./index.js --mkdir-parents
+alva fs write --path '~/feeds/btc-hourly/v1/src/index.js' --file ./index.js --mkdir-parents
 ```
 
 Where `index.js` contains:
@@ -239,19 +239,19 @@ feed.def("market", {
 ### 2. Test the script manually
 
 ```bash
-alva run --entry-path ~/feeds/btc-hourly/v1/src/index.js
+alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 ```
 
 ### 3. Make the output public
 
 ```bash
-alva fs grant --path ~/feeds/btc-hourly/v1 --subject "special:user:*" --permission read
+alva fs grant --path '~/feeds/btc-hourly/v1' --subject "special:user:*" --permission read
 ```
 
 ### 4. Deploy as a cronjob
 
 ```bash
-alva deploy create --name btc-hourly-price-feed --path ~/feeds/btc-hourly/v1/src/index.js --cron "0 */4 * * *"
+alva deploy create --name btc-hourly-price-feed --path '~/feeds/btc-hourly/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
 ### 5. Verify the cronjob
@@ -263,7 +263,7 @@ alva deploy list
 ### 6. Read the data (from anywhere)
 
 ```bash
-alva fs read --path /alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@last/24
+alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@last/24'
 ```
 
 ---

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -271,7 +271,7 @@ Deploy as a scheduled cronjob with `push_notify: true`:
 
 ```bash
 alva deploy create --name daily-briefing \
-  --path ~/feeds/daily-briefing/v1/scripts/main.js \
+  --path '~/feeds/daily-briefing/v1/scripts/main.js' \
   --cron "0 8 * * *" --push-notify
 ```
 
@@ -557,9 +557,9 @@ Feed outputs are accessible via the filesystem after the feed runs.
 ### From the CLI
 
 ```bash
-alva fs read --path ~/feeds/btc-ema/v1/data/metrics/prices/@last/100
+alva fs read --path '~/feeds/btc-ema/v1/data/metrics/prices/@last/100'
 
-alva fs read --path /alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100
+alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100'
 ```
 
 ### From JavaScript (inside jagent)
@@ -651,7 +651,7 @@ records if some timestamps have multiple items.
 Grant public read access so anyone can read the data:
 
 ```bash
-alva fs grant --path ~/feeds/btc-ema/v1 --subject "special:user:*" --permission read
+alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
 ```
 
 Public reads must use absolute paths:
@@ -664,7 +664,7 @@ Public reads must use absolute paths:
 ### Step 1: Create the directory and write the script
 
 ```bash
-alva fs write --path ~/feeds/btc-ema/v1/src/index.js --file ./index.js --mkdir-parents
+alva fs write --path '~/feeds/btc-ema/v1/src/index.js' --file ./index.js --mkdir-parents
 ```
 
 Where `index.js` contains:
@@ -706,25 +706,25 @@ feed.def("metrics", {
 ### Step 2: Run the feed
 
 ```bash
-alva run --entry-path ~/feeds/btc-ema/v1/src/index.js
+alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
 ```
 
 ### Step 3: Make it public
 
 ```bash
-alva fs grant --path ~/feeds/btc-ema/v1 --subject "special:user:*" --permission read
+alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
 ```
 
 ### Step 4: Read from any client
 
 ```bash
-alva fs read --path /alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100
+alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100'
 ```
 
 ### Step 5: Deploy as a cronjob (required for live playbooks)
 
 ```bash
-alva deploy create --name btc-ema-update --path ~/feeds/btc-ema/v1/src/index.js --cron "0 */4 * * *"
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
 ---
@@ -761,13 +761,13 @@ only -- do not use in production.**
 
 ```bash
 # Clear a specific time series output (e.g. market/ohlcv)
-alva fs remove --path ~/feeds/my-feed/v1/data/market/ohlcv --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market/ohlcv' --recursive
 
 # Clear an entire group (all outputs under "market")
-alva fs remove --path ~/feeds/my-feed/v1/data/market --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data/market' --recursive
 
 # Full reset: clear ALL data + KV state (removes the data mount, re-created on next run)
-alva fs remove --path ~/feeds/my-feed/v1/data --recursive
+alva fs remove --path '~/feeds/my-feed/v1/data' --recursive
 ```
 
 Clearing time series also removes the associated typedoc (schema metadata). KV

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -42,9 +42,9 @@ When using `entry_path`, relative imports resolve from the entry script's
 directory:
 
 ```javascript
-// ~/tasks/my-task/src/index.js
-const helper = require("./helper.js"); // loads ~/tasks/my-task/src/helper.js
-const utils = require("./lib/utils.js"); // loads ~/tasks/my-task/src/lib/utils.js
+// Entry on ALFS: '~/tasks/my-task/src/index.js'
+const helper = require("./helper.js"); // resolves './helper.js' on ALFS under that directory
+const utils = require("./lib/utils.js"); // resolves './lib/utils.js' on ALFS under that directory
 ```
 
 ---
@@ -59,7 +59,7 @@ like the REST API).
 ```javascript
 const alfs = require("alfs");
 const env = require("env");
-const home = "/alva/home/" + env.username;
+const home = "/alva/home/" + env.username; // absolute ALFS prefix (e.g. '/alva/home/alice')
 ```
 
 | Method           | Signature                                     | Description                                             |

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -29,10 +29,10 @@ The `@{owner}/{name}` token after "Playbook(" contains the two key fields:
 
 For the example above: owner = `alice`, name = `btc-momentum`.
 
-Together they resolve to the ALFS base path:
+Together they resolve to the ALFS base path (quote in CLI):
 
 ```
-/alva/home/{owner}/playbooks/{name}/
+'/alva/home/{owner}/playbooks/{name}/'
 ```
 
 **Behavior note**: If the user's prompt does not specify what to change (only
@@ -44,7 +44,7 @@ user what they'd like to customize** before proceeding.
 ## Step 1 — Read Playbook Metadata
 
 ```bash
-alva fs read --path /alva/home/{owner}/playbooks/{name}/playbook.json
+alva fs read --path '/alva/home/{owner}/playbooks/{name}/playbook.json'
 ```
 
 Returns JSON with structure:
@@ -69,7 +69,7 @@ From `latest_release.feeds`, collect the feed IDs you need to inspect.
 ## Step 2 — Read UI Layer (HTML Source)
 
 ```bash
-alva fs read --path /alva/home/{owner}/playbooks/{name}/index.html
+alva fs read --path '/alva/home/{owner}/playbooks/{name}/index.html'
 ```
 
 This returns the full HTML source of the playbook dashboard — the ECharts
@@ -84,14 +84,14 @@ Each feed referenced in `playbook.json` has a symlink under the release's
 `feeds/` directory pointing to the feed's ALFS path.
 
 ```bash
-alva fs readlink --path /alva/home/{owner}/playbooks/{name}/releases/{version}/feeds/{feed_id}
+alva fs readlink --path '/alva/home/{owner}/playbooks/{name}/releases/{version}/feeds/{feed_id}'
 # → {"target_path": "/alva/home/{owner}/feeds/{feed_name}"}
 ```
 
 Then read the feed script source:
 
 ```bash
-alva fs read --path /alva/home/{owner}/feeds/{feed_name}/v1/src/index.js
+alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js'
 ```
 
 This contains the strategy logic, data fetching, and indicator computations.
@@ -99,7 +99,7 @@ This contains the strategy logic, data fetching, and indicator computations.
 Optionally, read sample feed output to understand the data schema:
 
 ```bash
-alva fs read --path /alva/home/{owner}/feeds/{feed_name}/v1/data/{group}/{output}/@last/5
+alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/data/{group}/{output}/@last/5'
 ```
 
 ---
@@ -121,12 +121,12 @@ re-release a source whose data layer was never legitimate.
 
 Follow the standard playbook creation flow (see SKILL.md):
 
-1. **Write feed script** to `~/feeds/{new-name}/v1/src/index.js`
-2. **Test** via `alva run --entry-path ~/feeds/{new-name}/v1/src/index.js`
-3. **Grant** public read: `alva fs grant --path ~/feeds/{new-name} --subject "special:user:*" --permission read`
-4. **Deploy cronjob**: `alva deploy create --name {new-name} --path ~/feeds/{new-name}/v1/src/index.js --cron "..."`
+1. **Write feed script** to `'~/feeds/{new-name}/v1/src/index.js'`
+2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
+3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
+4. **Deploy cronjob**: `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
 5. **Release feed**: `alva release feed --name {new-name} --version 1.0.0 --cronjob-id ID`
-6. **Write HTML** to `~/playbooks/{new-name}/index.html` (update data paths to
+6. **Write HTML** to `'~/playbooks/{new-name}/index.html'` (update data paths to
    point to your own feed)
 7. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
 8. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..."`
@@ -166,20 +166,20 @@ Agent reads:
 
 ```bash
 # 1. Metadata
-alva fs read --path /alva/home/alice/playbooks/btc-momentum/playbook.json
+alva fs read --path '/alva/home/alice/playbooks/btc-momentum/playbook.json'
 
 # 2. HTML source
-alva fs read --path /alva/home/alice/playbooks/btc-momentum/index.html
+alva fs read --path '/alva/home/alice/playbooks/btc-momentum/index.html'
 
 # 3. Feed symlink → feed path
-alva fs readlink --path /alva/home/alice/playbooks/btc-momentum/releases/v1.0.0/feeds/100
+alva fs readlink --path '/alva/home/alice/playbooks/btc-momentum/releases/v1.0.0/feeds/100'
 # → /alva/home/alice/feeds/btc-momentum
 
 # 4. Feed source code
-alva fs read --path /alva/home/alice/feeds/btc-momentum/v1/src/index.js
+alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/src/index.js'
 
 # 5. (Optional) Sample data for schema understanding
-alva fs read --path /alva/home/alice/feeds/btc-momentum/v1/data/market/ohlcv/@last/3
+alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/data/market/ohlcv/@last/3'
 ```
 
 Agent then runs the content-legitimacy audit on the source HTML and feed

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -7,14 +7,15 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 
 | SDK | Module | Best for |
 | --- | ------ | -------- |
-| `searchGrokX` | `@arrays/data/widget-scrap/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
-| `searchSerper` | `@arrays/data/widget-scrap/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
-| `searchBrave` | `@arrays/data/widget-scrap/search-brave:v1.0.0` | Independent index, good Reddit coverage |
-| `scrapeUrl` | `@arrays/data/widget-scrap/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
+| `searchGrokX` | `@arrays/data/search/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
+| `searchSerper` | `@arrays/data/search/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
+| `searchBrave` | `@arrays/data/search/search-brave:v1.0.0` | Independent index, good Reddit coverage |
+| `scrapeUrl` | `@arrays/data/search/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
 
 ## Sources
 
 ### Twitter/X
+
 - **Search**: `searchGrokX` with `from_date`/`to_date` (YYYY-MM-DD format)
 - **Enrich**: Not needed — GrokX returns engagement natively
 - **Signals**: `like_count`, `retweet_count`, `reply_count`, `quote_count`
@@ -23,6 +24,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Gotcha**: A single broad query returns mostly 0-engagement noise. Fix: (1) run 3-5 queries with different topical angles (e.g. "NVDA earnings", "NVDA AI chips", "NVDA stock price") plus entity aliases (`$NVDA`, `NVIDIA`); (2) filter results — tweets with `like_count == 0` AND `retweet_count == 0` are almost always noise; (3) `author_followers_count` and `author_verified` are strong quality signals for sorting survivors.
 
 ### News
+
 - **Search**: `searchSerper` with `type:"news"` + `searchBrave` with `freshness` filter
 - **Enrich**: Optional — `scrapeUrl` for full article text
 - **Signals**: Freshness (time-based), source authority (domain)
@@ -31,6 +33,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Fields (Brave)**: `title`, `url`, `description`, `age` (string), `date` (ms, index time)
 
 ### Reddit
+
 - **Search**: `searchSerper` or `searchBrave` with `site:reddit.com`
 - **Enrich**: Append `.json` to post URL → `scrapeUrl` → regex extract `score`, `num_comments`, `created_utc`
 - **Signals**: `score`, `num_comments`, `created_utc` (real publish time, seconds → ×1000 for ms)
@@ -38,6 +41,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Gotcha**: `searchBrave` with `result_filter:"discussions"` returns 0 results — do not use. Cross-posts produce duplicate titles — dedup by Jaccard similarity on title if needed.
 
 ### YouTube
+
 - **Search**: `searchSerper` or `searchBrave` with `site:youtube.com`
 - **Enrich**: `scrapeUrl` the watch page → regex extract views/likes. Thumbnails: `https://img.youtube.com/vi/{VIDEO_ID}/mqdefault.jpg`
 - **Signals**: `views`, `likes`
@@ -45,6 +49,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Video ID extraction**: `url.match(/(?:v=|shorts\/)([\w-]{11})/)`
 
 ### Podcasts
+
 - **Search**: Apple Podcasts Search API (free, no auth):
   `https://itunes.apple.com/search?term={query}&media=podcast&entity=podcastEpisode&limit=20`
 - **Enrich**: Not needed — API returns full metadata
@@ -53,6 +58,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Note**: Limited source — best as supplementary, not primary. No engagement metrics.
 
 ### General Web
+
 - **Search**: `searchSerper` or `searchBrave` (no site filter)
 - **Enrich**: `scrapeUrl` for content extraction
 - **Signals**: Search rank position, freshness


### PR DESCRIPTION
## Summary

- **ALFS paths**: Wrap home-relative and absolute ALFS paths in single quotes across the Alva skill and API reference docs (`alva fs`, `alva run --entry-path`, `alva deploy --path`, tables, and memory/playbook examples) so they are clearly distinct from the host filesystem (e.g. `/Users/...`).
- **filesystem.md**: Strengthen path conventions and fix any unquoted CLI examples.
- **search.md**: Point content-search modules at `@arrays/data/search/*` (replacing `widget-scrap` paths).

## Testing

Documentation-only; no runtime tests.

Made with [Cursor](https://cursor.com)