### PR TITLE
docs(alva): tune widget title size, tab-L padding, and chart-blue2 to…

### DIFF
--- a/skills/alva/references/design-components.md
+++ b/skills/alva/references/design-components.md
@@ -1554,6 +1554,7 @@ border through their transparent border.
   gap: var(--spacing-l);
 }
 .tab-underline.tab-l .tab-item {
+  padding-bottom: 6px;
   font-size: 16px;
   line-height: 26px;
   letter-spacing: 0.16px;

--- a/skills/alva/references/design-tokens.css
+++ b/skills/alva/references/design-tokens.css
@@ -39,8 +39,8 @@
     --chart-blue1-main: #3d8bd1;
     --chart-blue1-1: #005daf;
     --chart-blue1-2: #88b7e0;
-    --chart-blue2-main: #0d7498;
-    --chart-blue2-1: #54a5c2;
+    --chart-blue2-main: #54A5C2;
+    --chart-blue2-1: #0D7498;
     --chart-blue2-2: #91d1db;
     --chart-purple1-main: #5f75c9;
     --chart-purple1-1: #3a52be;

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -57,7 +57,7 @@
 }
 
 .widget-title-text {
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 400;
   color: var(--text-n9);
   letter-spacing: 0.14px;


### PR DESCRIPTION
…ken order

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
