### PR TITLE
fix(alva): use File column (not Path) for endpoint lookup

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -392,9 +392,12 @@ the right API for a task, use the `alva skills` CLI (public, no auth):
    matches your data need.
 2. **Fetch the skill summary**: `alva skills summary --name <skill>` — returns
    the endpoints table for that domain.
-3. **Fetch endpoint detail**: `alva skills endpoint --name <skill> --path <path>`
-   — use the Path value from the summary endpoints table (e.g. `company/list`,
-   `market-news`) to get full parameters, response fields, and examples.
+3. **Fetch endpoint detail**: `alva skills endpoint --name <skill> --file <file>`
+   — use the **File** value from the summary endpoints table (e.g. `rates`,
+   `macro-index-historical`, `earnings-calendar`) to get full parameters,
+   response fields, and examples. The `File` column is the endpoint slug;
+   the `Path` column is the REST URL path and is NOT accepted here (e.g. for
+   treasury rates, use `--file rates`, not `--file macro/treasury-rates`).
 4. **Call Arrays data endpoints** with `Authorization: Bearer <ARRAYS_JWT>`.
    In runtime code, load the token via `secret.loadPlaintext('ARRAYS_JWT')`.
    The token is verified during preflight (see [Arrays JWT Check](#4-arrays-jwt-check));
@@ -406,8 +409,8 @@ shapes from memory. The doc lookup ensures you use the correct endpoint and
 handle the actual response format.
 
 **Enforcement**: Before any Arrays data HTTP call or `alva run` that hits one,
-you MUST have completed `alva skills endpoint --name <skill> --path <path>` for
-that endpoint in this session. If the call fails with an unexpected shape,
+you MUST have completed `alva skills endpoint --name <skill> --file <file>` for
+that endpoint in this session (passing the **File** column value, not the Path). If the call fails with an unexpected shape,
 re-fetch the endpoint detail rather than guessing.
 
 #### Runtime Libraries


### PR DESCRIPTION
## Summary

- Cherry-pick of commit [`fd5fd8d0`](https://github.com/alva-ai/skills/commit/fd5fd8d03b4d4eac82686e2e5e8b34b0b1adbff0) from the closed PR #67, adapted to current main (which uses `alva skills` CLI wording instead of the REST API docs the original commit targeted).
- `alva skills endpoint --path <X>` (and the underlying `/api/v1/skills/:name?endpoint=<X>` API) accepts the **File** column value from the summary endpoints table, not the Path column. The Path column is the REST URL path; the File column is the endpoint slug.
- Prior wording told agents to use the Path value, which only works when File == Path (e.g. `company/list`, `market-news`) and fails on multi-prefix skills like `arrays-data-api-macro-and-economics` where `Path=macro/treasury-rates` but `File=rates`.

Addresses Bug B in alva-ai/eval-issues#280.

## Test plan

- [ ] Verify agents pass the File column value to `alva skills endpoint --path` when looking up an endpoint on a multi-prefix skill (e.g. `--path rates`, not `--path macro/treasury-rates`).
- [ ] Confirm the enforcement clause still reads cleanly after the rewording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)