### PR TITLE
docs(alva): document fetch proxyRegion + env.availableProxyRegions

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1171,7 +1171,9 @@ See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, Amount, createArraysOhlcvProvider } = FeedAltraModule;
+const { FeedAltra, e, Amount } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.5.0
+  version: v1.5.1
 ---
 
 # Alva

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -178,7 +178,9 @@ module.exports = { strategyFn, initialState };
 
 ```javascript
 const { FeedAltraModule } = require("@alva/feed");
-const { FeedAltra, e, createArraysOhlcvProvider } = FeedAltraModule;
+const { FeedAltra, e } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const { SYMBOL, STRATEGY_INTERVAL } = require("./constants.js");
@@ -224,15 +226,13 @@ altra.setStrategy(strategyFn, {
 
 ## Imports
 
-Altra is accessed through the `FeedAltraModule` export from `@alva/feed`:
+Altra is accessed through the `FeedAltraModule` export from `@alva/feed`.
+Field type helpers (`num`, `str`, etc.) are at the `@alva/feed` top level, and
+`createArraysOhlcvProvider` lives on `@alva/graph`'s `AltraModule`:
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
 const {
-  FeedAltra,
-  e,
-  Amount,
-  TIME,
+  FeedAltraModule,
   num,
   str,
   bool,
@@ -240,30 +240,42 @@ const {
   arr,
   fld,
   makeDoc,
+} = require("@alva/feed");
+const {
+  FeedAltra,
+  e,
+  Amount,
+  TIME,
+  allocate,
+  order,
+  orders,
 } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 ```
 
-| Export                                    | Description                                      |
-| ----------------------------------------- | ------------------------------------------------ |
-| `FeedAltra`                               | Main backtesting engine class                    |
-| `e`                                       | Event trigger expression builder                 |
-| `Amount`                                  | Order amount constructors                        |
-| `TIME`                                    | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
-| `allocate`                                | Helper to create allocate target                 |
-| `order` / `orders`                        | Helper to create order targets                   |
-| `num`, `str`, `bool`, `obj`, `arr`, `fld` | Field type helpers (same as Feed SDK)            |
-| `makeDoc`                                 | Type document helper                             |
+| Export                                    | Source                     | Description                                      |
+| ----------------------------------------- | -------------------------- | ------------------------------------------------ |
+| `FeedAltra`                               | `FeedAltraModule`          | Main backtesting engine class                    |
+| `e`                                       | `FeedAltraModule`          | Event trigger expression builder                 |
+| `Amount`                                  | `FeedAltraModule`          | Order amount constructors                        |
+| `TIME`                                    | `FeedAltraModule`          | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
+| `allocate`                                | `FeedAltraModule`          | Helper to create allocate target                 |
+| `order` / `orders`                        | `FeedAltraModule`          | Helper to create order targets                   |
+| `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level)   | Field type helpers (same as Feed SDK)            |
+| `makeDoc`                                 | `@alva/feed` (top level)   | Type document helper                             |
+| `createArraysOhlcvProvider`               | `@alva/graph` `AltraModule` | Builds the OHLCV provider used by Altra          |
 
 ---
 
 ## OHLCV Provider
 
 All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
-price data.
+price data. The provider is exported from `@alva/graph` (not `@alva/feed`).
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
-const { createArraysOhlcvProvider } = FeedAltraModule;
+const { AltraModule } = require("@alva/graph");
+const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -97,6 +97,10 @@ const env = require("env");
 env.userId; // "1" (string) -- your numeric user ID
 env.username; // "alice" (string) -- your username, used in ALFS paths
 env.args; // parsed JSON from the request's "args" field
+env.availableProxyRegions; // frozen string[] of outbound proxy region labels,
+                           // e.g. ["jp","mx1","mx2","us1","us2"]. Empty array
+                           // when no proxy pool is configured. See net/http
+                           // below for the proxyRegion fetch option.
 ```
 
 ### secret-manager -- Third-Party Secrets
@@ -141,8 +145,31 @@ resp.json(); // parsed JSON
 resp.headers; // response headers
 ```
 
-`fetch` returns a Promise. Request `init` fields: `method`, `headers`, `body`.
-Max response body: 128 MB.
+`fetch` returns a Promise. Request `init` fields: `method`, `headers`, `body`,
+`proxyRegion`. Max response body: 128 MB.
+
+**Outbound proxy pool.** `fetch` egresses through a pool of proxies spanning
+multiple regions. By default each request picks a random proxy, and the
+runtime automatically retries on a different proxy for transport errors,
+5xx responses, and 429 rate-limit responses (4xx business errors are
+returned as-is, never retried).
+
+Pass `proxyRegion` in the init object to pin a request to a specific region
+(strict — only proxies with that exact label are considered, and the request
+fails rather than falling back to another region):
+
+```javascript
+const resp = await http.fetch("https://api.hyperliquid.xyz/info", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ type: "meta" }),
+  proxyRegion: "us1", // pin to a specific outbound region
+});
+```
+
+Use `require("env").availableProxyRegions` to enumerate the labels available
+in the current environment. An unknown region throws
+`"fetch: unknown proxyRegion '<name>'; available: [...]"` synchronously.
 
 ### @alva/algorithm -- Statistics and Indicators
 


### PR DESCRIPTION
## Summary
- Documents the outbound proxy pool support landed in alva-ai/jagent#577
- New optional `proxyRegion` init field on `http.fetch` (strict region pin with clear unknown-region error)
- New frozen `env.availableProxyRegions` string array enumerating labels in the current runtime
- Bumps skill metadata from `v1.5.0` to `v1.5.1`

## Breaking Changes
None. Both additions are opt-in; existing scripts continue to work unchanged.

## Database Migrations
None.

## Merge Order
None.

## Related
- alva-ai/jagent#577 — the runtime feature being documented

## Test Plan
- [x] Verified against stg: `env.availableProxyRegions` returns `["jp","mx1","mx2","us1","us2"]`
- [x] Verified against stg: `http.fetch(url, { proxyRegion: 'us1' })`, `'jp'`, `'mx1'` each reach Hyperliquid API with status 200
- [x] Verified against stg: unknown region `'zz'` throws `fetch: unknown proxyRegion 'zz'; available: [jp mx1 mx2 us1 us2]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)