### PR TITLE
docs(alva): point AI Digest template at example HTML, tighten alvaask scaffold

### DIFF
--- a/skills/alva/templates/ai-digest/example/index.html
+++ b/skills/alva/templates/ai-digest/example/index.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>AI Chip Supply Chain — Notification Playbook</title>
+<link rel="stylesheet" href="https://alva-ai-static.b-cdn.net/design-system/design-tokens.css" />
+<script src="https://cdn.jsdelivr.net/npm/markdown-it@13/dist/markdown-it.min.js"></script>
+<style>
+  /* ── @font-face (Fix #1: load Delight from CDN) ── */
+  @font-face {
+    font-family: "Delight";
+    src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf") format("truetype");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: "Delight";
+    src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Medium.ttf") format("truetype");
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  html { height:100%; overflow:hidden; }
+  body {
+    height:100%; overflow-y:auto; overflow-x:hidden;
+    margin:0; background:var(--b0-page); color:var(--text-n9);
+    font-family:"Delight", -apple-system, BlinkMacSystemFont, "OPPO Sans 4.0", sans-serif;
+    -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+    text-rendering:optimizeLegibility;
+  }
+  body.modal-open { overflow: hidden; }
+  * {
+    box-sizing: border-box;
+    -ms-overflow-style:none; scrollbar-width:none;
+  }
+  *::-webkit-scrollbar { display:none; }
+
+  strong, b { font-weight: 500; }
+
+  /* ── Fix #2: container top padding → --spacing-xs ── */
+  .playbook-container {
+    width:100%; max-width:980px; margin:0 auto;
+    padding: var(--spacing-xs) var(--spacing-xxl) var(--spacing-xxxxl);
+  }
+  @media (max-width: 768px) {
+    .playbook-container { padding: var(--spacing-m); }
+  }
+
+  /* ── Topic meta row (single header bar) ── */
+  .topic-meta-row {
+    display:flex; flex-wrap:wrap; gap:var(--spacing-xs);
+    align-items:center; margin-bottom:var(--spacing-l);
+  }
+  .topic-meta-spacer { flex: 1 1 auto; min-width: 0; }
+
+  /* README chip — secondary, tab-bar style */
+  .readme-btn {
+    display: inline-flex; align-items: center; gap: var(--spacing-xxs);
+    height: 24px;
+    padding: var(--spacing-xxxs) var(--spacing-xs);
+    background: var(--b-r02);
+    border: 0.5px solid var(--line-l2);
+    border-radius: var(--radius-ct-s);
+    font-family: inherit;
+    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
+    color: var(--text-n9); cursor: pointer;
+    transition: background .15s, border-color .15s;
+  }
+  .readme-btn:hover,
+  .readme-btn:active {
+    background: var(--b-r03);
+    border-color: var(--line-l9);
+  }
+  .readme-btn-icon {
+    width: 14px; height: 14px; flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg") center / contain no-repeat;
+            mask: url("https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg") center / contain no-repeat;
+  }
+  .pill {
+    display:inline-flex; align-items:center; gap:var(--spacing-xxs);
+    padding:2px var(--spacing-s); border-radius: var(--radius-ct-s);
+    font-size:12px; line-height:20px;
+  }
+  .pill.source { background: var(--b-r05); color: var(--text-n7); }
+  .pill.cadence { background: var(--main-m1-10); color: var(--main-m1); }
+
+  /* ── Subscribe button (primary CTA) ── */
+  .subscribe-cta {
+    display:inline-flex; align-items:center; justify-content:center; gap:6px;
+    height: 32px; padding: 6px var(--spacing-m);
+    background: var(--main-m1); color: var(--b-common-white);
+    border: none; border-radius: var(--radius-btn-s);
+    font-family: inherit; font-weight: 500;
+    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
+    cursor: pointer; text-decoration: none;
+    transition: all 0.2s ease-in-out;
+  }
+  .subscribe-cta:hover { background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.1)); }
+  .subscribe-cta:active { background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)); }
+
+  /* ── Timeline ── */
+  .day-separator {
+    display:flex; align-items:center; gap: var(--spacing-m);
+    margin: var(--spacing-xl) 0;
+  }
+  .day-separator::before, .day-separator::after {
+    content:''; flex:1; height:1px; background: var(--line-l07);
+  }
+  .day-separator-label {
+    font-size:11px; text-transform:uppercase; letter-spacing:0.5px;
+    color: var(--text-n5);
+  }
+
+  /* ── Fix #3 & #4 & #5: widget-card structure, no border, grey-g01 bg ── */
+  .widget-card {
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: visible;
+  }
+
+  .notif-card {
+    background: var(--grey-g01);
+    border: none;
+    border-radius: var(--radius-ct-s);
+    padding: var(--spacing-l) var(--spacing-xl);
+    margin-bottom: var(--spacing-xl);
+    transition: background .15s;
+  }
+  .notif-card:hover { background: var(--b-r02); }
+  .notif-card-header {
+    display:flex; align-items:center; gap: var(--spacing-s);
+    font-size:12px; color: var(--text-n5);
+    margin-bottom: var(--spacing-s);
+  }
+  .notif-time { font-variant-numeric: tabular-nums; }
+  .notif-status {
+    display: inline-flex; align-items: center; gap: var(--spacing-xxs);
+    margin-left: auto;
+  }
+  .notif-status-dot { width:8px; height:8px; border-radius:50%; }
+  .status-pushed { background: var(--main-m3); }
+  .status-skipped { background: var(--text-n3); }
+  .notif-mode { text-transform: lowercase; letter-spacing: 0.12px; }
+  .notif-push-line {
+    font-family: 'Delight', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
+    font-weight: 500; color: var(--text-n9);
+    margin: 0 0 var(--spacing-s); padding-top: 2px;
+  }
+  /* Citation pill — override markdown-container link styles */
+  .notif-body .cite-ref {
+    color: var(--main-m1); margin-left: 2px;
+    font-size: 11px; vertical-align: super; line-height: 1;
+    text-decoration: none;
+  }
+  .notif-body .cite-ref::after { display: none; }
+  .notif-body .cite-ref:hover { color: var(--main-m1); text-decoration: underline; }
+
+  .notif-cite-row {
+    margin-top: var(--spacing-s); padding-top: var(--spacing-s);
+    border-top: 1px solid var(--line-l05);
+  }
+  .notif-sources-toggle {
+    background:transparent; border:none; cursor:pointer;
+    font-size:12px; color: var(--text-n5); padding:0;
+    font-family: inherit;
+    display:inline-flex; align-items:center; gap: var(--spacing-xxs);
+  }
+  .notif-sources-toggle:hover { color: var(--main-m1); }
+  .notif-sources-arrow {
+    width: 12px; height: 12px; flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/arrow-right-l2.svg") center / contain no-repeat;
+            mask: url("https://alva-ai-static.b-cdn.net/icons/arrow-right-l2.svg") center / contain no-repeat;
+  }
+  .notif-sources-toggle[aria-expanded="true"] .notif-sources-arrow {
+    -webkit-mask-image: url("https://alva-ai-static.b-cdn.net/icons/arrow-down-l2.svg");
+            mask-image: url("https://alva-ai-static.b-cdn.net/icons/arrow-down-l2.svg");
+  }
+  .notif-matches {
+    margin-top: var(--spacing-s); display:flex; flex-direction:column;
+    gap: var(--spacing-xxs); font-size:12px;
+  }
+  .notif-matches.hidden { display:none; }
+  .match-row {
+    display:grid; grid-template-columns: 76px 1fr auto;
+    gap: var(--spacing-s); align-items:center;
+    padding: var(--spacing-xxs) var(--spacing-s);
+    margin: 0 calc(-1 * var(--spacing-s));
+    border-radius: var(--radius-ct-s);
+    text-decoration:none; color: var(--text-n7);
+    transition: background .15s;
+  }
+  .match-row:hover { background: var(--b-r02); color: var(--text-n9); }
+  .match-source {
+    display:inline-flex; align-items:center; gap: var(--spacing-xxs);
+    font-size:10px; text-transform:uppercase; letter-spacing:0.5px;
+    color: var(--text-n5);
+  }
+  .match-source-icon {
+    width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0;
+    object-fit: cover; background: var(--b-r02);
+  }
+  .match-source-icon.no-radius { border-radius: 0; background: transparent; }
+  .match-title {
+    font-size:12px; line-height:18px;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+  }
+  .match-ts {
+    font-size:11px; color: var(--text-n5);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Skipped card — muted background, condensed padding ── */
+  .notif-card--skipped {
+    background: var(--b-r02);
+    padding: var(--spacing-s) var(--spacing-m);
+  }
+  .notif-card--skipped:hover { background: var(--b-r03); }
+  .notif-card--skipped .notif-push-line,
+  .notif-card--skipped .notif-body,
+  .notif-card--skipped .notif-cite-row { display: none; }
+  .notif-card--skipped .notif-card-header { color: var(--text-n3); margin-bottom: 0; }
+
+  .loading, .empty {
+    padding: var(--spacing-xxl) 0;
+    text-align:center; color: var(--text-n5); font-size: 13px;
+  }
+
+  .error-banner {
+    background: var(--main-m4-10, rgba(224,83,87,0.1));
+    color: var(--main-m4, #e05357);
+    padding: var(--spacing-s) var(--spacing-m);
+    border-radius: var(--radius-ct-s);
+    font-size: 12px; margin-bottom: var(--spacing-m);
+  }
+
+  /* ── README Modal ── */
+  .readme-modal {
+    position: fixed; inset: 0; z-index: 1000;
+    display: flex; align-items: center; justify-content: center;
+    padding: var(--spacing-m);
+  }
+  .readme-modal[hidden] { display: none; }
+  .readme-backdrop {
+    position: absolute; inset: 0;
+    background: rgba(10, 15, 24, 0.45); backdrop-filter: blur(2px);
+  }
+  .readme-dialog {
+    position: relative; max-width: 680px; width: 100%;
+    max-height: 85vh; overflow-y: auto;
+    background: var(--b0-container, #fff);
+    border-radius: var(--radius-ct-l);
+    box-shadow: var(--shadow-l, 0 16px 48px rgba(10,15,24,0.2));
+    padding: var(--spacing-xl) var(--spacing-xxl) var(--spacing-xxl);
+  }
+  .readme-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: var(--spacing-m);
+  }
+  .readme-title {
+    font-size: 18px; line-height: 26px; font-weight: 500;
+    color: var(--text-n9); margin: 0; letter-spacing: 0.18px;
+  }
+  .readme-close {
+    width: 18px; height: 18px; flex-shrink: 0;
+    border: none; background-color: var(--text-n9); padding: 0;
+    cursor: pointer;
+    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
+            mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
+    transition: opacity .15s ease;
+  }
+  .readme-close:hover { opacity: 0.6; }
+
+  /* ════════════════════════════════════════════════════════════
+     Alva Markdown — verbatim from design-components.md
+     ════════════════════════════════════════════════════════════ */
+  .markdown-container {
+    width: 100%;
+    display: flex; flex-direction: column;
+    gap: 16px;
+  }
+  .markdown-container * { box-sizing: border-box; }
+
+  /* Headings */
+  .markdown-container h1,
+  .markdown-container h2,
+  .markdown-container h3,
+  .markdown-container h4,
+  .markdown-container h5,
+  .markdown-container h6 {
+    font-family: 'Delight', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-weight: 500; font-style: normal;
+    color: var(--text-n9);
+    margin: 0; width: 100%;
+  }
+  .markdown-container h1,
+  .markdown-container h2 {
+    font-size: 20px; line-height: 30px; letter-spacing: 0.2px; padding-top: 8px;
+  }
+  .markdown-container h3 {
+    font-size: 18px; line-height: 28px; letter-spacing: 0.18px; padding-top: 4px;
+  }
+  .markdown-container h4,
+  .markdown-container h5,
+  .markdown-container h6 {
+    font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
+  }
+
+  /* Paragraph */
+  .markdown-container p {
+    font-family: 'Delight', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
+    color: var(--text-n9);
+    margin: 0; white-space: pre-wrap;
+  }
+
+  /* Lists */
+  .markdown-container ul,
+  .markdown-container ol {
+    display: flex; flex-direction: column; gap: 8px;
+    list-style: none; margin: 0; padding: 0;
+  }
+  .markdown-container li {
+    font-family: 'Delight', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 16px; line-height: 26px; letter-spacing: 0.16px;
+    color: var(--text-n9);
+    position: relative; padding-left: 24px;
+  }
+  .markdown-container ul > li::before {
+    content: ''; width: 5px; height: 5px; border-radius: 50%;
+    background: var(--text-n9);
+    position: absolute; left: 9.5px; top: 10.5px;
+  }
+  .markdown-container ol { counter-reset: md-ol; }
+  .markdown-container ol > li { counter-increment: md-ol; }
+  .markdown-container ol > li::before {
+    content: counter(md-ol) '.';
+    position: absolute; left: 0; top: 0;
+    width: 24px; text-align: center;
+    font-size: 16px; line-height: 26px;
+    color: var(--text-n9);
+  }
+
+  /* Code */
+  .markdown-container code,
+  .markdown-container pre {
+    background: var(--b-r02); border-radius: 2px;
+    font-family: 'JetBrains Mono', monospace;
+    color: var(--text-n7);
+  }
+  .markdown-container code {
+    display: inline-block; vertical-align: middle;
+    box-shadow: inset 0 0 0 1px var(--line-l07);
+    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
+    padding: 2px 8px; margin: 0 4px;
+  }
+  .markdown-container pre {
+    border: 1px solid var(--line-l07);
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
+    padding: 12px 16px; margin: 0; overflow-x: auto;
+  }
+  .markdown-container pre code {
+    display: inline; vertical-align: baseline;
+    font-size: inherit; line-height: inherit; letter-spacing: inherit;
+    box-shadow: none; padding: 0; margin: 0; background: none;
+  }
+
+  /* Inline emphasis */
+  .markdown-container em { font-style: italic; }
+  .markdown-container strong { font-weight: 500; }
+
+  /* Divider */
+  .markdown-container hr {
+    height: 1px; background: var(--line-l07);
+    border: none; margin: 4px 0;
+  }
+
+  /* Table */
+  .markdown-container table {
+    width: 100%; border-collapse: separate;
+    border-spacing: 16px 0; margin: 0 -16px;
+  }
+  .markdown-container th,
+  .markdown-container td {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line-l07);
+    font-family: 'Delight', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-weight: 400;
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
+    color: var(--text-n9); text-align: left;
+    max-height: 180px;
+  }
+  .markdown-container th {
+    color: var(--text-n7); padding-top: 0; padding-bottom: 12px;
+  }
+  .markdown-container tr:last-child td { border-bottom: none; }
+  .markdown-container td code { margin: 0; }
+
+  /* Link */
+  .markdown-container a {
+    color: var(--text-n7);
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-decoration-color: var(--text-n5);
+    text-decoration-thickness: 8%;
+    text-underline-offset: 30%;
+    text-decoration-skip-ink: none;
+    transition: color 0.15s ease;
+  }
+  .markdown-container a:hover {
+    color: var(--main-m1);
+    text-decoration-color: var(--main-m1);
+  }
+  .markdown-container a::after {
+    content: '';
+    width: 16px; height: 16px;
+    background: currentColor;
+    mask: url('https://alva-ai-static.b-cdn.net/icons/go-l.svg') center / contain no-repeat;
+    -webkit-mask: url('https://alva-ai-static.b-cdn.net/icons/go-l.svg') center / contain no-repeat;
+    display: inline-block; vertical-align: middle;
+    margin-left: 4px; flex-shrink: 0;
+  }
+
+  /* Medium size modifier */
+  .markdown-container--m { gap: 8px; }
+  .markdown-container--m h1 {
+    font-size: 18px; line-height: 28px; letter-spacing: 0.18px; padding-top: 2px;
+  }
+  .markdown-container--m h2 {
+    font-size: 16px; line-height: 26px; letter-spacing: 0.16px; padding-top: 2px;
+  }
+  .markdown-container--m h3 {
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px; padding-top: 0;
+  }
+  .markdown-container--m h4,
+  .markdown-container--m h5,
+  .markdown-container--m h6 {
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
+  }
+  .markdown-container--m p,
+  .markdown-container--m li {
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
+  }
+  .markdown-container--m li { padding-left: var(--spacing-l); }
+  .markdown-container--m ul > li::before { left: 7.5px; top: 8.5px; }
+  .markdown-container--m ol > li::before {
+    font-size: 14px; line-height: 22px; width: 20px;
+  }
+  .markdown-container--m ul,
+  .markdown-container--m ol { gap: 4px; }
+  .markdown-container--m th,
+  .markdown-container--m td {
+    font-size: 14px; line-height: 22px; letter-spacing: 0.14px;
+    padding: 10px 8px;
+  }
+  .markdown-container--m code { padding: 1px 8px; }
+  .markdown-container--m pre {
+    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
+  }
+  .markdown-container--m a::after { width: 14px; height: 14px; }
+</style>
+</head>
+<body>
+<div class="playbook-container">
+
+
+  <div id="timeline">
+    <div class="loading">Loading timeline...</div>
+  </div>
+
+</div>
+
+<!-- ── README Modal ── -->
+<div class="readme-modal" id="readme-modal" hidden>
+  <div class="readme-backdrop" data-readme-close></div>
+  <div class="readme-dialog" role="dialog" aria-modal="true" aria-labelledby="readme-title">
+    <header class="readme-header">
+      <h2 id="readme-title" class="readme-title">About this playbook</h2>
+      <button class="readme-close" data-readme-close aria-label="Close"></button>
+    </header>
+    <div class="readme-body markdown-container markdown-container--m" id="readme-body"></div>
+  </div>
+</div>
+
+<script type="application/json" id="playbook-config">
+{
+  "topic": {
+    "name": "AI Chip Supply Chain",
+    "description": "Monitoring TSMC, SMIC, HBM memory, AI accelerator capacity, and delivery timelines. Emphasis on supply-chain disruption (sanctions, fires, geopolitics, capacity planning) rather than daily share-price moves."
+  },
+  "sources": [
+    { "type": "news",    "query": "TSMC OR SMIC OR HBM memory OR AI chip supply", "lookback_hours": 24 },
+    { "type": "social",  "query": "TSMC capacity OR SMIC sanctions OR HBM shortage", "lookback_hours": 24 },
+    { "type": "podcast", "query": "semiconductor supply chain", "lookback_hours": 168 }
+  ],
+  "cadence": { "mode": "digest", "cron": "0 12 * * *", "quiet_day_policy": "ping" },
+  "audience": "followers",
+  "angle": "Focus on macro supply-chain disruption and capacity signals. Opinionated — tell the reader what to watch next, not just what happened. Every factual claim must cite its source. No buy/sell/price targets.",
+  "output_style": { "length": "medium", "tone": "opinionated", "must_cite": true, "model": "claude-sonnet-4-6" },
+  "relevance_filter": { "mode": "hybrid", "semantic_model": "claude-haiku-4-5", "batch_size": 15 },
+  "dedupe_window_hours": 48
+}
+</script>
+
+<script>
+(async function () {
+  const md = window.markdownit({ html: true, linkify: true, breaks: false });
+  const USERNAME = "leoz";
+  const FEED_PATH = `/alva/home/${USERNAME}/feeds/ai-chip-supply-chain-deep/v1/data/notifications/events/@last/50`;
+  const endpoint = (typeof ALVA_ENDPOINT !== "undefined" && ALVA_ENDPOINT)
+    ? ALVA_ENDPOINT
+    : "https://api-llm.prd.alva.ai";
+  const url = `${endpoint}/api/v1/fs/read?path=${encodeURIComponent(FEED_PATH)}`;
+
+
+  // ── Timeline ──
+  const timelineEl = document.getElementById("timeline");
+  let events;
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    events = await resp.json();
+  } catch (e) {
+    timelineEl.innerHTML = `<div class="error-banner">Failed to load timeline: ${e.message}</div>`;
+    return;
+  }
+  if (!Array.isArray(events) || events.length === 0) {
+    timelineEl.innerHTML = `<div class="empty">No notifications yet. First fire at 12:00 UTC.</div>`;
+    return;
+  }
+  events.reverse();
+
+  function fmtEst(ms) {
+    const d = new Date(ms);
+    return d.toLocaleString("en-US", {
+      timeZone: "America/New_York",
+      hour: "numeric", minute: "2-digit", hour12: true,
+    }) + " ET";
+  }
+  function dayLabel(ms) {
+    const d = new Date(ms);
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const dd = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    if (dd === today) return "Today";
+    if (dd === today - 86400_000) return "Yesterday";
+    return d.toLocaleDateString("en-US", { weekday:"short", month:"short", day:"numeric" });
+  }
+  function fmtRelative(ms) {
+    const diff = Date.now() - ms;
+    const h = Math.floor(diff / 3600_000);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+  }
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+      "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;",
+    }[c]));
+  }
+  function sourceIcon(source, url) {
+    const s = String(source || "").toLowerCase();
+    if (s === "social" || s === "x" || s === "twitter") {
+      return { src: "https://alva-ai-static.b-cdn.net/icons/logo-feed-x.svg", noRadius: false };
+    }
+    if (s === "podcast") {
+      return { src: "https://alva-ai-static.b-cdn.net/icons/logo-social-podcast.svg", noRadius: false };
+    }
+    if (s === "youtube") {
+      return { src: "https://alva-ai-static.b-cdn.net/icons/logo-social-youtube.svg", noRadius: true };
+    }
+    if (s === "news") {
+      try {
+        const host = new URL(url).hostname;
+        return { src: `https://www.google.com/s2/favicons?domain=${host}&sz=64`, noRadius: false };
+      } catch (e) { return { src: "", noRadius: false }; }
+    }
+    return { src: "", noRadius: false };
+  }
+  function renderBodyWithCites(body, citations) {
+    const citMap = new Map(citations.map(c => [c.ref, c]));
+    const html = md.render(body);
+    return html.replace(/\[(\d+)\]/g, (m, n) => {
+      const c = citMap.get(+n);
+      if (!c) return m;
+      const title = escapeHtml(`${c.source}: ${(c.claim || '').slice(0, 140)}`);
+      return `<a class="cite-ref" href="${c.url}" target="_blank" rel="noopener noreferrer" title="${title}">[${n}]</a>`;
+    });
+  }
+
+  let lastDay = null;
+  let html = "";
+  for (const ev of events) {
+    const label = dayLabel(ev.date);
+    if (label !== lastDay) {
+      html += `<div class="day-separator"><span class="day-separator-label">${label}</span></div>`;
+      lastDay = label;
+    }
+
+    const pushed = ev.delivery && ev.delivery.pushed;
+    const reason = ev.delivery && ev.delivery.reason;
+    if (!pushed) {
+      html += `<article class="widget-card notif-card notif-card--skipped">
+        <header class="notif-card-header">
+          <time class="notif-time">${fmtEst(ev.date)}</time>
+          <span class="notif-status">
+            <span class="notif-status-dot status-skipped"></span>
+            <span class="notif-mode">${ev.trigger_mode || "digest"} · skipped (${reason || "n/a"})</span>
+          </span>
+        </header>
+      </article>`;
+      continue;
+    }
+
+    const bodyHtml = renderBodyWithCites(ev.body || "", ev.citations || []);
+    const matches = ev.matches || [];
+    const matchesHtml = matches.slice(0, 20).map(m => {
+      const ic = sourceIcon(m.source, m.url);
+      const iconHtml = ic.src
+        ? `<img class="match-source-icon${ic.noRadius ? ' no-radius' : ''}" src="${ic.src}" alt="" onerror="this.style.visibility='hidden'">`
+        : "";
+      return `
+      <a class="match-row" href="${m.url}" target="_blank" rel="noopener noreferrer">
+        <span class="match-source">${iconHtml}<span>${m.source}</span></span>
+        <span class="match-title">${escapeHtml(m.title)}</span>
+        <time class="match-ts">${fmtRelative(m.ts)}</time>
+      </a>`;
+    }).join("");
+
+    html += `<article class="widget-card notif-card">
+      <header class="notif-card-header">
+        <time class="notif-time">${fmtEst(ev.date)}</time>
+        <span class="notif-status">
+          <span class="notif-status-dot status-pushed"></span>
+          <span class="notif-mode">${ev.trigger_mode || "digest"} · pushed</span>
+        </span>
+      </header>
+      <h2 class="notif-push-line">${escapeHtml(ev.push_line || "")}</h2>
+      <div class="notif-body markdown-container markdown-container--m">${bodyHtml}</div>
+      <footer class="notif-cite-row">
+        <button class="notif-sources-toggle" type="button" aria-expanded="false" onclick="const m=this.nextElementSibling; m.classList.toggle('hidden'); this.setAttribute('aria-expanded', String(!m.classList.contains('hidden')));">
+          <span>Sources (${matches.length})</span>
+          <span class="notif-sources-arrow" aria-hidden="true"></span>
+        </button>
+        <div class="notif-matches hidden">${matchesHtml}</div>
+      </footer>
+    </article>`;
+  }
+  timelineEl.innerHTML = html;
+})();
+</script>
+</body>
+</html>

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -12,7 +12,7 @@ replay** of past pushes — not an analytical dashboard.
 > **Highest-priority standard — strictly follow. Template iterates; always
 > work from the latest version of this file.**
 
