### PR TITLE
[jaxxjj] docs(alva): alfs paths in REST responses + notifications API

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -733,6 +733,7 @@ Reference docs:
 - [Playbook Comments](references/api/playbook-comment.md) — `alva comments`
 - [Screenshot](references/api/screenshot.md) — `alva screenshot`
 - [Trading](references/api/trading.md) — `alva trading`
+- [Notifications](references/api/notifications.md) — `alva notifications`
 - [Error Responses](references/api/error-responses.md)
 
 ---

--- a/skills/alva/references/api/notifications.md
+++ b/skills/alva/references/api/notifications.md
@@ -1,0 +1,74 @@
+# Notifications
+
+Read the caller's notification history scoped to a playbook or feed.
+Cursor pagination over `(created_at, id)`.
+
+## List Playbook Notifications
+
+```bash
+alva notifications list-playbook --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
+```
+
+Returns notifications sent to the caller for `(username, name)`. The
+playbook must be `public` or `paid`.
+
+| Flag       | Type   | Required | Description                                |
+| ---------- | ------ | -------- | ------------------------------------------ |
+| --username | string | yes      | Playbook owner's username                  |
+| --name     | string | yes      | URL-safe playbook name                     |
+| --channel  | string | no       | `telegram` / `web` / ...                   |
+| --status   | string | no       | `sent` / `failed` / `filtered`             |
+| --since    | int64  | no       | Unix seconds; only newer than this         |
+| --first    | int32  | no       | Page size, default 50, max 200             |
+| --cursor   | string | no       | Token from previous page's `next_cursor`   |
+
+Response:
+
+| Field         | Type   | Description                                                |
+| ------------- | ------ | ---------------------------------------------------------- |
+| items         | array  | Notification rows                                          |
+| next_cursor   | string | Token for the next page; empty when done                   |
+| playbook_path | string | `/alva/home/<username>/playbooks/<name>`                   |
+
+Each row:
+
+| Field       | Type   | Description                                          |
+| ----------- | ------ | ---------------------------------------------------- |
+| id          | string | Notification ID                                      |
+| event_type  | string | E.g. `playbook_data_ready`, `feed_run_complete`      |
+| user_id     | string | Recipient user ID                                    |
+| channel     | string | Delivery channel                                     |
+| status      | string | `sent` / `failed` / `filtered`                       |
+| created_at  | int64  | Unix seconds                                         |
+| message     | string | Rendered body (omitted if empty)                     |
+| error_msg   | string | Delivery error (only when `status == "failed"`)      |
+| playbook_id | string | Present when notification is playbook-scoped         |
+| feed_id     | string | Present when notification is feed-scoped             |
+
+```bash
+alva notifications list-playbook --username alice --name btc-dashboard --first 5
+# → {
+#     "items": [{"id":"24463","event_type":"feed_run_complete","status":"sent",
+#                "created_at":1777355703,"message":"...","feed_id":"8117", ...}, ...],
+#     "next_cursor": "MTc3NzM1NTU4MjIzOTc5NzoyNDQ1OA==",
+#     "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"
+#   }
+```
+
+## List Feed Notifications
+
+```bash
+alva notifications list-feed --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
+```
+
+Same shape as above, scoped to a feed. Authorization is alfs read on
+`/alva/home/<username>/feeds/<name>`. Response uses `feed_path`
+instead of `playbook_path`.
+
+```bash
+alva notifications list-feed --username alice --name btc-ema --first 5 --status sent
+# → {"items": [...], "next_cursor": "...", "feed_path": "/alva/home/alice/feeds/btc-ema"}
+```
+
+`NOT_FOUND` covers both "slug doesn't exist" and "slug exists but
+caller can't see it" — by design (no namespace enumeration).

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -37,7 +37,7 @@ releasing.
 ```
 alva release feed --name btc-ema --version 1.0.0 --cronjob-id 42 \
   --description "Fetches BTC/USDT 1h klines from Binance and emits the 20-period EMA as a time series"
-→ {"feed_id": 100, "name": "btc-ema", "feed_major": 1}
+→ {"feed_id": 100, "name": "btc-ema", "feed_major": 1, "feed_path": "/alva/home/alice/feeds/btc-ema"}
 ```
 
 ## Release Playbook
@@ -70,7 +70,7 @@ Requires both a URL-safe `name` and a human-readable `display-name`.
 
 ``` bash
 alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashboard" --description "BTC market dashboard with price, technicals, and volume" --feeds '[{"feed_id": 100}]' --trading-symbols '["BTC"]'
-→ {"playbook_id": 99, "playbook_version_id": 200}
+→ {"playbook_id": 99, "playbook_version_id": 200, "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
 
 ## Release Playbook
@@ -100,7 +100,7 @@ Feed reference fields:
 
 ```
 alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release"
-→ {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html"}
+→ {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html", "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
 
 After a successful release, output the alva.ai playbook link to the user:

--- a/skills/alva/references/api/user-info.md
+++ b/skills/alva/references/api/user-info.md
@@ -12,8 +12,9 @@ Returns the authenticated user's profile.
 | username            | string | Username                                                       |
 | subscription_tier   | string | `"free"` or `"pro"`. Determines release flow and feature gates |
 | telegram_username   | string | Telegram username if connected, otherwise `null`               |
+| home_path           | string | Caller's alfs home directory (`/alva/home/<username>`)         |
 
 ```bash
 alva whoami
-# → {"id":1, "subscription_tier":"free", "telegram_username":"alice_tg", "username":"alice"}
+# → {"id":1, "subscription_tier":"free", "telegram_username":"alice_tg", "username":"alice", "home_path":"/alva/home/alice"}
 ```


### PR DESCRIPTION
## Summary

Companion to alva-gateway PR #292 (\`feat(gateway): include alfs paths in REST responses where applicable\`).

- \`api/release.md\`: \`feed_path\` / \`playbook_path\` shown in response examples for release/feed, draft/playbook, release/playbook.
- \`api/user-info.md\`: \`/me\` response includes \`home_path\`.
- \`api/notifications.md\` (new): documents \`alva notifications list-{playbook,feed}\` — endpoints existed but had no skill doc.
- \`SKILL.md\`: API ref index links the new file.

## Out of scope

- Playbook management (\`pause\`/\`resume\`/\`visibility\`/\`delete\`) and remix (\`resolve\`/\`parents\`/\`children\`) endpoints are also un- or under-documented; deferred.