### PR TITLE
docs(alva): surface getTwitterBackfill (account-level historical feed)

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -419,7 +419,7 @@ do NOT guess a different name. Return to step 1.
 | `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
 | `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Social & news subscription feeds: news, Twitter/X, YouTube, Reddit, podcasts. For subscribing to specific accounts/channels.                                            |
+| `feed_widgets`                            | Social & news by account/channel: news, Twitter/X, YouTube, Reddit, podcasts. Two modes — declarative **subscriptions** (rolling targets-based feed, e.g. `getTwitterFeed`) and **historical backfill** per handle over an absolute time window (e.g. `getTwitterBackfill`, Pro-gated). For keyword/topic search across sources, use [Content Search](#content-search) instead. |
 
 For unstructured content — news articles, social discussions, videos, podcasts
 — see [Content Search](#content-search) below.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -419,7 +419,7 @@ do NOT guess a different name. Return to step 1.
 | `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
 | `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Per-handle/channel access — news, Twitter/X, YouTube, Reddit, podcasts. Rolling subscriptions (`getTwitterFeed`) or historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
+| `feed_widgets`                            | Per-handle/channel rolling subscriptions — news, Twitter/X, YouTube, Reddit, podcasts (e.g. `getTwitterFeed`). Twitter also has historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
 
 For unstructured content — news articles, social discussions, videos, podcasts
 — see [Content Search](#content-search) below.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -419,7 +419,7 @@ do NOT guess a different name. Return to step 1.
 | `etf_fundamentals`                        | ETF holdings breakdown.                                                                                                                                                 |
 | `macro_and_economics_data`                | CPI, GDP, unemployment, federal funds rate, Treasury rates, PPI, consumer sentiment, VIX, TIPS, nonfarm payroll, retail sales, recession probability, etc. (20 modules) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers: RSI, MACD, Bollinger Bands, ATR, VWAP, Ichimoku, Parabolic SAR, KDJ, OBV, etc. Input your own price arrays.                               |
-| `feed_widgets`                            | Social & news by account/channel: news, Twitter/X, YouTube, Reddit, podcasts. Two modes — declarative **subscriptions** (rolling targets-based feed, e.g. `getTwitterFeed`) and **historical backfill** per handle over an absolute time window (e.g. `getTwitterBackfill`, Pro-gated). For keyword/topic search across sources, use [Content Search](#content-search) instead. |
+| `feed_widgets`                            | Per-handle/channel access — news, Twitter/X, YouTube, Reddit, podcasts. Rolling subscriptions (`getTwitterFeed`) or historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
 
 For unstructured content — news articles, social discussions, videos, podcasts
 — see [Content Search](#content-search) below.

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -1,9 +1,8 @@
 # Content Search
 
 Search SDKs for discovering unstructured content across multiple sources.
-For account/channel-level access (subscribe to an account, or backfill a
-handle's full history over a time window), use `feed_widgets` instead —
-see [Account-Level Access](#account-level-access-feed_widgets) below.
+For handle-first access (subscribe to an account, or backfill its history),
+use `feed_widgets` — see [Account-Level Access](#account-level-access-feed_widgets).
 
 ## SDK Modules
 
@@ -24,7 +23,7 @@ see [Account-Level Access](#account-level-access-feed_widgets) below.
 - **Fields**: `content`, `url`, `author_name`, `author_username`, `author_avatar`, `created_at` (ms — real publish time), `author_verified`, `author_followers_count`
 - **Batch queries**: GrokX is AI-powered, not keyword-matching — multiple related entities can be combined into one call (e.g. "Why are $AAPL $TSLA $NVDA moving? Explain each"). The `summary` will segment by entity automatically. Returned tweets are mixed (not per-entity); only do per-entity individual searches when the use case requires raw per-entity source content.
 - **Gotcha**: A single broad query returns mostly 0-engagement noise. Fix: (1) run 3-5 queries with different topical angles (e.g. "NVDA earnings", "NVDA AI chips", "NVDA stock price") plus entity aliases (`$NVDA`, `NVIDIA`); (2) filter results — tweets with `like_count == 0` AND `retweet_count == 0` are almost always noise; (3) `author_followers_count` and `author_verified` are strong quality signals for sorting survivors.
-- **Not the right tool when the input is a handle, not a topic.** `searchGrokX` + `from:handle` will NOT return a complete account timeline — it's optimised for topical relevance, not coverage. If the user wants every tweet from `@handle` between T0 and T1 (KOL analysis, narrative audit, historical backtest), use `getTwitterBackfill` in `feed_widgets` instead. See [Account-Level Access](#account-level-access-feed_widgets).
+- **Handle-first → use backfill, not search.** `searchGrokX` + `from:handle` filters for topical relevance, not coverage, and will miss tweets. For every tweet from `@handle` in a window (KOL audits, backtests), use `getTwitterBackfill` — see [Account-Level Access](#account-level-access-feed_widgets).
 
 ### News
 
@@ -85,29 +84,10 @@ These apply across all sources:
 
 ## Account-Level Access (`feed_widgets`)
 
-When the input is a specific **account/handle** rather than a topic, content
-search is the wrong hammer. The `feed_widgets` partition covers two
-account-level modes — pick by whether you need rolling updates or a bounded
-historical snapshot.
+Handle-first intents, picked by shape:
 
-| Need | SDK | Shape |
-| --- | --- | --- |
-| Rolling subscription — playbook follows an account, feed keeps updating on a cron | `getTwitterFeed` (`@arrays/data/widget-scrap/twitter:v1.0.0`) | Declarative targets-based; the current targets list IS the complete subscribe state. Per-call filters & limit. |
-| One-shot historical backfill — "every tweet from `@user` between T0 and T1" | `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) | Single unary call. `start_time` required, `end_time` defaults to now. Read-only, no subscription side-effects. **Pro-gated.** |
+- **Rolling subscription** (playbook follows an account on a cron) → `getTwitterFeed` (`@arrays/data/widget-scrap/twitter:v1.0.0`)
+- **Historical backfill** (every tweet from `@user` between T0 and T1 — KOL audits, backtests, training data) → `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) — **Pro-gated**; always check `response.partial` before treating the result as complete (mid-stream errors surface already-drained tweets with `partial: true` and `error` set).
+- **Topic/keyword search** → `searchGrokX` (see [Twitter/X](#twitterx) above).
 
-### When to pick backfill over search or subscribe
-
-- **KOL / account audits, historical backtests, training datasets** — you want the complete timeline for one handle over a window, not the topically-relevant subset. Use backfill.
-- **Narrative tracking for a live playbook** — ongoing coverage of an account on a cron. Use the subscription feed.
-- **"What are people saying about X" / "find tweets about X"** — topic-first, not handle-first. Use `searchGrokX`.
-
-### `getTwitterBackfill` gotchas
-
-Always run `alva sdk doc --name @arrays/data/widget-scrap/twitter-backfill` for the authoritative shape. The points worth knowing up front:
-
-- **Pro-tier gated.** Non-Pro callers get `PERMISSION_DENIED`. Inside a jagent, `user_id` defaults to `require('env').userId`; outside the jagent runtime it must be passed explicitly.
-- **Partial results on mid-stream errors.** Backend drains a server-streaming RPC internally. On mid-stream failures the envelope still returns already-collected tweets with `response.partial === true` and `response.error` set. Always check `response.partial` before treating the dataset as complete.
-- **Unary response, no progress events.** Callers see one response, not a stream.
-- **Bound the window.** Very wide windows can take minutes and may hit gateway timeouts; prefer reasonable windows (e.g. 30-180 days) and paginate by re-calling with shifted `start_time` if you need more.
-- **Ordering not guaranteed.** `response.data` usually comes back newest-first but the SDK does not promise it — sort by `date` yourself if order matters.
-- **Handle sanitisation.** Leading `@` is stripped automatically; pass either form.
+Run `alva sdk doc --name @arrays/data/widget-scrap/twitter-backfill` for the full shape before calling.

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -1,8 +1,9 @@
 # Content Search
 
 Search SDKs for discovering unstructured content across multiple sources.
-For handle-first access (subscribe to an account, or backfill its history),
-use `feed_widgets` — see [Account-Level Access](#account-level-access-feed_widgets).
+For handle-first access (subscribe to an account, or — Twitter only —
+backfill its history), use `feed_widgets` — see
+[Handle-First Access](#handle-first-access-feed_widgets).
 
 ## SDK Modules
 
@@ -23,7 +24,7 @@ use `feed_widgets` — see [Account-Level Access](#account-level-access-feed_wid
 - **Fields**: `content`, `url`, `author_name`, `author_username`, `author_avatar`, `created_at` (ms — real publish time), `author_verified`, `author_followers_count`
 - **Batch queries**: GrokX is AI-powered, not keyword-matching — multiple related entities can be combined into one call (e.g. "Why are $AAPL $TSLA $NVDA moving? Explain each"). The `summary` will segment by entity automatically. Returned tweets are mixed (not per-entity); only do per-entity individual searches when the use case requires raw per-entity source content.
 - **Gotcha**: A single broad query returns mostly 0-engagement noise. Fix: (1) run 3-5 queries with different topical angles (e.g. "NVDA earnings", "NVDA AI chips", "NVDA stock price") plus entity aliases (`$NVDA`, `NVIDIA`); (2) filter results — tweets with `like_count == 0` AND `retweet_count == 0` are almost always noise; (3) `author_followers_count` and `author_verified` are strong quality signals for sorting survivors.
-- **Handle-first → use backfill, not search.** `searchGrokX` + `from:handle` filters for topical relevance, not coverage, and will miss tweets. For every tweet from `@handle` in a window (KOL audits, backtests), use `getTwitterBackfill` — see [Account-Level Access](#account-level-access-feed_widgets).
+- **Handle-first → use backfill, not search.** `searchGrokX` + `from:handle` filters for topical relevance, not coverage, and will miss tweets. For every tweet from `@handle` in a window (KOL audits, backtests), use `getTwitterBackfill` — see [Handle-First Access](#handle-first-access-feed_widgets).
 
 ### News
 
@@ -82,12 +83,14 @@ These apply across all sources:
 | Serper | `tbs` | `qdr:d` | `qdr:w` | `qdr:m` |
 | Brave | `freshness` | `pd` | `pw` | `pm` |
 
-## Account-Level Access (`feed_widgets`)
+## Handle-First Access (`feed_widgets`)
 
-Handle-first intents, picked by shape:
+Twitter-specific pickers by intent:
 
 - **Rolling subscription** (playbook follows an account on a cron) → `getTwitterFeed` (`@arrays/data/widget-scrap/twitter:v1.0.0`)
-- **Historical backfill** (every tweet from `@user` between T0 and T1 — KOL audits, backtests, training data) → `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) — **Pro-gated**; always check `response.partial` before treating the result as complete (mid-stream errors surface already-drained tweets with `partial: true` and `error` set).
+- **Historical backfill** (every tweet from `@user` between T0 and T1 — KOL audits, backtests, training data) → `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) — **Pro-gated**; always check `response.partial` before treating the result as complete (mid-stream errors surface already-drained tweets with `partial: true` and `error` set). Twitter-only today — no equivalent for news / YouTube / Reddit / podcasts.
 - **Topic/keyword search** → `searchGrokX` (see [Twitter/X](#twitterx) above).
 
 Run `alva sdk doc --name @arrays/data/widget-scrap/twitter-backfill` for the full shape before calling.
+
+For rolling subscriptions on other sources (news, YouTube, Reddit, podcasts), the same partition has per-source feed SDKs — discover with `alva sdk partition-summary --partition feed_widgets`.

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -1,7 +1,9 @@
 # Content Search
 
 Search SDKs for discovering unstructured content across multiple sources.
-For subscribing to specific accounts/channels, use `feed_widgets` instead.
+For account/channel-level access (subscribe to an account, or backfill a
+handle's full history over a time window), use `feed_widgets` instead —
+see [Account-Level Access](#account-level-access-feed_widgets) below.
 
 ## SDK Modules
 
@@ -22,6 +24,7 @@ For subscribing to specific accounts/channels, use `feed_widgets` instead.
 - **Fields**: `content`, `url`, `author_name`, `author_username`, `author_avatar`, `created_at` (ms — real publish time), `author_verified`, `author_followers_count`
 - **Batch queries**: GrokX is AI-powered, not keyword-matching — multiple related entities can be combined into one call (e.g. "Why are $AAPL $TSLA $NVDA moving? Explain each"). The `summary` will segment by entity automatically. Returned tweets are mixed (not per-entity); only do per-entity individual searches when the use case requires raw per-entity source content.
 - **Gotcha**: A single broad query returns mostly 0-engagement noise. Fix: (1) run 3-5 queries with different topical angles (e.g. "NVDA earnings", "NVDA AI chips", "NVDA stock price") plus entity aliases (`$NVDA`, `NVIDIA`); (2) filter results — tweets with `like_count == 0` AND `retweet_count == 0` are almost always noise; (3) `author_followers_count` and `author_verified` are strong quality signals for sorting survivors.
+- **Not the right tool when the input is a handle, not a topic.** `searchGrokX` + `from:handle` will NOT return a complete account timeline — it's optimised for topical relevance, not coverage. If the user wants every tweet from `@handle` between T0 and T1 (KOL analysis, narrative audit, historical backtest), use `getTwitterBackfill` in `feed_widgets` instead. See [Account-Level Access](#account-level-access-feed_widgets).
 
 ### News
 
@@ -79,3 +82,32 @@ These apply across all sources:
 | GrokX | `from_date` / `to_date` | YYYY-MM-DD (1 day ago) | YYYY-MM-DD (7 days ago) | YYYY-MM-DD (30 days ago) |
 | Serper | `tbs` | `qdr:d` | `qdr:w` | `qdr:m` |
 | Brave | `freshness` | `pd` | `pw` | `pm` |
+
+## Account-Level Access (`feed_widgets`)
+
+When the input is a specific **account/handle** rather than a topic, content
+search is the wrong hammer. The `feed_widgets` partition covers two
+account-level modes — pick by whether you need rolling updates or a bounded
+historical snapshot.
+
+| Need | SDK | Shape |
+| --- | --- | --- |
+| Rolling subscription — playbook follows an account, feed keeps updating on a cron | `getTwitterFeed` (`@arrays/data/widget-scrap/twitter:v1.0.0`) | Declarative targets-based; the current targets list IS the complete subscribe state. Per-call filters & limit. |
+| One-shot historical backfill — "every tweet from `@user` between T0 and T1" | `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) | Single unary call. `start_time` required, `end_time` defaults to now. Read-only, no subscription side-effects. **Pro-gated.** |
+
+### When to pick backfill over search or subscribe
+
+- **KOL / account audits, historical backtests, training datasets** — you want the complete timeline for one handle over a window, not the topically-relevant subset. Use backfill.
+- **Narrative tracking for a live playbook** — ongoing coverage of an account on a cron. Use the subscription feed.
+- **"What are people saying about X" / "find tweets about X"** — topic-first, not handle-first. Use `searchGrokX`.
+
+### `getTwitterBackfill` gotchas
+
+Always run `alva sdk doc --name @arrays/data/widget-scrap/twitter-backfill` for the authoritative shape. The points worth knowing up front:
+
+- **Pro-tier gated.** Non-Pro callers get `PERMISSION_DENIED`. Inside a jagent, `user_id` defaults to `require('env').userId`; outside the jagent runtime it must be passed explicitly.
+- **Partial results on mid-stream errors.** Backend drains a server-streaming RPC internally. On mid-stream failures the envelope still returns already-collected tweets with `response.partial === true` and `response.error` set. Always check `response.partial` before treating the dataset as complete.
+- **Unary response, no progress events.** Callers see one response, not a stream.
+- **Bound the window.** Very wide windows can take minutes and may hit gateway timeouts; prefer reasonable windows (e.g. 30-180 days) and paginate by re-calling with shifted `start_time` if you need more.
+- **Ordering not guaranteed.** `response.data` usually comes back newest-first but the SDK does not promise it — sort by `date` yourself if order matters.
+- **Handle sanitisation.** Leading `@` is stripped automatically; pass either form.


### PR DESCRIPTION
## Summary

The `feed_widgets` partition got a new Pro-gated SDK — [`@arrays/data/widget-scrap/twitter-backfill`](https://github.com/alva-ai/sdkhub/tree/main/assets/%40arrays/data/widget-scrap/twitter-backfill/v1.0.0) — for one-shot historical backfill of a single handle over an absolute time window. It fills a real gap that neither `getTwitterFeed` (rolling subscription) nor `searchGrokX` (topic search) covers well.

Without a pointer in the skill, the model would default to `searchGrokX` + `from:handle` for KOL/account-audit flows, which gives topic-relevant results rather than complete account coverage.

## Changes

- **`SKILL.md` partition index** — `feed_widgets` row now describes both modes (subscription + historical backfill) and flags Pro-gating. Points topical searches at Content Search.
- **`references/search.md`**:
  - Twitter section: anti-pattern note steering handle-first use cases away from `searchGrokX` toward `getTwitterBackfill`.
  - New `## Account-Level Access (feed_widgets)` section with a decision table (search / subscribe / backfill) and `getTwitterBackfill` gotchas — Pro gate, `response.partial` handling on mid-stream errors, unary shape, window bounds, ordering not guaranteed, handle sanitisation.

Kept the full API shape out of the skill on purpose — the existing discipline (`alva sdk partition-summary` → `alva sdk doc` before any `require`) still owns the source of truth.

## Test plan

- [ ] Manual: prompt the skill with "give me every tweet from @elonmusk in the last 30 days" and confirm it picks `getTwitterBackfill` over `searchGrokX` + date filters.
- [ ] Manual: prompt with "what are people saying about NVDA earnings this week" and confirm it still picks `searchGrokX`.
- [ ] Manual: prompt with "build a playbook that tracks @cathiewood's tweets" and confirm it picks the subscription-based `getTwitterFeed`.
- [ ] Spot-check the anchor link `#account-level-access-feed_widgets` renders in the referenced cross-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)