-Gotchas that bite first-time implementors are codified in §14.1 "Known
+Gotchas that bite first-time implementors are codified in §14.7 "Known
 platform quirks" — scan that table before writing code.
 
 ---
@@ -36,6 +36,26 @@ design system — never re-spec a token or base that already exists.
 
 ---
 
+## 0.1 Reference implementation (start here)
+
+A working timeline UI lives at `example/index.html` next to this file —
+**copy it directly.** Change `USERNAME` + `FEED_PATH` + `playbook-config`
+JSON + the title; leave the rest. It already encodes the design system,
+markdown-it body rendering, README modal, source-icon resolver, day
+separators, and pushed/skipped cards. §10 and §11 only document what's
+AI Digest-unique on top — do not re-derive the layout from them.
+
+The feed-side scaffold lives in §14, built around a single
+`@alva/alvaask` call with live-search tools (the model does its own
+fetch + relevance + grounding, guided by a strict prompt). §6–§9 are
+the behavior contract; §14 shows the smallest shape that satisfies it.
+
+The §7 multi-stage pipeline is still valid for cases where you need
+explicit source adapters or upstream feeds — pick whichever fits your
+sources, but ship the §14 shape unless you have a reason to fork.
+
+---
+
 ## Component Index
 
 Read in this order:
