### PR TITLE
docs(alva/remix-workflow): update for dbview refactor

### DIFF
--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -5,6 +5,11 @@ The user copies a prompt from the Remix button on any playbook page and pastes
 it into their agent. The agent then fetches the source playbook's code and UI,
 customizes them per the user's preferences, and deploys a new playbook.
 
+> **Note**: This workflow was updated for the dbview refactor (April 2026).
+> Feed references now live inline in `playbook.json` under `releases[].feeds[]`.
+> The legacy `releases/{version}/feeds/{feed_id}` ALFS symlinks no longer exist —
+> resolve feed paths directly from the JSON payload.
+
 ---
 
 ## Prompt Format
@@ -58,11 +63,25 @@ Returns JSON with structure:
     "version": "v1.0.0",
     "feeds_dir": "./releases/v1.0.0/feeds/",
     "feeds": [{ "feed_id": 100, "feed_major": 1 }]
-  }
+  },
+  "releases": [
+    {
+      "version": "v1.0.0",
+      "feeds": [{ "feed_id": 100, "feed_major": 1 }]
+    }
+  ]
 }
 ```
 
-From `latest_release.feeds`, collect the feed IDs you need to inspect.
+`releases[].feeds[]` (and equivalently `latest_release.feeds`) is the
+**authoritative** feed list — each entry gives you `{feed_id, feed_major}`,
+which is everything you need to resolve the feed's canonical ALFS path. The
+`feeds_dir` string is a legacy shape-compatibility field; **do not traverse
+it** — the `./releases/{version}/feeds/` and `./draft/feeds/` directories no
+longer exist on ALFS.
+
+From `latest_release.feeds`, collect the `{feed_id, feed_major}` pairs you
+need to inspect.
 
 ---
 
@@ -80,18 +99,20 @@ the new playbook's UI.
 
 ## Step 3 — Read Code Layer (Feed Scripts)
 
-Each feed referenced in `playbook.json` has a symlink under the release's
-`feeds/` directory pointing to the feed's ALFS path.
+Parse `releases[].feeds[]` from the target release in `playbook.json`
+(typically `latest_release.feeds`). For each entry `{feed_id, feed_major}`,
+the feed's canonical ALFS path is:
 
-```bash
-alva fs readlink --path '/alva/home/{owner}/playbooks/{name}/releases/{version}/feeds/{feed_id}'
-# → {"target_path": "/alva/home/{owner}/feeds/{feed_name}"}
+```
+/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/feed.json
 ```
 
-Then read the feed script source:
+No `readlink` needed — the JSON payload already tells you everything. Read
+the feed metadata, then the script source:
 
 ```bash
-alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js'
+alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/feed.json'
+alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/src/index.js'
 ```
 
 This contains the strategy logic, data fetching, and indicator computations.
@@ -99,7 +120,7 @@ This contains the strategy logic, data fetching, and indicator computations.
 Optionally, read sample feed output to understand the data schema:
 
 ```bash
-alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/data/{group}/{output}/@last/5'
+alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/data/{group}/{output}/@last/5'
 ```
 
 ---
@@ -167,19 +188,16 @@ Agent reads:
 ```bash
 # 1. Metadata
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/playbook.json'
+# latest_release.feeds = [{ "feed_id": 100, "feed_major": 1 }]
 
 # 2. HTML source
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/index.html'
 
-# 3. Feed symlink → feed path
-alva fs readlink --path '/alva/home/alice/playbooks/btc-momentum/releases/v1.0.0/feeds/100'
-# → /alva/home/alice/feeds/btc-momentum
+# 3. Feed source code (resolved directly from feed_id/feed_major — no readlink)
+alva fs read --path '/alva/home/alice/feeds/100/v1/src/index.js'
 
-# 4. Feed source code
-alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/src/index.js'
-
-# 5. (Optional) Sample data for schema understanding
-alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/data/market/ohlcv/@last/3'
+# 4. (Optional) Sample data for schema understanding
+alva fs read --path '/alva/home/alice/feeds/100/v1/data/market/ohlcv/@last/3'
 ```
 
 Agent then runs the content-legitimacy audit on the source HTML and feed

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -5,10 +5,15 @@ The user copies a prompt from the Remix button on any playbook page and pastes
 it into their agent. The agent then fetches the source playbook's code and UI,
 customizes them per the user's preferences, and deploys a new playbook.
 
