### PR TITLE
chore(alva): update version to v1.7.0 in SKILL.md and refine JSON out…

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.6.5
+  version: v1.7.0
 ---
 
 # Alva

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -570,11 +570,11 @@ function filterRelevanceBatch(matches, topic, relevanceModel) {
       slice.map((m, j) =>
         `[${j}] title: ${m.title}\n    snippet: ${(m.snippet || "").slice(0, 200)}`
       ).join("\n\n") +
-      `\n\nReturn strict JSON only: {"answers": ["yes"|"no", ...]} — one per item, in order.`;
+      `\n\nReturn strict JSON only: {"answers": {"0": "yes"|"no", ..., "${slice.length - 1}": "yes"|"no"}} — keyed by the [n] index of each item.`;
     const { text } = ask(prompt, { model: relevanceModel });
     try {
       const { answers } = JSON.parse(text.replace(/^```(?:json)?\s*|\s*```$/g, ""));
-      slice.forEach((m, j) => { if (/^yes/i.test(answers[j] || "")) out.push(m); });
+      slice.forEach((m, j) => { if (/^yes/i.test(answers[String(j)] || "")) out.push(m); });
     } catch (e) {
       // On parse failure, pass through un-filtered — better than dropping everything.
       out.push(...slice);


### PR DESCRIPTION
…put format in AI Digest template

- Bumped the version number in SKILL.md to v1.7.0.
- Modified the AI Digest template to change the JSON output format, ensuring answers are keyed by their index for improved clarity and usability.

# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