@@ -56,7 +76,7 @@ Read in this order:
 - [Push plumbing](#9-push-plumbing) — deterministic payload derivation.
 - [Page Layout](#10-page-layout) and [Components](#11-components-ai-digest-unique)
   — feed-first timeline UI.
-- [Hard Rules](#13-hard-rules) and [Known platform quirks](#141-known-platform-quirks-v1-test-findings-codified)
+- [Hard Rules](#13-hard-rules) and [Known platform quirks](#147-known-platform-quirks-v1-test-findings-codified)
   — scan before implementation.
 
 ---
@@ -828,202 +848,54 @@ for followers, `alva release feed` is mandatory or pushes arrive empty.
 
 ## 10. Page Layout
 
-**Single vertical scroll.** No tabs. No filters. No snapshot picker. The
-timeline *is* the navigation.
+**Use `example/index.html` directly.** It's the canonical layout; do not
+re-derive it from this section.
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│ ─── Today ───────────────────────────────────────────        │
-│ ┌─────────────────────────────────────────────┐              │
-│ │ 12:00 EST · 🟢 pushed · digest              │              │
-│ │ ## <push_line>                              │              │
-│ │ <body rendered as markdown>                 │              │
-│ │ <citations row: [1] [2] [3] …>              │              │
-│ │ Sources ⌄                                   │              │
-│ └─────────────────────────────────────────────┘              │
-│                                                              │
-│ ─── Yesterday ───────────────────────────────────            │
-│ ┌ 12:00 EST · ⚪ skipped (quiet day) ⌄ ┐                     │
-│ └────────────────────────────────────────┘                   │
-│                                                              │
-│ … Load more (infinite scroll or explicit button)             │
-└──────────────────────────────────────────────────────────────┘
-```
+The rules the example already encodes — keep them when you adapt:
 
-- Container: `.playbook-container` from `design-system.md` (no re-spec).
-- Reverse chronological; today on top, load older on scroll.
-- Read `digest/events/@last/50` on initial render; paginate with
-  additional `@last/N` reads.
-- **No live recomputation.** The HTML is a view over stored records — if
-  nothing in the feed changed, the page renders identically.
-- **No in-page header chrome.** Do not add a template-owned topic header,
-  source-pill row, cadence badge, README button, or methodology block before
-  the feed. The outer playbook shell owns title, subscription, and metadata
-  surfaces. If methodology is needed, expose it through that secondary surface,
-  not above the timeline.
+- Single vertical scroll. No tabs, filters, or snapshot picker. The
+  timeline *is* the navigation.
+- Container: `.playbook-container` on top of `design-tokens.css`.
+- Reverse chronological; today on top, older days below; day separators
+  in EST (`Today` / `Yesterday` / `Mon, Apr 14`).
+- Read `<group>/<doc>/@last/N` on initial render (example uses
+  `notifications/events/@last/50`). No live recomputation — the HTML is
+  a view over stored records.
+- No in-page header chrome above the feed. The outer playbook shell owns
+  title, subscription, and metadata. If you need methodology, render it
+  through the README modal already wired in `example/index.html`, not as a
+  banner above the timeline.
+
+To adapt: change `USERNAME`, `FEED_PATH`, `<title>`, and the
+`#playbook-config` JSON block. Leave the rest.
 
 ---
 
 ## 11. Components (AI Digest-unique)
 
-Everything else reuses the shared design system and `design-components.md` —
-do not re-spec markdown containers, pill primitives, or typography.
+The full markup and CSS for these components live in `example/index.html`.
+This section names them and notes the contract — don't re-spec the styles.
 
-### AI Digest Card
+- **Notification card** (`.notif-card`) — primary component, two states:
+  `pushed` (full body) and `skipped` (collapsed header). Both render from
+  the same event record.
+- **Cite refs** (`.cite-ref`) — inline `[N]` anchors generated by
+  replacing `[N]` markers in the rendered markdown body. Hover tooltip
+  shows `citations[N].source` + `claim`; link to `citations[N].url` when
+  present.
+- **Sources toggle** (`.notif-sources-toggle` / `.notif-matches`) — click
+  to expand the match list under each pushed card.
+- **Match row** (`.match-row`) — grid: source icon + label, title, and
+  relative timestamp. Source-icon resolver (`sourceIcon()` in
+  `example/index.html`) handles X/podcast/youtube/news favicons.
+- **Day separator** (`.day-separator`) — one per calendar day (EST).
+- **README modal** (`.readme-modal`) — methodology surface for the
+  outer shell to open. Body content can be derived from
+  `#playbook-config` JSON (topic, sources, cadence, angle, models).
 
-The primary component. Two states: `pushed` (full body) and `skipped`
-(collapsed header only). Both render from the same `digest/events`
-record.
-
-```html
-<article class="digest-card digest-card--pushed">
-  <header class="digest-card-header">
-    <time class="digest-time">12:00 EST</time>
-    <span class="digest-status-dot status-pushed"></span>
-    <span class="digest-mode">digest</span>
-  </header>
-  <h3 class="digest-push-line">{{push_line}}</h3>
-  <div class="digest-body markdown-container --m">{{rendered body with [N] anchors}}</div>
-  <footer class="digest-cite-row">
-    <button class="digest-sources-toggle">Sources <span class="caret">⌄</span></button>
-    <div class="digest-matches hidden">…match list…</div>
-  </footer>
-</article>
-```
-
-The rendered body replaces each `[N]` marker with an inline anchor:
-
-```html
-<sup class="cite-ref" data-ref="1" tabindex="0">[1]</sup>
-```
-
-On hover / focus, a popover shows `citations[N].source` + `claim`; link to
-`citations[N].url` only when present. For structured facts, show
-`citations[N].source_ref` instead. Keyboard-accessible via `tabindex`.
-
-```css
-.digest-card { background: var(--b0-container); border: 0.5px solid var(--line-l2);
-  border-radius: var(--radius-ct-l); padding: var(--spacing-l) var(--spacing-xl);
-  margin-bottom: var(--spacing-m); transition: border-color .15s; }
-.digest-card:hover { border-color: var(--line-l07); }
-.digest-card-header { display:flex; align-items:center; gap: var(--spacing-s);
-  font-size:12px; color: var(--text-n5); margin-bottom: var(--spacing-s); }
-.digest-time { font-variant-numeric: tabular-nums; }
-.digest-status-dot { width:8px; height:8px; border-radius:50%; }
-.status-pushed  { background: var(--main-m3); }
-.status-skipped { background: var(--text-n3); }
-.digest-mode { text-transform: lowercase; letter-spacing: 0.12px; }
-
-.digest-push-line { font-size:16px; line-height:24px; font-weight:500;
-  color: var(--text-n9); margin: 0 0 var(--spacing-s); letter-spacing: 0.16px; }
-
-.digest-body { font-size:14px; line-height:22px; color: var(--text-n8);
-  letter-spacing: 0.14px; }
-.digest-body .cite-ref { color: var(--main-m1); margin-left:2px; cursor:pointer;
-  font-size:11px; vertical-align: super; line-height:1; }
-.digest-body .cite-ref:hover { text-decoration: underline; }
-
-.digest-cite-row { margin-top: var(--spacing-s); padding-top: var(--spacing-s);
-  border-top: 1px dashed var(--line-l07); }
-.digest-sources-toggle { background:transparent; border:none; cursor:pointer;
-  font-size:12px; color: var(--text-n5); padding:0; display:inline-flex;
-  align-items:center; gap: var(--spacing-xxs); }
-.digest-sources-toggle:hover { color: var(--main-m1); }
-.digest-matches { margin-top: var(--spacing-s); display:flex; flex-direction:column;
-  gap: var(--spacing-xxs); font-size:12px; }
-.digest-matches.hidden { display:none; }
-
-/* Skipped state: dimmed, collapsed to header only */
-.digest-card--skipped { background: transparent; border-style: dashed;
-  padding: var(--spacing-s) var(--spacing-m); }
-.digest-card--skipped .digest-push-line,
-.digest-card--skipped .digest-body,
-.digest-card--skipped .digest-cite-row { display: none; }
-.digest-card--skipped .digest-card-header { color: var(--text-n3); margin-bottom: 0; }
-.digest-card--skipped .digest-card-header::after {
-  content: attr(data-skip-reason); color: var(--text-n3);
-  font-size: 11px; margin-left: auto; }
-```
-
-### Match Popover
-
-On "Sources" click, toggle `.digest-matches.hidden`. Each row:
-
-```html
-<a class="match-row" href="{{match.url}}" target="_blank" rel="noopener">
-  <span class="match-source">news</span>
-  <span class="match-title">{{match.title}}</span>
-  <time class="match-ts">{{fmtRelative(match.ts)}}</time>
-</a>
-```
-
-```css
-.match-row { display:grid; grid-template-columns: 60px 1fr auto;
-  gap: var(--spacing-s); align-items:center;
-  padding: var(--spacing-xxs) var(--spacing-xs); border-radius: var(--radius-ct-s);
-  text-decoration:none; color: var(--text-n7); transition: background .15s; }
-.match-row:hover { background: var(--grey-g01); color: var(--text-n9); }
-.match-source { font-size:10px; text-transform:uppercase;
-  letter-spacing:0.5px; color: var(--text-n5); }
-.match-title { font-size:12px; line-height:18px;
-  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.match-ts { font-size:11px; color: var(--text-n5); font-variant-numeric: tabular-nums; }
-```
-
-### Day Separator
-
-One divider per calendar day (EST) — thin rule + day label. Today's
-separator reads `Today`; yesterday's `Yesterday`; older days `Mon, Apr 14`.
-
-```css
-.day-separator { display:flex; align-items:center; gap: var(--spacing-m);
-  margin: var(--spacing-xl) 0 var(--spacing-m); }
-.day-separator::before,
-.day-separator::after { content:''; flex:1; height:1px; background: var(--line-l07); }
-.day-separator-label { font-size:11px; text-transform:uppercase; letter-spacing:0.5px;
-  color: var(--text-n5); }
-```
-
-### About content (secondary surface only)
-
-If the outer playbook shell exposes an "about" or README surface, derive its
-content from `CONFIG`. Do not render this block above or below the main feed.
-
-```
-## About this playbook
-
-An AI Digest tracking <topic.name>.
-<topic.description>
-
-### Sources
-- **news** — <news source details>
-- **social** — <social source details>
-- **podcast** — <podcast source details>
-- (…)
-
-### Optional entities & enrichment
-Only render this section when `CONFIG.entities` or `CONFIG.enrichment` exists.
-- Entities: <entity aliases from CONFIG.entities>
-- Context facts: <enrichment sources and thresholds from CONFIG.enrichment / push_policy>
-
-### Cadence
-<humanized cron> · quiet-day policy: <quiet_day_policy> · dedupe: <dedupe_window_hours> h
-
-### Angle
-<angle verbatim>
-
-### How it works
-Every run: fetch → optionally enrich with Alva context facts → relevance filter
-(keyword + batched semantic yes/no) → dedupe against the configured window →
-materiality check → daily push-cap check → generate opinionated digest via
-<generation_model> → grounding check (every number traces to a match or
-optional context fact, every claim carries [N]) → write the configured delivery
-sidecar.
-
-### Models
-- Generation: `<generation_model>`
-- Relevance filter: `<relevance_model>` (batched 15 items / call)
-```
+Everything else reuses the shared design system and
+`design-components.md` (markdown container, pills, typography). Do not
+re-spec what those already provide.
 
 ---
 
@@ -1069,75 +941,109 @@ claim sub-minute delivery guarantees.
 
 ---
 
-## 14. Minimal feed-script scaffold
+## 14. Feed-script scaffold — single-call `@alva/alvaask`
 
-Reference shape — copy, trim, adapt. **No `FeedAltra`, no `@alva/adk`.**
-All LLM calls go through `@alva/alvaask`'s `ask()` (§8).
+The lowest-code AI Digest is **one `ask()` call per fire**: the model
+runs its own search, filters, and writes grounded JSON, guided by a
+strict prompt. Use this shape unless you need explicit source adapters
+or structured numbers (§14.3).
+
+### 14.1 The `ask()` contract
 
 ```javascript
-const { Feed, feedPath, makeDoc, str, num, bool, obj, arr, fld } = require("@alva/feed");
 const { ask } = require("@alva/alvaask");
-const http = require("net/http");
-const { getSerperSearch } = require("@arrays/data/search/serper-search:v1.0.0");
-const { searchGrokX }    = require("@arrays/data/search/search-grok-x:v1.0.0");
-
-const CONFIG = { /* … see §4 … */ };
-
-const feed = new Feed({ path: feedPath("<playbook-name>") });
-
-feed.def("digest", {
-  events: makeDoc("AI Digest Events", "One record per cron fire", [
-    obj("delivery", [bool("pushed"), str("reason")]),
-    obj("materiality", [bool("is_material"), str("reason")]),
-    str("push_line"),
-    str("body"),
-    arr("citations", [num("ref"), str("claim"), str("url"), str("source"), str("source_ref")]),
-    arr("matches", [str("source"), str("url"), str("title"), num("ts"), str("snippet"), fld("meta", "object")]),
-    // Optional §5 enrichment. Keep the field so event records stay stable;
-    // write [] in the lightweight default path.
-    arr("context_facts", [
-      str("ref_id"), str("source"), str("label"), str("value"),
-      num("ts"), str("evidence"), str("url"),
-    ]),
-    arr("dedupe_keys", [str("key")]),        // NOTE: wrapped; Feed SDK arr() can't take primitives
-    str("source"),
-  ]),
+const { text } = ask(userPrompt, {
+  system: "<persona + must-use-live-search + JSON-only>",
+  model: "claude-sonnet-4-6",   // full Alva ID; "sonnet" / dated IDs rejected
 });
-// When audience: "followers":
-feed.def("signal", {
-  targets: makeDoc("Signal Targets", "Push payload for followers", [
-    obj("instruction", [str("type"), arr("weights", [str("symbol"), num("weight")])]),
-    obj("meta", [str("reason")]),
-  ]),
-});
+```
+
+- **Synchronous.** Do not `await`. Parallelism = multiple call sites, not `Promise.all`.
+- **`text` is raw.** May come fenced as ```` ```json ```` or with stray prose. Extract tolerantly:
+  ```javascript
+  const fence = text.match(/```(?:json)?\s*\n([\s\S]*?)\n```/);
+  const parsed = JSON.parse(fence ? fence[1] : text);
+  ```
+- **Live search is on by default.** The system prompt MUST mandate tool use and forbid training-data recall — otherwise the digest silently cites year-old articles.
+- **No `@alva/adk`.** `ask()` is the only LLM path for this template (relevance batching in §7.2 and digest generation both).
+
+### 14.2 Prompt shape
+
+Five sections, in order: (1) ISO `now` + lookback window, (2) scope +
+named entities, (3) sourcing rules with **year discipline** — every
+`match.ts` must fall in the window; older items are disqualified even
+if topical, (4) exact JSON schema in a fenced code block with word
+budgets and citation discipline spelled out, (5) a final self-check
+("count words, verify citations are 1-indexed and contiguous"). The
+self-check goes last because models follow checklists best when they
+sit immediately before the output instruction.
+
+### 14.3 Server-side gates after `ask()`
+
+The model will sometimes cite stale items or repeat yesterday's news.
+Three gates run in JS before writing the record:
+
+1. **Freshness** — drop `match.ts < now - 48h`; if < 3 fresh remain, swap to a "quiet day" body.
+2. **Dedupe** — 7-day rolling `dedupe_keys` in `ctx.kv`. All-seen → write `delivery.pushed=false`, no push.
+3. **Throttle** — `lastRunMs` in `ctx.kv` short-circuits replays/double-deploys.
+
+### 14.4 Skeleton
+
+```javascript
+const { Feed, feedPath, makeDoc, str, num, bool, obj, arr } = require("@alva/feed");
+const { ask } = require("@alva/alvaask");
+
+const feed = new Feed({ path: feedPath("<your-playbook-name>") });
+feed.def("notifications", { events: makeDoc("AI Digest Events", "", [/* see example */]) });
+feed.def("signal",        { targets: makeDoc("Push Signal", "",      [/* see example */]) });
 
 (async () => {
   await feed.run(async (ctx) => {
-    const now = (ctx.args && ctx.args.now) ? Number(ctx.args.now) : Date.now();
+    const now = Date.now();
 
-    // 1. FETCH
-    const matches = await fetchAllSources(CONFIG.sources, now);
+    // throttle
+    const lastRun = Number(await ctx.kv.load("lastRunMs")) || 0;
+    if (lastRun && now - lastRun < 6 * 3600_000) return;
 
-    // 2. ENRICH  (optional; leave [] unless CONFIG.enrichment is enabled — see §5)
-    const contextFacts = CONFIG.enrichment
-      ? await enrichContextFacts(CONFIG.enrichment, now)
-      : [];
+    // one LLM call — model fetches, filters, grounds, writes JSON
+    const { text } = ask(buildPrompt(now), { system: SYSTEM_PROMPT, model: "claude-sonnet-4-6" });
+    const parsed = extractJson(text);
 
-    // 3. RELEVANCE FILTER  (batched ask() — see §7.2)
-    const relevant = matches.length
-      ? filterRelevanceBatch(matches, CONFIG.topic, CONFIG.relevance_model)
-      : [];
+    // freshness + dedupe gates (§14.3)
+    const fresh = (parsed.matches || []).filter(m => Number(m.ts) >= now - 48 * 3600_000);
+    const seen = JSON.parse((await ctx.kv.load("seenKeys")) || "{}");
+    const allOldDup = (parsed.dedupe_keys || []).length > 0
+      && (parsed.dedupe_keys || []).every(d => seen[d.key]);
+    const tooStale = fresh.length < 3;
+    if (tooStale) Object.assign(parsed, quietDayPayload());
 
-    // 4. DEDUPE  (ctx.self.ts(...).last(n), NOT .read({limit}))
-    const { newMatches, dedupeKeys } = await dedupe(ctx, relevant, now);
+    // always write event; push only when material
+    const record = { date: now, /* …push_line, body, citations, matches, dedupe_keys… */
+      delivery: { pushed: !allOldDup && !tooStale, reason: ... } };
+    await ctx.self.ts("notifications", "events").append([record]);
+    if (record.delivery.pushed) {
+      await ctx.self.ts("signal", "targets").append([{ date: now,
+        instruction: { type: "allocate", weights: [] },
+        meta: { reason: `${record.push_line}\n\n→ ${PLAYBOOK_URL}` } }]);
+    }
 
-    // 5-9. MATERIALITY + RATE LIMIT + GENERATE + GROUND + WRITE/DELIVER  (see §7.4, §8, §9)
-    await dispatch(ctx, { newMatches, contextFacts, dedupeKeys, now });
+    // persist dedupe + throttle
+    for (const d of parsed.dedupe_keys || []) seen[d.key] = now;
+    await ctx.kv.put("seenKeys", JSON.stringify(seen));
+    await ctx.kv.put("lastRunMs", String(now));
   });
 })();
 ```
 
-**Deploy (followers push):**
+### 14.5 When to leave the single-call shape
+
+Layer adapters in front of `ask()` and pass results as `INPUT_MATCHES` /
+`CONTEXT_FACTS` (§8) when you need: fixed-handle subscriptions web
+search misses (KOL feeds, subreddits, podcast RSS), structured Alva
+numbers that must be quoted verbatim (§5), or threshold watches where
+the trigger is a deterministic JS check.
+
+### 14.6 Deploy
 
 ```bash
 alva fs grant --path '~/feeds/<name>' --subject 'special:user:*' --permission read
@@ -1147,7 +1053,7 @@ alva release feed --name <name> --version 1.0.0 --cronjob-id <ID> \
   --description "<one-sentence playbook purpose>"
 ```
 
-### 14.1 Known platform quirks (v1 test findings, codified)
+### 14.7 Known platform quirks (v1 test findings, codified)
 
 Surface of practical issues that surprised v1 implementors — if any bite
 you during build, it's a template bug, not your bug.
@@ -1161,9 +1067,3 @@ you during build, it's a template bug, not your bug.
 | FeedAltra | Pure AI Digest feeds use plain `Feed` even when writing `signal/targets` (see §6). |
 | Outbound HTTP | Runtime's outbound proxy occasionally resets external fetches (iTunes, Serper). Wrap source adapters in a 1-retry loop; treat a failed source as "no matches", not fatal. |
 | SDK discovery | Always `alva sdk doc --name <module>` before writing a new source adapter. Function names drift (e.g. `getSerperSearch`, not `searchSerper`). |
-
-Full reference implementation will live in
-`templates/ai-digest/reference-playbook/` once the first real
-AI Digest ships — treat that as the living example, and update
-few-shot packs + the `dispatch` orchestration there rather than in this
-template file.


### PR DESCRIPTION
## Summary
- Add `alva/templates/ai-digest/example/index.html` — canonical timeline UI to copy directly (CDN design tokens, markdown-it, README modal, source-icon resolver, day separators, pushed/skipped cards). Adapt by changing `USERNAME` + `FEED_PATH` + `playbook-config` JSON.
- Collapse §10 (Page Layout) and §11 (Components) in `template.md` to short pointers at the example, keeping only AI-Digest-unique invariants and class-name contracts.
- Rewrite §14 as a self-contained `@alva/alvaask` showcase: `ask()` contract, prompt shape, JSON extraction, server-side gates (freshness/dedupe/throttle), minimal skeleton, when-to-fork into adapters, deploy commands. No longer depends on a separate feed example file.

## Test plan
- [ ] Markdown renders cleanly on GitHub (anchor links in Component Index resolve to renumbered §14.7)
- [ ] `example/index.html` opens in browser with placeholder username and shows the empty-state message
- [ ] Skim §0.1 + §10 + §11 + §14 to confirm there are no remaining references to a deleted `example/feed/src/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)