### PR TITLE
docs(alva): drop redundant handle-first content in search.md

### DIFF
--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -2,8 +2,7 @@
 
 Search SDKs for discovering unstructured content across multiple sources.
 For handle-first access (subscribe to an account, or — Twitter only —
-backfill its history), use `feed_widgets` — see
-[Handle-First Access](#handle-first-access-feed_widgets).
+backfill its history), use the `feed_widgets` partition instead.
 
 ## SDK Modules
 
@@ -24,7 +23,6 @@ backfill its history), use `feed_widgets` — see
 - **Fields**: `content`, `url`, `author_name`, `author_username`, `author_avatar`, `created_at` (ms — real publish time), `author_verified`, `author_followers_count`
 - **Batch queries**: GrokX is AI-powered, not keyword-matching — multiple related entities can be combined into one call (e.g. "Why are $AAPL $TSLA $NVDA moving? Explain each"). The `summary` will segment by entity automatically. Returned tweets are mixed (not per-entity); only do per-entity individual searches when the use case requires raw per-entity source content.
 - **Gotcha**: A single broad query returns mostly 0-engagement noise. Fix: (1) run 3-5 queries with different topical angles (e.g. "NVDA earnings", "NVDA AI chips", "NVDA stock price") plus entity aliases (`$NVDA`, `NVIDIA`); (2) filter results — tweets with `like_count == 0` AND `retweet_count == 0` are almost always noise; (3) `author_followers_count` and `author_verified` are strong quality signals for sorting survivors.
-- **Handle-first → use backfill, not search.** `searchGrokX` + `from:handle` filters for topical relevance, not coverage, and will miss tweets. For every tweet from `@handle` in a window (KOL audits, backtests), use `getTwitterBackfill` — see [Handle-First Access](#handle-first-access-feed_widgets).
 
 ### News
 
@@ -82,15 +80,3 @@ These apply across all sources:
 | GrokX | `from_date` / `to_date` | YYYY-MM-DD (1 day ago) | YYYY-MM-DD (7 days ago) | YYYY-MM-DD (30 days ago) |
 | Serper | `tbs` | `qdr:d` | `qdr:w` | `qdr:m` |
 | Brave | `freshness` | `pd` | `pw` | `pm` |
-
-## Handle-First Access (`feed_widgets`)
-
-Twitter-specific pickers by intent:
-
-- **Rolling subscription** (playbook follows an account on a cron) → `getTwitterFeed` (`@arrays/data/widget-scrap/twitter:v1.0.0`)
-- **Historical backfill** (every tweet from `@user` between T0 and T1 — KOL audits, backtests, training data) → `getTwitterBackfill` (`@arrays/data/widget-scrap/twitter-backfill:v1.0.0`) — **Pro-gated**; always check `response.partial` before treating the result as complete (mid-stream errors surface already-drained tweets with `partial: true` and `error` set). Twitter-only today — no equivalent for news / YouTube / Reddit / podcasts.
-- **Topic/keyword search** → `searchGrokX` (see [Twitter/X](#twitterx) above).
-
-Run `alva sdk doc --name @arrays/data/widget-scrap/twitter-backfill` for the full shape before calling.
-
-For rolling subscriptions on other sources (news, YouTube, Reddit, podcasts), the same partition has per-source feed SDKs — discover with `alva sdk partition-summary --partition feed_widgets`.


### PR DESCRIPTION
## Summary

Follow-up to #289. The top-of-file bouncer redirects handle-first intents out of search.md toward `feed_widgets` before readers go any deeper — so the duplicated steering further down is noise.

By the time an agent is reading Twitter/X gotchas or the bottom of the file, they've committed to the search path. Pro-gate and `response.partial` details live in the SDK doc itself and surface naturally via the mandated `alva sdk doc` lookup before any `require`.

## Changes

- Drop the \"Handle-first → use backfill, not search\" bullet from Twitter/X gotchas.
- Drop the \"Handle-First Access (feed_widgets)\" section at the bottom of the file.
- Simplify the top cross-reference (no dangling anchor).

Net: `references/search.md` +1 / -15.

## Test plan

- [ ] Prompt: \"give me every tweet from @elonmusk in the last 30 days\" — confirm model still picks `getTwitterBackfill` (SKILL.md partition-index row is unchanged and carries the signal).
- [ ] Prompt: \"what are people saying about NVDA earnings this week\" — confirm model stays on `searchGrokX` without bouncing to backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)