### PR TITLE
docs(alva): require NOW injection in cron-driven ask() prompts

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -541,13 +541,18 @@ reports, heartbeat monitoring, and proactive alerts. Write to
 `notify/message` (see [feed-sdk.md](references/feed-sdk.md) Pattern E):
 
 ```javascript
-const result = ask("Brief crypto market update with key levels.");
+const result = ask(
+  `Brief crypto market update with key levels.\n\nNOW: ${new Date().toISOString()}`,
+);
 await ctx.self.ts("notify", "message").append([{
   date: Date.now(),
   title: "Daily Briefing",
   text: result.text,
 }]);
 ```
+
+Cron-driven `ask()` must append `NOW: <ISO UTC>` so the model can anchor
+relative time words; for events >12h before NOW, prefer absolute dates.
 
 The platform reads `/data/notify/message/@last/1` and pushes `title` + `text`
 to the owner on all connected channels (Telegram, Discord, Web). No playbook

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -689,6 +689,8 @@ RULES
   acknowledgement; only cite facts you actually mention.
 - If INPUT_MATCHES and CONTEXT_FACTS are empty: write one short sentence
   acknowledging the quiet day, empty citations array.
+- Anchor relative time words to NOW; if an event is >12h before NOW, use
+  its absolute date instead of a relative frame.
 
 MATERIALITY
 <<MATERIALITY_JSON>>
@@ -698,6 +700,9 @@ INPUT_MATCHES   // relevance-filtered, deduped
 
 CONTEXT_FACTS   // optional structured Alva/BYOD/upstream facts from §5; [] by default
 <<CONTEXT_FACTS_JSON>>
+
+NOW
+  <<NOW_ISO_UTC>>
 
 Output strict JSON only, no preamble:
 {
@@ -718,8 +723,9 @@ Output strict JSON only, no preamble:
 const { ask } = require("@alva/alvaask");
 
 function generate({ newMatches, contextFacts, materiality }) {
+  const now = new Date().toISOString();
   const { text } = ask(
-    userBlock({ newMatches, contextFacts, materiality }),
+    userBlock({ now, newMatches, contextFacts, materiality }),
     { system: systemPrompt(), model: CONFIG.generation_model },
   );
   const clean = (text || "").replace(/^```(?:json)?\s*|\s*```$/gm, "").trim();


### PR DESCRIPTION
## Summary
- Pattern E `ask()` example in `SKILL.md` appends `NOW: <ISO UTC>`; one-line rule below the snippet mandates absolute dates for events >12h before NOW.
- AI Digest prompt skeleton gets a trailing `NOW` slot and a RULES bullet anchoring relative time words to it; `generate()` call site passes `now` into `userBlock`.

## Why
Closes alva-ai/eval-issues#325. Cron-driven playbooks (e.g. `intc-earnings-watch`) had no current-time anchor, so the model emitted "this morning" for an earnings event that fired the previous BMO — repeated across 8+ runs spanning two calendar days. NOW grounding + the >12h absolute-date rule removes the source of the self-contradicting "this morning (Apr 23)" framing.

## Test plan
- [ ] Re-deploy a cron-driven playbook using updated Pattern E snippet; confirm prompt now contains a `NOW:` line.
- [ ] Re-deploy an AI Digest-templated playbook; confirm rendered prompt skeleton includes the trailing `NOW` slot populated with ISO UTC.
- [ ] Spot-check a fresh cronjob run >24h after a referenced event resolves to absolute-date framing rather than "this morning".

🤖 Generated with [Claude Code](https://claude.com/claude-code)