### PR TITLE
feat: replace SDKHub with Data Skills in SKILL.md (rebased from #67)

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -121,7 +121,14 @@ Session variables:
 - **`telegram_username`** — if set, recommend push-enabled feeds; if null,
   guide user to connect Telegram first.
 
-### 4. Load Memory
+### 4. Arrays JWT Check
+
+Data skills require `ARRAYS_JWT`. The `_meta.arrays_jwt` field in the
+`alva whoami` output above shows its status — if it needs attention (missing,
+`renewal_needed: true`, or absent), use `alva arrays token` to manage it
+(`status` to inspect, `ensure` to provision or refresh).
+
+### 5. Load Memory
 
 If you have **not** read the user's memory in this conversation, read it now.
 
@@ -378,21 +385,20 @@ the Feed SDK.
 
 Financial data APIs across 16+ domains, served by the Arrays backend
 (`$ARRAYS_ENDPOINT`, defaults to `https://data-tools.prd.space.id`). To find
-the right API for a task:
+the right API for a task, use the `alva skills` CLI (public, no auth):
 
-1. **Discover available data skills**: `GET $ARRAYS_ENDPOINT/api/v1/skills`
-   (public, no auth) — returns all data skills with their names and
-   descriptions. Use this to find the skill that matches your data need.
-2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
-   (public, no auth) — returns the endpoints table for that domain.
-3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
+1. **Discover available data skills**: `alva skills list` — returns all data
+   skills with their names and descriptions. Use this to find the skill that
+   matches your data need.
+2. **Fetch the skill summary**: `alva skills summary --name <skill>` — returns
+   the endpoints table for that domain.
+3. **Fetch endpoint detail**: `alva skills endpoint --name <skill> --path <path>`
    — use the Path value from the summary endpoints table (e.g. `company/list`,
    `market-news`) to get full parameters, response fields, and examples.
 4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
    In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
-   If the token is missing, call `POST $ALVA_ENDPOINT/api/v1/arrays-jwt/ensure`
-   first (idempotent — safe to call every session; renews only when missing or
-   near expiry).
+   The token is verified during preflight (see [Arrays JWT Check](#4-arrays-jwt-check));
+   if a call returns 401, re-run `alva arrays token ensure`.
 
 **Data skill doc lookup is mandatory.** Always fetch the endpoint detail before
 writing code that calls it. Do not guess paths, parameter names, or response
@@ -400,9 +406,9 @@ shapes from memory. The doc lookup ensures you use the correct endpoint and
 handle the actual response format.
 
 **Enforcement**: Before any Arrays data HTTP call or `alva run` that hits one,
-you MUST have completed `GET /api/v1/skills/:name?endpoint=<path>` for that
-endpoint in this session. If the call fails with an unexpected shape, re-fetch
-the endpoint detail rather than guessing.
+you MUST have completed `alva skills endpoint --name <skill> --path <path>` for
+that endpoint in this session. If the call fails with an unexpected shape,
+re-fetch the endpoint detail rather than guessing.
 
 #### Runtime Libraries
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -416,11 +416,12 @@ Built-in modules that run inside the jagent V8 runtime via `require()`. These
 are **not** data APIs — they are pure computation and utility libraries
 available in every script execution.
 
-| Module group                              | Description                                                        |
-| ----------------------------------------- | ------------------------------------------------------------------ |
-| `crypto_fundamentals`                     | Crypto supply, market cap, dominance (internal data source)        |
+| Module group                              | Description                                                               |
+| ----------------------------------------- | ------------------------------------------------------------------------- |
+| `crypto_fundamentals`                     | Crypto supply, market cap, dominance (internal data source)               |
 | `feed_widgets`                            | Per-handle/channel rolling subscriptions — news, Twitter/X, YouTube, Reddit, podcasts (e.g. `getTwitterFeed`). Twitter also has historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)          |
+| `unified_search`                          | Web search and URL scraping tools (X/Grok, Google, Brave, serper, decodo) |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)                 |
 
 To discover available modules and their documentation:
 
@@ -446,8 +447,11 @@ discovery ("trending crypto discussions this week"), including social
 discussions, market narratives, news coverage, sentiment, analyst commentary,
 and community reactions.
 
-Content search modules are called directly in code (not via the partition
-API). See [search.md](references/search.md) for per-source SDK usage,
+Content search modules live in the `unified_search` runtime-library
+partition. Discover them via the same partition API as the other runtime
+libraries (`GET /api/v1/sdk/partitions/unified_search/summary` → module
+listing; `GET /api/v1/sdk/doc?name=...` → full per-module documentation).
+See [search.md](references/search.md) for per-source SDK usage,
 enrichment patterns, and gotchas.
 
 ### 4. Altra (Alva Trading Engine)
@@ -734,7 +738,7 @@ variables, or shell. Host-agent permissions still apply. See
 (e.g. `@alva/technical-indicators/rsi:v1.0.0`). Version suffix is optional
 (defaults to `v1.0.0`). To discover function signatures, use
 `alva sdk doc --name "..."`. Module groups: `crypto_fundamentals`,
-`feed_widgets`, `technical_indicator_calculation_helpers`.
+`feed_widgets`, `technical_indicator_calculation_helpers`, `unified_search`.
 
 **Data APIs**: Financial data (crypto, stock, macro, ETF) is fetched via HTTP
 from the Arrays backend — see the [Data Skills](#3-data-skills) section. Load

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.4.0
+  version: v1.5.0
 ---
 
 # Alva

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -371,55 +371,59 @@ local machine. See [Filesystem](references/api/filesystem.md).
 Run JavaScript on Alva Cloud in a sandboxed V8 isolate. Code executed via
 `alva run` runs entirely on Alva's servers -- it cannot access
 the host machine's filesystem, environment variables, or processes. The runtime
-has access to ALFS, all 250+ SDKs, HTTP networking, LLM access, and the Feed
-SDK.
+has access to ALFS, data skills via HTTP, runtime libraries, LLM access, and
+the Feed SDK.
 
-### 3. SDKHub
+### 3. Data Skills
 
-250+ built-in financial data SDKs. To find the right SDK for a task, use the
-two-step retrieval flow:
+Financial data APIs across 16+ domains, served by the Arrays backend
+(`$ARRAYS_ENDPOINT`, defaults to `https://data-tools.prd.space.id`). To find
+the right API for a task:
 
-1. **Pick a partition** from the index below.
-2. **Call `alva sdk partition-summary --partition <name>`** to see module
-   summaries, then load the full doc for the chosen module.
+1. **Discover available data skills**: `GET $ARRAYS_ENDPOINT/api/v1/skills`
+   (public, no auth) — returns all data skills with their names and
+   descriptions. Use this to find the skill that matches your data need.
+2. **Fetch the skill summary**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name`
+   (public, no auth) — returns the endpoints table for that domain.
+3. **Fetch endpoint detail**: `GET $ARRAYS_ENDPOINT/api/v1/skills/:name?endpoint=<path>`
+   — use the Path value from the summary endpoints table (e.g. `company/list`,
+   `market-news`) to get full parameters, response fields, and examples.
+4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
+   In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
+   If the token is missing, call `POST $ALVA_ENDPOINT/api/v1/arrays-jwt/ensure`
+   first (idempotent — safe to call every session; renews only when missing or
+   near expiry).
 
-**SDK doc lookup is mandatory.** Always look up SDK documentation before writing
-any feed script. Do not guess function signatures, parameter names, or response
-shapes from memory. The doc lookup ensures you use the correct module, call the
-right function, and handle the actual response format.
+**Data skill doc lookup is mandatory.** Always fetch the endpoint detail before
+writing code that calls it. Do not guess paths, parameter names, or response
+shapes from memory. The doc lookup ensures you use the correct endpoint and
+handle the actual response format.
 
-**Enforcement**: Before any `require("@arrays/...")` or `alva run` call, you
-MUST have completed a doc lookup for that specific module in this session.
-The required sequence is:
+**Enforcement**: Before any Arrays data HTTP call or `alva run` that hits one,
+you MUST have completed `GET /api/v1/skills/:name?endpoint=<path>` for that
+endpoint in this session. If the call fails with an unexpected shape, re-fetch
+the endpoint detail rather than guessing.
 
-1. `alva sdk partition-summary --partition <name>` → find exact module path
-2. `alva sdk doc --name <module>` → get function names, params, response shape
-3. Write code using ONLY the names and shapes from step 2
+#### Runtime Libraries
 
-If an `alva run` call fails with "module not found" or "not a function",
-do NOT guess a different name. Return to step 1.
+Built-in modules that run inside the jagent V8 runtime via `require()`. These
+are **not** data APIs — they are pure computation and utility libraries
+available in every script execution.
 
-#### SDK Partition Index
-
-| Partition                                 | Description                                                                                                                                                             |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spot_market_price_and_volume`            | Spot OHLCV for crypto and equities. Price bars, volume, historical candles.                                                                                             |
-| `crypto_futures_data`                     | Perpetual futures: OHLCV, funding rates, open interest, long/short ratio.                                                                                               |
-| `crypto_technical_metrics`                | Crypto technical & on-chain indicators: MA, EMA, RSI, MACD, Bollinger, MVRV, SOPR, NUPL, whale ratio, market cap, FDV, etc. (20 modules)                                |
-| `crypto_exchange_flow`                    | Exchange inflow/outflow data for crypto assets.                                                                                                                         |
-| `crypto_fundamentals`                     | Crypto market fundamentals: circulating supply, max supply, market dominance.                                                                                           |
-| `crypto_screener`                         | Screen crypto assets by technical metrics over custom time ranges.                                                                                                      |
-| `company_crypto_holdings`                 | Public companies' crypto token holdings (e.g. MicroStrategy BTC).                                                                                                       |
-| `equity_fundamentals`                     | Stock fundamentals: income statements, balance sheets, cash flow, margins, PE, PB, ROE, ROA, EPS, market cap, dividend yield, enterprise value, etc. (31 modules)       |
-| `equity_estimates_and_targets`            | Analyst price targets, consensus estimates, earnings guidance.                                                                                                          |
-| `equity_events_calendar`                  | Dividend calendar, stock split calendar.                                                                                                                                |
-| `equity_ownership_and_flow`               | Institutional holdings, insider trades, senator trading activity.                                                                                                       |
-| `stock_screener`                          | Screen stocks by sector, industry, country, exchange, IPO date, earnings date, financial & technical metrics. (9 modules)                                               |
-| `stock_technical_metrics`                 | Stock technical indicators: beta, volatility, Bollinger, EMA, MA, MACD, RSI-14, VWAP, avg daily dollar volume.                                                          |
-| `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
-| `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
-| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
+| Module group                              | Description                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `crypto_fundamentals`                     | Crypto supply, market cap, dominance (internal data source)        |
 | `feed_widgets`                            | Per-handle/channel rolling subscriptions — news, Twitter/X, YouTube, Reddit, podcasts (e.g. `getTwitterFeed`). Twitter also has historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
+| `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)          |
+
+To discover available modules and their documentation:
+
+- `alva sdk partitions` — list all runtime module groups
+- `alva sdk partition-summary --partition <name>` — one-line summaries per group
+- `alva sdk doc --name <module>` — full doc for a specific runtime module
+
+Pick a module group → `partition-summary` to see modules → `sdk doc` for full
+documentation.
 
 For unstructured content — news articles, social discussions, videos, podcasts
 — see [Content Search](#content-search) below.
@@ -720,10 +724,16 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
-**SDKHub**: 250+ data modules available via
-`require("@arrays/crypto/ohlcv:v1.0.0")` etc. Version suffix is optional
-(defaults to `v1.0.0`). To discover function signatures and response shapes, use
-`alva sdk doc --name "..."`).
+**Runtime libraries**: Built-in computation modules available via `require()`
+(e.g. `@alva/technical-indicators/rsi:v1.0.0`). Version suffix is optional
+(defaults to `v1.0.0`). To discover function signatures, use
+`alva sdk doc --name "..."`. Module groups: `crypto_fundamentals`,
+`feed_widgets`, `technical_indicator_calculation_helpers`.
+
+**Data APIs**: Financial data (crypto, stock, macro, ETF) is fetched via HTTP
+from the Arrays backend — see the [Data Skills](#3-data-skills) section. Load
+`ARRAYS_JWT` via `secret.loadPlaintext('ARRAYS_JWT')` and call Arrays endpoints
+with `Authorization: Bearer <ARRAYS_JWT>`.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or
@@ -744,8 +754,12 @@ filesystem paths.
 
 ```javascript
 const { Feed, feedPath, makeDoc, num } = require("@alva/feed");
-const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0");
+const http = require("net/http");
+const secret = require("secret-manager");
 const { indicators } = require("@alva/algorithm");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ARRAYS_BASE = "https://data-tools.prd.space.id";
 
 const feed = new Feed({ path: feedPath("btc-ema") });
 
@@ -762,14 +776,11 @@ feed.def("metrics", {
     const start =
       lastDateMs > 0 ? Math.floor(lastDateMs / 1000) : now - 30 * 86400;
 
-    const bars = getCryptoKline({
-      symbol: "BTCUSDT",
-      start_time: start,
-      end_time: now,
-      interval: "1h",
-    })
-      .response.data.slice()
-      .reverse();
+    const resp = http.syncFetch(
+      `${ARRAYS_BASE}/api/v1/crypto/ohlcv?symbol=BTCUSDT&start_time=${start}&end_time=${now}&interval=1h&limit=10000`,
+      { headers: { Authorization: "Bearer " + ARRAYS_JWT } }
+    );
+    const bars = JSON.parse(resp.text()).data.slice().reverse();
     const closes = bars.map((b) => b.close);
     const ema10 = indicators.ema(closes, { period: 10 });
 
@@ -944,9 +955,9 @@ When an SDK module returns a Pro-only or subscription error:
 ### Coverage Limitations
 
 When the user requests data outside Alva's supported asset classes (e.g. forex
-pairs, which are not in SDKHub), state the limitation upfront rather than
-discovering it through failed searches. Suggest BYOD alternatives if a public
-API exists.
+pairs, which are not in the Data Skills catalog), state the limitation upfront
+rather than discovering it through failed searches. Suggest BYOD alternatives
+if a public API exists.
 
 ---
 
@@ -970,10 +981,10 @@ alva fs remove --path '~/feeds/my-feed/v1/data' --recursive
 
 ### Inline Debug Snippets
 
-Test SDK shapes before building a full feed:
+Test data skill response shapes before building a full feed:
 
 ```bash
-alva run --code 'const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0"); JSON.stringify(Object.keys(getCryptoKline({ symbol: "BTCUSDT", start_time: 0, end_time: 0, interval: "1h" })));'
+alva run --code 'const http = require("net/http"); const secret = require("secret-manager"); const jwt = secret.loadPlaintext("ARRAYS_JWT"); const r = http.syncFetch("https://data-tools.prd.space.id/api/v1/crypto/ohlcv?symbol=BTCUSDT&start_time=1735689600&end_time=1735776000&interval=1h&limit=5", {headers:{Authorization:"Bearer "+jwt}}); JSON.stringify(JSON.parse(r.text()).data[0]);'
 ```
 
 ---
@@ -1149,9 +1160,12 @@ usually incomplete — see
 See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, Amount } = FeedAltraModule;
+const { FeedAltra, e, Amount, createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(
   {
@@ -1161,7 +1175,7 @@ const altra = new FeedAltra(
     simOptions: { simTick: "1min", feeRate: 0.001 },
     perfOptions: { timezone: "UTC", marketType: "crypto" },
   },
-  createOHLCVProvider(),
+  ohlcvProvider,
 );
 
 const dg = altra.getDataGraph();

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -177,9 +177,9 @@ module.exports = { strategyFn, initialState };
 ### main.js
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e } = FeedAltraModule;
+const { FeedAltra, e, createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
 
 const { SYMBOL, STRATEGY_INTERVAL } = require("./constants.js");
 const { createMACDFeature } = require("./features.js");
@@ -188,7 +188,8 @@ const { strategyFn, initialState } = require("./strategy.js");
 const START_DATE = Date.parse("2025-01-01T00:00:00.000Z");
 const END_DATE = Date.now();
 
-const ohlcvProvider = createOHLCVProvider();
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(
   {
@@ -257,12 +258,16 @@ const {
 
 ## OHLCV Provider
 
-All OHLCV data must come through `createOHLCVProvider()`. Never fabricate price
-data.
+All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
+price data.
 
 ```javascript
-const { createOHLCVProvider } = require("@arrays/data/ohlcv-provider:v1.0.0");
-const ohlcvProvider = createOHLCVProvider();
+const { FeedAltraModule } = require("@alva/feed");
+const { createArraysOhlcvProvider } = FeedAltraModule;
+const secret = require("secret-manager");
+
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 
 const altra = new FeedAltra(config, ohlcvProvider);
 ```
@@ -327,6 +332,7 @@ When trading both crypto and stocks, use a single FeedAltra instance with
 `marketType: "mix"`:
 
 ```javascript
+const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 const altra = new FeedAltra(
   {
     path: "~/feeds/multi-asset/v1",
@@ -469,29 +475,31 @@ Raw data sources provide external data beyond OHLCV (funding rates, open
 interest, on-chain metrics, sentiment).
 
 ```javascript
-const { getOpenInterest } = require("@arrays/crypto/open-interest:v1.0.0");
+const http = require("net/http");
+const secret = require("secret-manager");
+const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
+const ARRAYS_BASE = "https://data-tools.prd.space.id";
 
 dataGraph.registerRawData({
   name: "btc_open_interest",
   description: "BTC perpetual futures open interest",
   fields: [num("sumOpenInterest"), num("sumOpenInterestValue")],
   fn: (fromExclusive, toInclusive) => {
-    const result = getOpenInterest({
-      symbol: "BINANCE_PERP_BTC_USDT",
-      start_time: fromExclusive,
-      end_time: toInclusive,
-      interval: "1d",
-    });
+    const resp = http.syncFetch(
+      `${ARRAYS_BASE}/api/v1/crypto/open-interest?symbol=BTCUSDT&start_time=${fromExclusive}&end_time=${toInclusive}&interval=1d`,
+      { headers: { Authorization: "Bearer " + ARRAYS_JWT } }
+    );
+    const result = JSON.parse(resp.text());
 
     if (!result.success) {
       throw new Error("getOpenInterest failed: " + JSON.stringify(result));
     }
 
     return {
-      data: result.response.data.map((d) => ({
+      data: result.data.map((d) => ({
         date: d.observedAt, // MUST use observedAt for PIT safety
-        sumOpenInterest: d.sumOpenInterest,
-        sumOpenInterestValue: d.sumOpenInterestValue,
+        sumOpenInterest: d.sum_open_interest,
+        sumOpenInterestValue: d.sum_open_interest_value,
       })),
     };
   },
@@ -531,8 +539,8 @@ e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d"); // Daily bar close
 e.raw("sentiment_score"); // Raw data update
 e.feature("rsi"); // Feature computed
 
-e.all(e.ohlcv("AAPL", "1d"), e.ohlcv("BTCUSDT", "1d")); // AND
-e.any(e.ohlcv("BTCUSDT", "1h"), e.raw("funding")); // OR
+e.all(e.ohlcv("XNAS_SPOT_AAPL_USD", "1d"), e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d")); // AND
+e.any(e.ohlcv("BINANCE_SPOT_BTC_USDT", "1h"), e.raw("funding")); // OR
 ```
 
 ### Strategy Config

--- a/skills/alva/references/api/sdk.md
+++ b/skills/alva/references/api/sdk.md
@@ -1,48 +1,51 @@
 # SDK
 
-Browse the 250+ SDK modules available in the runtime — covering
-crypto/equity/ETF market data (OHLCV, fundamentals, on-chain metrics), 60+
-technical indicators (SMA, RSI, MACD, Bollinger Bands…), macro & economic series
-(GDP, CPI, Treasury yields), and alternative data (news, social sentiment,
-DeFi).
+Browse the built-in runtime library modules — including 50+ technical
+indicators (SMA, RSI, MACD, Bollinger Bands), crypto fundamentals, and
+feed widgets.
 
-## Get SDK Doc
+> **Note:** Financial data APIs (crypto/equity/ETF market data, fundamentals,
+> macro, on-chain metrics) are now served by the Arrays backend — see the
+> Data Skills section in `SKILL.md`. The `alva sdk` commands only cover
+> runtime library modules.
+
+## Get Module Doc
 
 ```
 alva sdk doc --name <module_name>
 ```
 
-| Parameter | Type   | Required | Description                                           |
-| --------- | ------ | -------- | ----------------------------------------------------- |
-| name      | string | yes      | Full module name (e.g. `@arrays/crypto/ohlcv:v1.0.0`) |
+| Parameter | Type   | Required | Description                                                          |
+| --------- | ------ | -------- | -------------------------------------------------------------------- |
+| name      | string | yes      | Full module name (e.g. `@alva/technical-indicators/rsi:v1.0.0`)      |
 
 ```
-alva sdk doc --name "@arrays/crypto/ohlcv:v1.0.0"
-→ {"name":"@arrays/crypto/ohlcv:v1.0.0","doc":"..."}
+alva sdk doc --name "@alva/technical-indicators/relative-strength-index-rsi:v1.0.0"
+→ {"name":"@alva/technical-indicators/relative-strength-index-rsi:v1.0.0","doc":"..."}
 ```
 
-## List SDK Partitions
-
-```
-alva sdk partitions
-```
+## List Module Groups
 
 ```
 alva sdk partitions
-→ {"partitions":["spot_market_price_and_volume","crypto_onchain_and_derivatives",...]}
 ```
 
-## Get Partition Summary
+```
+alva sdk partitions
+→ {"partitions":["technical_indicator_calculation_helpers","crypto_fundamentals","feed_widgets"]}
+```
+
+## Get Module Group Summary
 
 ```
 alva sdk partition-summary --partition <partition>
 ```
 
-| Parameter | Type   | Required | Description    |
-| --------- | ------ | -------- | -------------- |
-| partition | string | yes      | Partition name |
+| Parameter | Type   | Required | Description       |
+| --------- | ------ | -------- | ----------------- |
+| partition | string | yes      | Module group name |
 
 ```
-alva sdk partition-summary --partition spot_market_price_and_volume
-→ {"summary":"@arrays/crypto/ohlcv:v1.0.0 — Spot OHLCV for crypto\n@arrays/data/stock/ohlcv:v1.0.0 — Spot OHLCV for equities\n..."}
+alva sdk partition-summary --partition technical_indicator_calculation_helpers
+→ {"summary":"@alva/technical-indicators/relative-strength-index-rsi:v1.0.0 — RSI\n@alva/technical-indicators/macd:v1.0.0 — MACD\n..."}
 ```

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -157,7 +157,7 @@ When a cronjob triggers:
 
 The script has full access to:
 
-- All `require()` modules (alfs, env, net/http, SDKHub modules, @alva/feed,
+- All `require()` modules (alfs, env, net/http, runtime libraries, @alva/feed,
   etc.)
 - `require("env").args` contains the args from the cronjob configuration
 - Filesystem read/write

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -24,8 +24,8 @@ via `alva run` (inline code or filesystem entry path) or triggered by cronjobs.
    `require("./helper.js")`) -- resolved from the filesystem on ALFS
 2. **Official/system modules** -- `alfs`, `env`, `secret-manager`,
    `net/http`, `@alva/algorithm`, `@alva/feed`, `@alva/adk`
-3. **SDKHub modules** -- versioned modules like
-   `require("@arrays/crypto/ohlcv:v1.0.0")`
+3. **Runtime library modules** -- versioned modules like
+   `require("@alva/technical-indicators/rsi:v1.0.0")`
 
 ### Version Handling
 
@@ -224,45 +224,36 @@ requests.
 
 ---
 
-## SDKHub Modules
+## Runtime Library Modules
 
-250+ financial data modules are embedded in the runtime. They follow the
-pattern:
+Built-in computation and utility modules available via `require()` in the
+V8 runtime. These are **not** data APIs — they run locally in the isolate.
 
 ```javascript
-const { getXxx } = require("@org/namespace/module:v1.0.0");
+const { rsi } = require("@alva/technical-indicators/relative-strength-index-rsi:v1.0.0");
 ```
 
 **Naming convention**: `@org/[namespace]*/module_name:v1.0.0`
 
-- `@alva/...` -- Alva-maintained modules (indicators, data, LLM)
-- `@arrays/...` -- Data provider modules (crypto, stock, macro, ETF)
+- `@alva/technical-indicators/...` -- 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)
+- `@alva/...` -- Alva-maintained modules (algorithm, feed, adk)
 - `@test/...` -- Testing utilities
 
 **Common response pattern**:
 
 ```javascript
-const { getCryptoKline } = require("@arrays/crypto/ohlcv:v1.0.0");
-const result = getCryptoKline({
-  symbol: "BTCUSDT",
-  start_time: startTimestamp,
-  end_time: endTimestamp,
-  interval: "1h",
-});
-
-if (!result.success) {
-  throw new Error("API call failed: " + JSON.stringify(result));
-}
-
-const bars = result.response.data;
-// bars = [{date, open, high, low, close, volume, ...}, ...]
+const { getRSI } = require("@alva/technical-indicators/relative-strength-index-rsi:v1.0.0");
+const result = getRSI({ prices: closePrices, period: 14 });
 ```
 
-Most SDK functions are **synchronous** and return
-`{ success: boolean, response: { data: [...] } }`.
+Most runtime library functions are **synchronous**.
 
 To discover function signatures and response shapes, use the SDK doc API
 (`alva sdk doc --name "..."`).
+
+**Data APIs** (crypto, stock, macro, ETF) are now served by Arrays via HTTP
+endpoints — see the Data Skills section in SKILL.md. They are **not**
+loaded via `require()`.
 
 ---
 

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -2,7 +2,7 @@
 
 Search SDKs for discovering unstructured content across multiple sources.
 For handle-first access (subscribe to an account, or — Twitter only —
-backfill its history), use the `feed_widgets` partition instead.
+backfill its history), use the `feed_widgets` partition instead. The search SDKs below live in the `unified_search` partition.
 
 ## SDK Modules
 


### PR DESCRIPTION
## Summary

Rebased version of #67 onto current `main`. That PR diverged ~50 commits behind main with conflicts that could not be resolved mechanically (e.g. `api-reference.md` was split into `references/api/*.md` on main, and main migrated from HTTP API examples to `alva` CLI).

Squashed the original 21 commits (which contained several revert pairs) into one commit capturing the net semantic intent.

## Changes

- **SKILL.md** — SDKHub section → Data Skills (Arrays backend `/api/v1/skills`) + Runtime Libraries split; Feed SDK / Altra / debug examples migrated from `require("@arrays/*")` to HTTP fetch with `ARRAYS_JWT`; coverage-gap wording updated.
- **altra-trading.md** — `createOHLCVProvider()` → `createArraysOhlcvProvider({ jwt: ARRAYS_JWT })`; open-interest raw-data example switched to HTTP fetch.
- **jagent-runtime.md** — SDKHub modules → Runtime Library Modules; note that data APIs are now served via Arrays HTTP.
- **api/sdk.md** — scoped to runtime libraries only, with pointer to Data Skills for financial data APIs.
- **deployment.md** — "SDKHub modules" → "runtime libraries".

## Notes on scope

- Dropped the original PR's `.alva.json` + `api_key` pre-flight edits — main replaced that flow with `alva auth login`, so they no longer apply.
- Left `@arrays/*` references in `feed-sdk.md`, `adk.md`, `search.md` untouched (out of #67's original scope — should be a follow-up PR).
- Kept one `@arrays` code example in `deployment.md` since #67 itself didn't migrate it.

## Test plan

- [ ] Verify rendered markdown reads cleanly
- [ ] Verify all HTTP examples reference `ARRAYS_JWT` via `secret-manager`
- [ ] Verify no lingering `SDKHub` or `createOHLCVProvider()` strings in edited files
- [ ] Close / supersede #67

Supersedes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)