-> **Note**: This workflow was updated for the dbview refactor (April 2026).
-> Feed references now live inline in `playbook.json` under `releases[].feeds[]`.
+> **Note**: This workflow was updated for the dbview refactor (April 2026) and
+> applies to **playbooks backed by the dbview subsystem (post-2026-04)**. Feed
+> references now live inline in `playbook.json` under both `latest_release.feeds`
+> and `releases[].feeds[]` (same shape — each entry is `{feed_id, feed_major}`).
 > The legacy `releases/{version}/feeds/{feed_id}` ALFS symlinks no longer exist —
-> resolve feed paths directly from the JSON payload.
+> resolve feed paths directly from the JSON payload. Legacy ALFS-only playbooks
+> (pre-dbview cached `playbook.json` files that may omit `releases`/`feeds`
+> entirely) are deprecated and out of scope for this doc; if encountered, fall
+> back to the legacy `alva fs readlink` flow.
 
 ---
 
@@ -112,10 +117,16 @@ the feed metadata, then the script source:
 
 ```bash
 alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/feed.json'
-alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/src/index.js'
+alva fs read --path '/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/src/main.js'
 ```
 
 This contains the strategy logic, data fetching, and indicator computations.
+
+**Entrypoint note**: Released feeds write their compiled/bundled entrypoint as
+`src/main.js` under the released tree (`~/feeds/{feed_id}/v{major}/src/main.js`).
+The authoring/draft path uses `src/index.js` under the owner's name-scoped tree
+(`~/feeds/{name}/v{major}/src/index.js`). Remix operates on released feeds by
+default, so read `src/main.js`.
 
 Optionally, read sample feed output to understand the data schema:
 
@@ -183,21 +194,23 @@ Add a summary section at the bottom.
 
 Extracted: owner = `alice`, name = `btc-momentum`.
 
-Agent reads:
+Agent reads (using generic placeholders — resolve `<feed_id>`, `<feed_major>`,
+`<group>`, and `<output_name>` from the `playbook.json` + `feed.json` payloads
+read in the preceding steps):
 
 ```bash
 # 1. Metadata
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/playbook.json'
-# latest_release.feeds = [{ "feed_id": 100, "feed_major": 1 }]
+# latest_release.feeds = [{ "feed_id": <feed_id>, "feed_major": <feed_major> }]
 
 # 2. HTML source
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/index.html'
 
 # 3. Feed source code (resolved directly from feed_id/feed_major — no readlink)
-alva fs read --path '/alva/home/alice/feeds/100/v1/src/index.js'
+alva fs read --path '/alva/home/alice/feeds/<feed_id>/v<feed_major>/src/main.js'
 
 # 4. (Optional) Sample data for schema understanding
-alva fs read --path '/alva/home/alice/feeds/100/v1/data/market/ohlcv/@last/3'
+alva fs read --path '/alva/home/alice/feeds/<feed_id>/v<feed_major>/data/<group>/<output_name>/@last/3'
 ```
 
 Agent then runs the content-legitimacy audit on the source HTML and feed


### PR DESCRIPTION
## Summary
Updates \`skills/alva/references/remix-workflow.md\` for the April 2026 playbook+feed dbview refactor:
- Removes \`alva fs readlink\` step that traversed deleted \`releases/{version}/feeds/{feed_id}\` symlinks
- Updates Step 3 + concrete example to parse \`releases[].feeds[]\` directly from \`playbook.json\` and resolve feed content at \`/alva/home/{owner}/feeds/{feed_id}/v{feed_major}/feed.json\`
- Adds header note explaining the refactor context
- Keeps shape-compat JSON sample (playbook.json still emits legacy \`feeds_dir\` strings for backward compat) with a clear "do not traverse" note

## Breaking Changes
None — documentation-only change. Agents following the updated workflow will work against both the pre- and post-refactor playbook.json shapes (the legacy \`feeds_dir\` fields still exist in the JSON for shape compat; only the recommended workflow changes).

## Database Migrations
None.

## Merge Order
Independent — can merge any time. Recommended to merge **after** alva-ai/alfs#137 and alva-ai/alva-backend#733 so the doc's new workflow reflects production reality.

## Related
- alva-ai/alfs#137 — dbview subsystem
- alva-ai/alva-backend#733 — service layer DB-source-of-truth refactor
- alva-ai/alva-local-dev#TBD — cross-service e2e

## Test Plan
- [x] Doc reads coherently end-to-end
- [x] Example JSON + commands match the new post-refactor reality
- [ ] Agent dry-run against updated doc (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)