### PR TITLE
[jaxxjj] docs(alva): drop --changelog flag from playbook-draft

### DIFF
--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -45,7 +45,7 @@ alva release feed --name btc-ema --version 1.0.0 --cronjob-id 42 \
 ## Create Playbook Draft
 
 ```
-alva release playbook-draft --name NAME --display-name "Title" --feeds '[{"feed_id":100}]' [--changelog "text"] [--description TEXT] [--trading-symbols '["BTC"]']
+alva release playbook-draft --name NAME --display-name "Title" --feeds '[{"feed_id":100}]' [--description TEXT] [--trading-symbols '["BTC"]']
 ```
 
 Create a new playbook with a draft version.
@@ -57,7 +57,6 @@ Requires both a URL-safe `name` and a human-readable `display-name`.
 | --name | string | yes | URL-safe playbook name (e.g. `btc-dashboard`), must be unique per user |
 | --display-name | string | yes | Human-readable playbook title, max 40 chars |
 | --feeds | array | yes | Feed references `[{feed_id, feed_major?}]` |
-| --changelog | string | no | Release changelog (optional; first-create can omit) |
 | --description | string | no | Short description of the playbook |
 | --trading-symbols | string[] | no | Base asset tickers (e.g. `["BTC","ETH"]`). Resolved server-side to full trading pairs, stored in playbook metadata. Max 50. |
 
@@ -68,8 +67,6 @@ Requires both a URL-safe `name` and a human-readable `display-name`.
 - Avoid personal markers such as `My`, `Test`, or `V2`
 - Avoid generic-only titles such as `Stock Dashboard` or `Trading Bot`
 - If the user provides `display-name`, use it and normalize any non-compliant parts
-
-First-time drafts may omit `--changelog`; subsequent calls overwrite the prior note if supplied, or preserve it if omitted.
 
 ``` bash
 alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashboard" --description "BTC market dashboard with price, technicals, and volume" --feeds '[{"feed_id": 100}]' --trading-symbols '["BTC"]'
@@ -84,6 +81,8 @@ alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' 
 
 Release an existing playbook for public hosting. Reads the playbook HTML from
 `'~/playbooks/{name}/index.html'` (ALFS — quote in CLI) and uploads it to CDN.
+
+Changelog lives on the release, not the draft — set it when publishing.
 
 | Flag        | Type   | Required | Description                                 |
 | ----------- | ------ | -------- | ------------------------------------------- |


### PR DESCRIPTION
## Summary

Update `skills/alva/references/api/release.md` to remove `--changelog` flag from the `playbook-draft` subcommand synopsis + field table, plus the misleading "first-time drafts may omit..." paragraph. `alva release playbook --changelog "..."` (the release command) keeps the flag — that is the single source of changelog.

Aligns agent-facing CLI docs with the backend refactor: playbook changelog is release-only (git-tag model), no longer stored on draft rows.

## Breaking Changes

None (docs-only). CLI flag removal itself happens in the external alva CLI repo; once that ships, this doc matches reality. In the interim, agents following this doc won't attempt a flag the backend already ignores.

## Database Migrations

None.

## Merge Order

Independent. Can merge any time.

## Related

- alva-ai/alva-backend#794 — backend refactor (primary)
- alva-ai/alva-gateway#282 — gateway companion
- External: alva CLI flag removal (separate repo, user-coordinated)

## Test Plan

- [x] `grep -n changelog skills/alva/references/api/release.md` — all remaining mentions are in the `alva release playbook` section (lines 79, 92, 102)
- [x] `playbook-draft` section has zero `changelog` mentions
- [x] Doc reads coherently end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)