### PR TITLE
docs(alva): link design references in AI Digest template

### DIFF
--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -23,9 +23,9 @@ platform quirks" — scan that table before writing code.
 
 Before writing HTML, read from the Alva skill:
 
-- `references/design-tokens.css` — use spacing/color tokens as-is, do NOT override
-- `references/design-components.md` — Tab / Dropdown / Pill / Markdown primitives
-- `references/design-system.md` — `.playbook-container`, `.playbook-header` base rules
+- [`../../references/design-tokens.css`](../../references/design-tokens.css) — use spacing/color tokens as-is, do NOT override
+- [`../../references/design-components.md`](../../references/design-components.md) — Tab / Dropdown / Pill / Markdown primitives
+- [`../../references/design-system.md`](../../references/design-system.md) — `.playbook-container`, `.playbook-header` base rules
 
 **Do NOT** apply `design-playbook-trading-strategy.md` — that's for trading
 dashboards with Overview/Analytics/Strategy/Feed tabs. AI Digest is a


### PR DESCRIPTION
## Summary
- Convert the three `references/design-*` paths in §0 of the AI Digest template to real relative markdown links (`../../references/...`) so they're clickable from the rendered template.

## Test plan
- [x] Confirmed targets exist at `skills/alva/references/design-tokens.css`, `design-components.md`, `design-system.md`
- [ ] Verify links render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)