### PR TITLE
feat(template): Link Design System references as real markdown links in templates

### DIFF
--- a/skills/alva/templates/screener/template.md
+++ b/skills/alva/templates/screener/template.md
@@ -7,9 +7,9 @@ Reference structure + screener-specific styling for any ranked-list screener
 
 ## Design System Compliance (READ FIRST)
 
-Before writing HTML, read `references/design-tokens.css` (tokens),
-`references/design-widgets.md` (Chart / Metric / Table Card bases), and
-`references/design-components.md` (Tab / Dropdown / Pill primitives). This
+Before writing HTML, read [references/design-tokens.css](../../references/design-tokens.css) (tokens),
+[references/design-widgets.md](../../references/design-widgets.md) (Chart / Metric / Table Card bases), and
+[references/design-components.md](../../references/design-components.md) (Tab / Dropdown / Pill primitives). This
 playbook only documents screener-unique rules on top of them — never re-spec
 a token or base that already exists.
 

--- a/skills/alva/templates/thesis/template.md
+++ b/skills/alva/templates/thesis/template.md
@@ -5,10 +5,10 @@ Reference structure for any narrative-driven thematic thesis tracker (defense, A
 ## Design System Compliance (READ FIRST)
 
 Before writing HTML, read from the Alva skill:
-- `references/design-system.md` -- `.playbook-container` rule verbatim (max-width 2048px, 28px horizontal padding)
-- `references/design-widgets.md` -- **Chart Card / Metric Card / Table Card / Free Text Card / Feed Card** bases. Every surface in this template maps to one of these widgets; do not invent new card types or re-style widget internals.
-- `references/design-components.md` -- **Tab** (Underline / Pill), **Modal**, **Dropdown**, **Markdown** primitives.
-- `references/design-tokens.css` -- use spacing/color tokens as-is, do NOT override.
+- [references/design-system.md](../../references/design-system.md) -- `.playbook-container` rule verbatim (max-width 2048px, 28px horizontal padding)
+- [references/design-widgets.md](../../references/design-widgets.md) -- **Chart Card / Metric Card / Table Card / Free Text Card / Feed Card** bases. Every surface in this template maps to one of these widgets; do not invent new card types or re-style widget internals.
+- [references/design-components.md](../../references/design-components.md) -- **Tab** (Underline / Pill), **Modal**, **Dropdown**, **Markdown** primitives.
+- [references/design-tokens.css](../../references/design-tokens.css) -- use spacing/color tokens as-is, do NOT override.
 
 This template shares its shell (tab bar + README chip + methodology modal) with the screener template. Where screener has already specified a pattern, **reference `templates/screener/template.md` rather than re-specing it** -- matching surfaces must stay visually identical across playbook families.
 

--- a/skills/alva/templates/what-if/template.md
+++ b/skills/alva/templates/what-if/template.md
@@ -10,9 +10,9 @@ For "what-if I bought/sold X when Y happens" analysis.
 
 Before writing HTML, read from the Alva skill:
 
-- `references/design-system.md` — copy `.playbook-container` rule verbatim (max-width 2048px, 28px horizontal padding)
-- `references/design-widgets.md` — metric cards / charts / tables specs
-- `references/design-tokens.css` — use spacing/color tokens as-is, do NOT override
+- [references/design-system.md](../../references/design-system.md) — copy `.playbook-container` rule verbatim (max-width 2048px, 28px horizontal padding)
+- [references/design-widgets.md](../../references/design-widgets.md) — metric cards / charts / tables specs
+- [references/design-tokens.css](../../references/design-tokens.css) — use spacing/color tokens as-is, do NOT override
 
 **Do NOT** apply `design-playbook-trading-strategy.md` — that doc is for trading-strategy dashboards with Overview/Analytics/Strategy/Feed tabs. What-if is a narrative, not a dashboard.
 


### PR DESCRIPTION
## Summary
- Convert ``references/*`` inline-code mentions in the "Design System Compliance (READ FIRST)" section of screener, thesis, and what-if templates into real relative markdown links (`../../references/...`).
- Readers can now click through to the referenced files instead of eyeballing paths.

## Test plan
- [ ] Open each template in a markdown viewer and confirm links resolve to the correct `skills/alva/references/*` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)