### PR TITLE
docs(alva): fix createArraysOhlcvProvider import path

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1171,7 +1171,9 @@ See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, Amount, createArraysOhlcvProvider } = FeedAltraModule;
+const { FeedAltra, e, Amount } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -178,7 +178,9 @@ module.exports = { strategyFn, initialState };
 
 ```javascript
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, createArraysOhlcvProvider } = FeedAltraModule;
+const { FeedAltra, e } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const { SYMBOL, STRATEGY_INTERVAL } = require("./constants.js");
@@ -224,15 +226,13 @@ altra.setStrategy(strategyFn, {
 
 ## Imports
 
-Altra is accessed through the `FeedAltraModule` export from `@alva/feed`:
+Altra is accessed through the `FeedAltraModule` export from `@alva/feed`.
+Field type helpers (`num`, `str`, etc.) are at the `@alva/feed` top level, and
+`createArraysOhlcvProvider` lives on `@alva/graph`'s `AltraModule`:
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
 const {
-  FeedAltra,
-  e,
-  Amount,
-  TIME,
+  FeedAltraModule,
   num,
   str,
   bool,
@@ -240,30 +240,42 @@ const {
   arr,
   fld,
   makeDoc,
+} = require("@alva/feed");
+const {
+  FeedAltra,
+  e,
+  Amount,
+  TIME,
+  allocate,
+  order,
+  orders,
 } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 ```
 
-| Export                                    | Description                                      |
-| ----------------------------------------- | ------------------------------------------------ |
-| `FeedAltra`                               | Main backtesting engine class                    |
-| `e`                                       | Event trigger expression builder                 |
-| `Amount`                                  | Order amount constructors                        |
-| `TIME`                                    | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
-| `allocate`                                | Helper to create allocate target                 |
-| `order` / `orders`                        | Helper to create order targets                   |
-| `num`, `str`, `bool`, `obj`, `arr`, `fld` | Field type helpers (same as Feed SDK)            |
-| `makeDoc`                                 | Type document helper                             |
+| Export                                    | Source                     | Description                                      |
+| ----------------------------------------- | -------------------------- | ------------------------------------------------ |
+| `FeedAltra`                               | `FeedAltraModule`          | Main backtesting engine class                    |
+| `e`                                       | `FeedAltraModule`          | Event trigger expression builder                 |
+| `Amount`                                  | `FeedAltraModule`          | Order amount constructors                        |
+| `TIME`                                    | `FeedAltraModule`          | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
+| `allocate`                                | `FeedAltraModule`          | Helper to create allocate target                 |
+| `order` / `orders`                        | `FeedAltraModule`          | Helper to create order targets                   |
+| `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level)   | Field type helpers (same as Feed SDK)            |
+| `makeDoc`                                 | `@alva/feed` (top level)   | Type document helper                             |
+| `createArraysOhlcvProvider`               | `@alva/graph` `AltraModule` | Builds the OHLCV provider used by Altra          |
 
 ---
 
 ## OHLCV Provider
 
 All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
-price data.
+price data. The provider is exported from `@alva/graph` (not `@alva/feed`).
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
-const { createArraysOhlcvProvider } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");


### PR DESCRIPTION
## Summary
- `createArraysOhlcvProvider` is exported from `@alva/graph`'s `AltraModule`, not `@alva/feed`'s `FeedAltraModule`. The old incantation in SKILL.md and altra-trading.md threw `TypeError: createArraysOhlcvProvider is not a function` at runtime.
- Also corrected the altra-trading.md Imports section: `num`/`str`/`bool`/`obj`/`arr`/`fld`/`makeDoc` are top-level on `@alva/feed`, not nested under `FeedAltraModule`. Added a `Source` column to the table so each export's origin is explicit.

## Verification
Verified end-to-end on stg (`https://api-llm.stg.alva.ai/`) by running the exact updated import block through `alva run`:

- Every destructured name resolves to the expected type (`FeedAltra: function`, `Amount: object`, `createArraysOhlcvProvider: function`, etc.)
- Constructed a real provider with `ARRAYS_JWT` from `secret-manager` and fetched live BTC/ETH daily klines via `provider.pairOhlcv(...)`.

## Test plan
- [ ] Re-run an existing Altra example that uses `createArraysOhlcvProvider` against stg to confirm no regressions.
- [ ] Spot-check the updated Imports table renders cleanly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)