### PR TITLE
feat(alva): add language reference for user-facing vocabulary

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -148,7 +148,11 @@ reading and writing rules.
 
 ## Communication
 
-No ALFS paths, API payloads, cronjob IDs, raw function names, internal jargon,
+**Vocabulary** — use the terms in [language.md](references/language.md) exactly.
+Key terms: **automation** (not "cronjob"), **feed**, **playbook**, **script**.
+Full definitions and "avoid" labels are in that file.
+
+No ALFS paths, API payloads, automation IDs, raw function names, internal jargon,
 or implementation details in user-facing responses. Say what it DOES, not how it
 works. These details are operating instructions for you, not content for the
 user.
@@ -712,6 +716,7 @@ already configured.
 | [search.md](references/search.md) | Content search SDKs: per-source usage, enrichment patterns, and gotchas for Twitter/X, news, Reddit, YouTube, podcasts, and web |
 | [secret-manager.md](references/secret-manager.md) | Secret upload, CRUD API, and runtime usage via `require("secret-manager")` |
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
+| [language.md](references/language.md) | Canonical user-facing vocabulary: automation, feed, playbook — and what to avoid |
 
 ---
 

--- a/skills/alva/references/language.md
+++ b/skills/alva/references/language.md
@@ -1,0 +1,39 @@
+# Language
+
+Canonical vocabulary for user-facing responses. Use these terms exactly —
+don't expose internal platform names, Unix infrastructure jargon, or
+implementation details. Consistent language is the point; don't drift into
+synonyms or technical equivalents.
+
+## Terms
+
+**Automation**
+A deployed, scheduled feed script that runs on Alva Cloud on a defined
+interval (e.g. every hour, every day). The user experiences this as a feed
+that updates automatically.
+_Avoid_: cronjob, cron job, scheduled job, deploy job.
+
+**Feed**
+A data pipeline on Alva Cloud that fetches, transforms, and stores financial
+data as a time series. Feeds are the data source for playbooks.
+_Avoid_: data feed script, pipeline job, worker, script.
+
+**Playbook**
+A hosted web app on Alva that visualizes feed data and delivers analysis or
+trading signals to the user and their followers.
+_Avoid_: app, report (unless the playbook is literally a report).
+
+**Script**
+JavaScript code that runs on Alva Cloud. Use this when explaining what the
+agent is building internally.
+_Avoid_: jagent script, V8 isolate, sandboxed runtime — these are
+implementation details invisible to the user.
+
+## Principles
+
+- **Say what it does, not how it works.** "Your automation runs every hour"
+  not "your cronjob executes on a 1h cron schedule."
+- **Expose outcomes, not mechanics.** "Your playbook updates automatically"
+  not "the cronjob triggers a feed run which writes to ALFS."
+- **CLI flags and API field names stay internal.** `--cronjob-id`, `cron_expression`,
+  `entry_path` — none of these appear in user-facing prose.


### PR DESCRIPTION
## Summary

- Adds `references/language.md` with canonical user-facing terms: **automation** (not "cronjob"), **feed**, **playbook**, **script** — each with explicit "avoid" labels
- Updates `Communication` section in `SKILL.md` to open with a vocabulary pointer and inline key rule (`automation`, not "cronjob")
- Adds `language.md` to the sub-documents reference table
- Internal technical docs (deployment.md, deploy-cronjob.md, etc.) are unchanged — they keep "cronjob" as the actual CLI/API vocabulary

Follows the same pattern as [mattpocock/skills improve-codebase-architecture](https://github.com/mattpocock/skills/blob/main/skills/improve-codebase-architecture/SKILL.md): define a glossary that governs external output rather than doing a bulk find-replace across all documents.

## Test plan

- [ ] Verify `references/language.md` renders correctly
- [ ] Check `SKILL.md` Communication section links to `language.md`
- [ ] Confirm internal reference docs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)