### PR TITLE
docs(alva/remix): read releases[0] instead of latest_release

### DIFF
--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -57,15 +57,18 @@ Returns JSON with structure:
   "releases": [
     {
       "version": "v1.0.0",
-      "feeds": [{ "feed_id": 100, "feed_major": 1 }]
+      "feeds": [
+        { "feed_id": 100, "feed_name": "btc-ema", "feed_major": 1 }
+      ]
     }
   ]
 }
 ```
 
 `releases` is ordered newest-first, so `releases[0]` is the latest
-release. From `releases[0].feeds`, collect the feed IDs you need to
-inspect.
+release. From `releases[0].feeds`, collect the feed refs you need to
+inspect — each entry carries both `feed_name` (for ALFS paths) and
+`feed_id` (for API calls).
 
 ---
 
@@ -83,15 +86,8 @@ the new playbook's UI.
 
 ## Step 3 — Read Code Layer (Feed Scripts)
 
-Each feed referenced in `playbook.json` has a symlink under the release's
-`feeds/` directory pointing to the feed's ALFS path.
-
-```bash
-alva fs readlink --path '/alva/home/{owner}/playbooks/{name}/releases/{version}/feeds/{feed_id}'
-# → {"target_path": "/alva/home/{owner}/feeds/{feed_name}"}
-```
-
-Then read the feed script source:
+Each entry in `releases[0].feeds` carries `feed_name` — use it to read
+the feed's script source directly:
 
 ```bash
 alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js'
@@ -168,20 +164,16 @@ Extracted: owner = `alice`, name = `btc-momentum`.
 Agent reads:
 
 ```bash
-# 1. Metadata
+# 1. Metadata — releases[0].feeds carries feed_name + feed_id per ref
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/playbook.json'
 
 # 2. HTML source
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/index.html'
 
-# 3. Feed symlink → feed path
-alva fs readlink --path '/alva/home/alice/playbooks/btc-momentum/releases/v1.0.0/feeds/100'
-# → /alva/home/alice/feeds/btc-momentum
-
-# 4. Feed source code
+# 3. Feed source code (use feed_name from playbook.json)
 alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/src/index.js'
 
-# 5. (Optional) Sample data for schema understanding
+# 4. (Optional) Sample data for schema understanding
 alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/data/market/ohlcv/@last/3'
 ```
 

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -54,15 +54,18 @@ Returns JSON with structure:
   "playbook_id": 42,
   "name": "btc-momentum",
   "description": "...",
-  "latest_release": {
-    "version": "v1.0.0",
-    "feeds_dir": "./releases/v1.0.0/feeds/",
-    "feeds": [{ "feed_id": 100, "feed_major": 1 }]
-  }
+  "releases": [
+    {
+      "version": "v1.0.0",
+      "feeds": [{ "feed_id": 100, "feed_major": 1 }]
+    }
+  ]
 }
 ```
 
-From `latest_release.feeds`, collect the feed IDs you need to inspect.
+`releases` is ordered newest-first, so `releases[0]` is the latest
+release. From `releases[0].feeds`, collect the feed IDs you need to
+inspect.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update the remix workflow step 1 to read `releases[0].feeds[0].feed_id` from `playbook.json` instead of the now-removed `latest_release.feeds[0]`
- `releases` is already ordered newest-first, so `releases[0]` is equivalent to what `latest_release` used to return
- Also trims stale `feeds_dir` field from the JSON example (that field is no longer emitted by the dbview refactor)

## Breaking Changes

None — this only changes skill guidance. Any agent following the current doc would break anyway once the backend PR lands (`latest_release` field removed).

## Database Migrations

None.

## Merge Order

⚠️ Merge after alva-ai/alva-backend#733. That PR removes `latest_release` from the `playbook.json` wire shape; this skill update must land concurrently so agents following the skill see consistent wire + doc.

## Related

- alva-ai/alva-backend#733 — parent PR that drops \`latest_release\` from the ALFS wire

## Test Plan

- [ ] After the backend PR is deployed, run \`alva fs read --path '/alva/home/{owner}/playbooks/{name}/playbook.json'\` and confirm the emitted JSON has \`releases\` but no \`latest_release\`
- [ ] Re-run a remix workflow end-to-end; the updated step 1 should collect feed IDs correctly from \`releases[0].feeds\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)