### PR TITLE
[codex] Fix AI Digest template contract and push TLDR

### DIFF
--- a/skills/alva/templates/ai-digest/example/index.html
+++ b/skills/alva/templates/ai-digest/example/index.html
@@ -31,7 +31,6 @@
     -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
     text-rendering:optimizeLegibility;
   }
-  body.modal-open { overflow: hidden; }
   * {
     box-sizing: border-box;
     -ms-overflow-style:none; scrollbar-width:none;
@@ -48,59 +47,6 @@
   @media (max-width: 768px) {
     .playbook-container { padding: var(--spacing-m); }
   }
-
-  /* ── Topic meta row (single header bar) ── */
-  .topic-meta-row {
-    display:flex; flex-wrap:wrap; gap:var(--spacing-xs);
-    align-items:center; margin-bottom:var(--spacing-l);
-  }
-  .topic-meta-spacer { flex: 1 1 auto; min-width: 0; }
-
-  /* README chip — secondary, tab-bar style */
-  .readme-btn {
-    display: inline-flex; align-items: center; gap: var(--spacing-xxs);
-    height: 24px;
-    padding: var(--spacing-xxxs) var(--spacing-xs);
-    background: var(--b-r02);
-    border: 0.5px solid var(--line-l2);
-    border-radius: var(--radius-ct-s);
-    font-family: inherit;
-    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
-    color: var(--text-n9); cursor: pointer;
-    transition: background .15s, border-color .15s;
-  }
-  .readme-btn:hover,
-  .readme-btn:active {
-    background: var(--b-r03);
-    border-color: var(--line-l9);
-  }
-  .readme-btn-icon {
-    width: 14px; height: 14px; flex-shrink: 0;
-    background-color: currentColor;
-    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg") center / contain no-repeat;
-            mask: url("https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg") center / contain no-repeat;
-  }
-  .pill {
-    display:inline-flex; align-items:center; gap:var(--spacing-xxs);
-    padding:2px var(--spacing-s); border-radius: var(--radius-ct-s);
-    font-size:12px; line-height:20px;
-  }
-  .pill.source { background: var(--b-r05); color: var(--text-n7); }
-  .pill.cadence { background: var(--main-m1-10); color: var(--main-m1); }
-
-  /* ── Subscribe button (primary CTA) ── */
-  .subscribe-cta {
-    display:inline-flex; align-items:center; justify-content:center; gap:6px;
-    height: 32px; padding: 6px var(--spacing-m);
-    background: var(--main-m1); color: var(--b-common-white);
-    border: none; border-radius: var(--radius-btn-s);
-    font-family: inherit; font-weight: 500;
-    font-size: 12px; line-height: 20px; letter-spacing: 0.12px;
-    cursor: pointer; text-decoration: none;
-    transition: all 0.2s ease-in-out;
-  }
-  .subscribe-cta:hover { background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.1)); }
-  .subscribe-cta:active { background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)); }
 
   /* ── Timeline ── */
   .day-separator {
@@ -183,13 +129,14 @@
     -webkit-mask-image: url("https://alva-ai-static.b-cdn.net/icons/arrow-down-l2.svg");
             mask-image: url("https://alva-ai-static.b-cdn.net/icons/arrow-down-l2.svg");
   }
-  .notif-matches {
+  .notif-sources {
     margin-top: var(--spacing-s); display:flex; flex-direction:column;
     gap: var(--spacing-xxs); font-size:12px;
   }
-  .notif-matches.hidden { display:none; }
-  .match-row {
-    display:grid; grid-template-columns: 76px 1fr auto;
+  .notif-sources.hidden { display:none; }
+  .match-row,
+  .fact-row {
+    display:grid; grid-template-columns: 96px 1fr auto;
     gap: var(--spacing-s); align-items:center;
     padding: var(--spacing-xxs) var(--spacing-s);
     margin: 0 calc(-1 * var(--spacing-s));
@@ -197,8 +144,10 @@
     text-decoration:none; color: var(--text-n7);
     transition: background .15s;
   }
-  .match-row:hover { background: var(--b-r02); color: var(--text-n9); }
-  .match-source {
+  .match-row:hover,
+  .fact-row:hover { background: var(--b-r02); color: var(--text-n9); }
+  .match-source,
+  .fact-source {
     display:inline-flex; align-items:center; gap: var(--spacing-xxs);
     font-size:10px; text-transform:uppercase; letter-spacing:0.5px;
     color: var(--text-n5);
@@ -208,11 +157,14 @@
     object-fit: cover; background: var(--b-r02);
   }
   .match-source-icon.no-radius { border-radius: 0; background: transparent; }
-  .match-title {
+  .match-title,
+  .fact-title {
     font-size:12px; line-height:18px;
     white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
   }
-  .match-ts {
+  .match-ts,
+  .fact-ts,
+  .empty-sources {
     font-size:11px; color: var(--text-n5);
     font-variant-numeric: tabular-nums;
   }
@@ -240,43 +192,6 @@
     border-radius: var(--radius-ct-s);
     font-size: 12px; margin-bottom: var(--spacing-m);
   }
-
-  /* ── README Modal ── */
-  .readme-modal {
-    position: fixed; inset: 0; z-index: 1000;
-    display: flex; align-items: center; justify-content: center;
-    padding: var(--spacing-m);
-  }
-  .readme-modal[hidden] { display: none; }
-  .readme-backdrop {
-    position: absolute; inset: 0;
-    background: rgba(10, 15, 24, 0.45); backdrop-filter: blur(2px);
-  }
-  .readme-dialog {
-    position: relative; max-width: 680px; width: 100%;
-    max-height: 85vh; overflow-y: auto;
-    background: var(--b0-container, #fff);
-    border-radius: var(--radius-ct-l);
-    box-shadow: var(--shadow-l, 0 16px 48px rgba(10,15,24,0.2));
-    padding: var(--spacing-xl) var(--spacing-xxl) var(--spacing-xxl);
-  }
-  .readme-header {
-    display: flex; align-items: center; justify-content: space-between;
-    margin-bottom: var(--spacing-m);
-  }
-  .readme-title {
-    font-size: 18px; line-height: 26px; font-weight: 500;
-    color: var(--text-n9); margin: 0; letter-spacing: 0.18px;
-  }
-  .readme-close {
-    width: 18px; height: 18px; flex-shrink: 0;
-    border: none; background-color: var(--text-n9); padding: 0;
-    cursor: pointer;
-    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
-            mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
-    transition: opacity .15s ease;
-  }
-  .readme-close:hover { opacity: 0.6; }
 
   /* ════════════════════════════════════════════════════════════
      Alva Markdown — verbatim from design-components.md
@@ -477,18 +392,6 @@
 
 </div>
 
-<!-- ── README Modal ── -->
-<div class="readme-modal" id="readme-modal" hidden>
-  <div class="readme-backdrop" data-readme-close></div>
-  <div class="readme-dialog" role="dialog" aria-modal="true" aria-labelledby="readme-title">
-    <header class="readme-header">
-      <h2 id="readme-title" class="readme-title">About this playbook</h2>
-      <button class="readme-close" data-readme-close aria-label="Close"></button>
-    </header>
-    <div class="readme-body markdown-container markdown-container--m" id="readme-body"></div>
-  </div>
-</div>
-
 <script type="application/json" id="playbook-config">
 {
   "topic": {
@@ -511,9 +414,9 @@
 
 <script>
 (async function () {
-  const md = window.markdownit({ html: true, linkify: true, breaks: false });
+  const md = window.markdownit({ html: false, linkify: true, breaks: false });
   const USERNAME = "leoz";
-  const FEED_PATH = `/alva/home/${USERNAME}/feeds/ai-chip-supply-chain-deep/v1/data/notifications/events/@last/50`;
+  const FEED_PATH = `/alva/home/${USERNAME}/feeds/ai-chip-supply-chain-deep/v1/data/digest/events/@last/50`;
   const endpoint = (typeof ALVA_ENDPOINT !== "undefined" && ALVA_ENDPOINT)
     ? ALVA_ENDPOINT
     : "https://api-llm.prd.alva.ai";
@@ -544,14 +447,23 @@
       hour: "numeric", minute: "2-digit", hour12: true,
     }) + " ET";
   }
+  const etDateParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric", month: "2-digit", day: "2-digit",
+  });
+  const etDayFormat = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    weekday: "short", month: "short", day: "numeric",
+  });
+  function etDayNumber(ms) {
+    const parts = Object.fromEntries(etDateParts.formatToParts(new Date(ms)).map(p => [p.type, p.value]));
+    return Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day)) / 86400_000;
+  }
   function dayLabel(ms) {
-    const d = new Date(ms);
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-    const dd = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-    if (dd === today) return "Today";
-    if (dd === today - 86400_000) return "Yesterday";
-    return d.toLocaleDateString("en-US", { weekday:"short", month:"short", day:"numeric" });
+    const delta = etDayNumber(Date.now()) - etDayNumber(ms);
+    if (delta === 0) return "Today";
+    if (delta === 1) return "Yesterday";
+    return etDayFormat.format(new Date(ms));
   }
   function fmtRelative(ms) {
     const diff = Date.now() - ms;
@@ -563,6 +475,14 @@
     return String(s).replace(/[&<>"']/g, c => ({
       "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;",
     }[c]));
+  }
+  function safeHttpUrl(value) {
+    try {
+      const url = new URL(String(value || ""));
+      return url.protocol === "http:" || url.protocol === "https:" ? url.href : "";
+    } catch (e) {
+      return "";
+    }
   }
   function sourceIcon(source, url) {
     const s = String(source || "").toLowerCase();
@@ -577,7 +497,9 @@
     }
     if (s === "news") {
       try {
-        const host = new URL(url).hostname;
+        const safeUrl = safeHttpUrl(url);
+        if (!safeUrl) return { src: "", noRadius: false };
+        const host = new URL(safeUrl).hostname;
         return { src: `https://www.google.com/s2/favicons?domain=${host}&sz=64`, noRadius: false };
       } catch (e) { return { src: "", noRadius: false }; }
     }
@@ -590,8 +512,36 @@
       const c = citMap.get(+n);
       if (!c) return m;
       const title = escapeHtml(`${c.source}: ${(c.claim || '').slice(0, 140)}`);
-      return `<a class="cite-ref" href="${c.url}" target="_blank" rel="noopener noreferrer" title="${title}">[${n}]</a>`;
+      const href = safeHttpUrl(c.url);
+      if (!href) return `<span class="cite-ref cite-ref--static" tabindex="0" title="${title}">[${n}]</span>`;
+      return `<a class="cite-ref" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer" title="${title}">[${n}]</a>`;
     });
+  }
+  function renderMatchRow(m) {
+    const href = safeHttpUrl(m.url);
+    const ic = sourceIcon(m.source, href);
+    const iconHtml = ic.src
+      ? `<img class="match-source-icon${ic.noRadius ? ' no-radius' : ''}" src="${ic.src}" alt="" onerror="this.style.visibility='hidden'">`
+      : "";
+    const content = `
+        <span class="match-source">${iconHtml}<span>${escapeHtml(m.source || "source")}</span></span>
+        <span class="match-title">${escapeHtml(m.title || m.url || "Untitled match")}</span>
+        <time class="match-ts">${fmtRelative(Number(m.ts) || Date.now())}</time>`;
+    return href
+      ? `<a class="match-row" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${content}</a>`
+      : `<div class="match-row">${content}</div>`;
+  }
+  function renderFactRow(fact) {
+    const href = safeHttpUrl(fact.url);
+    const label = fact.label || fact.ref_id || "Context fact";
+    const value = fact.value ? ` · ${fact.value}` : "";
+    const content = `
+        <span class="fact-source">${escapeHtml(fact.source || "context")}</span>
+        <span class="fact-title">${escapeHtml(label + value)}</span>
+        <time class="fact-ts">${fmtRelative(Number(fact.ts) || Date.now())}</time>`;
+    return href
+      ? `<a class="fact-row" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${content}</a>`
+      : `<div class="fact-row" title="${escapeHtml(fact.evidence || fact.ref_id || "")}">${content}</div>`;
   }
 
   let lastDay = null;
@@ -620,18 +570,15 @@
 
     const bodyHtml = renderBodyWithCites(ev.body || "", ev.citations || []);
     const matches = ev.matches || [];
-    const matchesHtml = matches.slice(0, 20).map(m => {
-      const ic = sourceIcon(m.source, m.url);
-      const iconHtml = ic.src
-        ? `<img class="match-source-icon${ic.noRadius ? ' no-radius' : ''}" src="${ic.src}" alt="" onerror="this.style.visibility='hidden'">`
-        : "";
-      return `
-      <a class="match-row" href="${m.url}" target="_blank" rel="noopener noreferrer">
-        <span class="match-source">${iconHtml}<span>${m.source}</span></span>
-        <span class="match-title">${escapeHtml(m.title)}</span>
-        <time class="match-ts">${fmtRelative(m.ts)}</time>
-      </a>`;
-    }).join("");
+    const citations = ev.citations || [];
+    const citedFactRefs = new Set(citations.map(c => c.source_ref).filter(Boolean));
+    const contextFacts = Array.isArray(ev.context_facts) ? ev.context_facts : [];
+    const citedFacts = contextFacts.filter(f => citedFactRefs.has(f.ref_id));
+    const sourceCount = matches.length + citedFacts.length;
+    const sourcesHtml = [
+      ...matches.slice(0, 20).map(renderMatchRow),
+      ...citedFacts.map(renderFactRow),
+    ].join("") || `<div class="empty-sources">No visible sources for this event.</div>`;
 
     html += `<article class="widget-card notif-card">
       <header class="notif-card-header">
@@ -645,10 +592,10 @@
       <div class="notif-body markdown-container markdown-container--m">${bodyHtml}</div>
       <footer class="notif-cite-row">
         <button class="notif-sources-toggle" type="button" aria-expanded="false" onclick="const m=this.nextElementSibling; m.classList.toggle('hidden'); this.setAttribute('aria-expanded', String(!m.classList.contains('hidden')));">
-          <span>Sources (${matches.length})</span>
+          <span>Sources (${sourceCount})</span>
           <span class="notif-sources-arrow" aria-hidden="true"></span>
         </button>
-        <div class="notif-matches hidden">${matchesHtml}</div>
+        <div class="notif-sources hidden">${sourcesHtml}</div>
       </footer>
     </article>`;
   }

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -27,6 +27,9 @@ Before writing HTML, read from the Alva skill:
 - [`../../references/design-components.md`](../../references/design-components.md) — Tab / Dropdown / Pill / Markdown primitives
 - [`../../references/design-system.md`](../../references/design-system.md) — `.playbook-container`, `.playbook-header` base rules
 
+Default to the existing Alva light-theme tokens. Do not introduce dark mode,
+black/slate page backgrounds, glow effects, gradients, or custom color palettes.
+
 **Do NOT** apply `design-playbook-trading-strategy.md` — that's for trading
 dashboards with Overview/Analytics/Strategy/Feed tabs. AI Digest is a
 **timeline**, not a dashboard.
@@ -41,8 +44,8 @@ design system — never re-spec a token or base that already exists.
 A working timeline UI lives at `example/index.html` next to this file —
 **copy it directly.** Change `USERNAME` + `FEED_PATH` + `playbook-config`
 JSON + the title; leave the rest. It already encodes the design system,
-markdown-it body rendering, README modal, source-icon resolver, day
-separators, and pushed/skipped cards. §10 and §11 only document what's
+safe markdown rendering, source resolver, day separators, and pushed/skipped
+cards. §10 and §11 only document what's
 AI Digest-unique on top — do not re-derive the layout from them.
 
 The feed-side scaffold lives in §14, built around a single
@@ -400,7 +403,7 @@ All three are Feed SDK time-series
 | `body` | string | Markdown with inline `[N]` reference markers. `""` on grounding failure |
 | `citations` | `[{ref, claim, url, source, source_ref}]` | One entry per `[N]` marker. `source_ref` is a match URL, `match.meta.event_key`, or, when using enrichment, `context_facts[].ref_id`. `[]` when body is `""` |
 | `matches` | `[{source, url, title, ts, snippet, meta}]` | All matches considered this fire (post-relevance, post-dedupe) |
-| `context_facts` | `[{ref_id, source, label, value, ts, evidence, url}]` | Optional structured Alva/BYOD/upstream facts used for materiality and grounding. `[]` in the lightweight default path. |
+| `context_facts` | `[{ref_id, source, label, value, ts, evidence, url}]` | Optional structured Alva/BYOD/upstream facts used for materiality and grounding. Render cited facts as structured fact rows under Sources; do not fake them as news/social sources. `[]` in the lightweight default path. |
 | `dedupe_keys` | `Array<{key: string}>` | Hashes consumed by this record. Feed SDK's `arr()` helper can't describe primitive-string arrays; each entry is wrapped as `{key: hash}`. Declare: `arr("dedupe_keys", [str("key")])`. |
 | `source` | `"alvaask" \| "fallback"` | `"fallback"` when body is `""` |
 
@@ -415,13 +418,17 @@ always; let `delivery.pushed` drive rendering.**
 
 When `audience: "followers"`, also append one record to `signal/targets` per
 pushed fire. Format follows Altra's target schema (see `references/feed-sdk.md`
-Pattern D); the platform reads `meta.reason` as the push body:
+Pattern D); the platform reads `meta.reason` as the push body and truncates it
+to 500 chars. Always pass the released playbook URL so the compact push can
+reserve the final link line:
 
 ```javascript
+const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
+
 await ctx.self.ts("signal", "targets").append([{
   date: now,
   instruction: { type: "allocate", weights: [] },   // no-op — this is notify-only
-  meta: { reason: composePushPayload(event) },       // ≤ 500 chars; see §9
+  meta: { reason: composePushPayload(event, PLAYBOOK_URL) }, // ≤ 500 chars; see §9
 }]);
 ```
 
@@ -445,10 +452,12 @@ When `audience: "owner"`, write to `notify/message` instead. No FeedAltra
 requirement; plain `Feed` suffices.
 
 ```javascript
+const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
+
 await ctx.self.ts("notify", "message").append([{
   date: now,
   title: `${CONFIG.topic.name} · ${fmtEst(now)}`,
-  text: composePushPayload(event),
+  text: composePushPayload(event, PLAYBOOK_URL),
 }]);
 ```
 
@@ -792,21 +801,153 @@ On failure: write the event with `body: ""`, `push_line: ""`, `citations:
 
 ## 9. Push plumbing
 
-### `composePushPayload(event)`
+### `composePushPayload(event, playbookUrl)`
 
 The push body is derived deterministically from the event record — one
-`ask()` per fire, one payload shape. Telegram caps `signal/targets` at
-500 chars; budget ≤ 450 to leave headroom.
+`ask()` per fire, one payload shape. Keep Telegram copy compact but not
+headline-only: treat it as the playbook page TLDR. Preserve the core point,
+key numbers, and why-it-matters sentence from the playbook body. Prefer natural
+prose for short/medium bodies, switch to concise bullet points only when the
+body is already list-shaped or long and data-dense. Bullet count is not fixed;
+fit as many meaningful short points as the remaining budget allows, then always
+reserve room for the playbook link. Do **not** list sources in the Telegram
+push; citations and full source rows live in the playbook. The hard budget is
+500 chars because `/data/signal/targets` truncates at 500.
 
 ```javascript
 function composePushPayload(event, playbookUrl) {
-  const topSources = (event.citations || [])
-    .slice(0, 3).map(c => c.source).filter(Boolean).join(", ");
+  const MAX_PUSH_CHARS = 500;
+  const HEADLINE_CHARS = 140;
+  const TLDR_BUDGET_CHARS = 330;
+  const SHORT_BODY_CHARS = 180;
+  const NATURAL_POINT_CHARS = 150;
+  const BULLET_THRESHOLD_CHARS = 330;
+  const MAX_BULLETS = 5;
+  const MIN_BULLET_LINE_CHARS = 48;
+  const BULLET_CHARS = 105;
+  const linkLine = `Full update → ${playbookUrl}`;
+
+  const stripMarkdown = (s) => String(s || "")
+    .replace(/\[[0-9]+\]/g, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_>#]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s+([.,!?;:。！？])/g, "$1")
+    .trim();
+  const tidyTruncation = (s) => String(s || "")
+    .replace(/\s+\b(?:but|and|or|because|while|with|without|that|which|as|to|of|by|for|the|is|are)\s*…$/i, "…")
+    .replace(/[,;:]\s*…$/, "…");
+  const trimPoint = (s, limit) => {
+    const clean = stripMarkdown(s);
+    return clean.length > limit
+      ? tidyTruncation(clean.slice(0, limit).replace(/\s+\S*$/, "") + "…")
+      : clean;
+  };
+  const trimBlock = (s, limit) => {
+    const clean = String(s || "").trim();
+    return clean.length > limit
+      ? tidyTruncation(clean.slice(0, limit).replace(/\s+\S*$/, "") + "…")
+      : clean;
+  };
+  const fitSummary = (summary, limit) => {
+    const clean = String(summary || "").trim();
+    if (!clean || clean.length <= limit) return clean;
+    if (!clean.includes("\n• ")) return trimBlock(clean, limit);
+
+    const fitted = [];
+    let used = 0;
+    for (const line of clean.split("\n")) {
+      const separator = fitted.length ? 1 : 0;
+      const available = limit - used - separator;
+      if (available <= 0) break;
+      if (line.length <= available) {
+        fitted.push(line);
+        used += separator + line.length;
+      } else if (fitted.length < 2 && available >= 48) {
+        fitted.push(trimBlock(line, available));
+        break;
+      } else {
+        break;
+      }
+    }
+    return fitted.join("\n");
+  };
+  const sentencePoints = (body) => stripMarkdown(body)
+    .split(/(?<=[.!?。！？])\s*/)
+    .map(s => s.trim())
+    .filter(Boolean);
+  const bulletPoints = (body) => String(body || "")
+    .split("\n")
+    .map(s => s.trim())
+    .filter(s => /^[-*•]\s+/.test(s))
+    .map(s => s.replace(/^[-*•]\s+/, ""));
+  const hasData = (s) => /[$€¥%]|\d|bps?\b|x\b|million|billion|trillion/i.test(s);
+  const hasImpact = (s) =>
+    /\b(guidance|margin|revenue|capex|inventory|orders?|shipments?|lead time|pricing|demand|supply|backlog|export|risk|watch|implies|means|matters|beat|miss|raise|cut)\b/i.test(s);
+  const selectKeyPoints = (points, maxPoints = MAX_BULLETS) => {
+    const cleaned = points.map(stripMarkdown).filter(Boolean);
+    if (cleaned.length <= maxPoints) return cleaned;
+    const selected = new Set([0]);
+    const ranked = cleaned.slice(1).map((text, offset) => {
+      const index = offset + 1;
+      const score = (hasData(text) ? 3 : 0) + (hasImpact(text) ? 2 : 0) + (text.length <= 220 ? 1 : 0);
+      return { index, score };
+    }).sort((a, b) => b.score - a.score || a.index - b.index);
+    for (const item of ranked) {
+      if (selected.size >= maxPoints) break;
+      selected.add(item.index);
+    }
+    return [...selected].sort((a, b) => a - b).map(index => cleaned[index]);
+  };
+  const bulletSummary = (points, budget) => {
+    const selected = selectKeyPoints(points, MAX_BULLETS);
+    const lines = [];
+    let used = 0;
+    for (const point of selected) {
+      const separator = lines.length ? 1 : 0;
+      const available = budget - used - separator;
+      if (available < MIN_BULLET_LINE_CHARS) break;
+      const lineLimit = Math.min(BULLET_CHARS, available - 2);
+      const line = `• ${trimPoint(point, lineLimit)}`;
+      if (line.length > available) break;
+      lines.push(line);
+      used += separator + line.length;
+    }
+    return lines.length >= 2 ? lines.join("\n") : trimPoint(selected[0] || "", budget);
+  };
+
+  function summarizeTldr(body, budget) {
+    const compact = stripMarkdown(body);
+    if (!compact) return "";
+    const bullets = bulletPoints(body);
+    const points = bullets.length >= 2 ? bullets : sentencePoints(body);
+    const shouldUseBullets = bullets.length >= 2
+      || (compact.length >= BULLET_THRESHOLD_CHARS && points.length >= 4 && points.filter(hasData).length >= 2);
+    if (!shouldUseBullets && (compact.length < SHORT_BODY_CHARS || points.length < 2)) {
+      return trimPoint(compact, TLDR_BUDGET_CHARS);
+    }
+    if (!shouldUseBullets) {
+      return selectKeyPoints(points, 2)
+        .map(p => trimPoint(p, NATURAL_POINT_CHARS))
+        .join(" ");
+    }
+    return bulletSummary(points, budget);
+  }
+
+  const headline = trimPoint(event.push_line, HEADLINE_CHARS);
+  const reserved = [headline, linkLine].filter(Boolean).join("\n").length + 2;
+  const summaryBudget = Math.max(0, Math.min(TLDR_BUDGET_CHARS, MAX_PUSH_CHARS - reserved));
+  const summary = fitSummary(summarizeTldr(event.body, summaryBudget), summaryBudget);
+  const prefix = [
+    headline,
+    summary,
+  ].filter(Boolean).join("\n");
+  const prefixBudget = Math.max(0, MAX_PUSH_CHARS - linkLine.length - 1);
+
   return [
-    event.push_line,
-    topSources && `Sources: ${topSources}`,
-    `Full update → ${playbookUrl}`,
-  ].filter(Boolean).join("\n").slice(0, 450);
+    prefix.slice(0, prefixBudget).trim(),
+    linkLine,
+  ].filter(Boolean).join("\n");
 }
 ```
 
@@ -858,13 +999,11 @@ The rules the example already encodes — keep them when you adapt:
 - Container: `.playbook-container` on top of `design-tokens.css`.
 - Reverse chronological; today on top, older days below; day separators
   in EST (`Today` / `Yesterday` / `Mon, Apr 14`).
-- Read `<group>/<doc>/@last/N` on initial render (example uses
-  `notifications/events/@last/50`). No live recomputation — the HTML is
+- Read `digest/events/@last/N` on initial render. No live recomputation — the HTML is
   a view over stored records.
 - No in-page header chrome above the feed. The outer playbook shell owns
-  title, subscription, and metadata. If you need methodology, render it
-  through the README modal already wired in `example/index.html`, not as a
-  banner above the timeline.
+  title, subscription, metadata, and any methodology/about surface. Keep
+  `example/index.html` to the timeline only.
 
 To adapt: change `USERNAME`, `FEED_PATH`, `<title>`, and the
 `#playbook-config` JSON block. Leave the rest.
@@ -881,17 +1020,17 @@ This section names them and notes the contract — don't re-spec the styles.
   the same event record.
 - **Cite refs** (`.cite-ref`) — inline `[N]` anchors generated by
   replacing `[N]` markers in the rendered markdown body. Hover tooltip
-  shows `citations[N].source` + `claim`; link to `citations[N].url` when
-  present.
-- **Sources toggle** (`.notif-sources-toggle` / `.notif-matches`) — click
-  to expand the match list under each pushed card.
+  shows `citations[N].source` + `claim`; link to `citations[N].url` only
+  when it is an `http:` or `https:` URL. Empty or structured-fact citations
+  render as non-link refs.
+- **Sources toggle** (`.notif-sources-toggle` / `.notif-sources`) — click
+  to expand content matches plus cited `context_facts[]` under each pushed card.
 - **Match row** (`.match-row`) — grid: source icon + label, title, and
   relative timestamp. Source-icon resolver (`sourceIcon()` in
   `example/index.html`) handles X/podcast/youtube/news favicons.
+- **Fact row** (`.fact-row`) — structured fact row for cited
+  `context_facts[]`, showing source, label/value, and timestamp.
 - **Day separator** (`.day-separator`) — one per calendar day (EST).
-- **README modal** (`.readme-modal`) — methodology surface for the
-  outer shell to open. Body content can be derived from
-  `#playbook-config` JSON (topic, sources, cadence, angle, models).
 
 Everything else reuses the shared design system and
 `design-components.md` (markdown container, pills, typography). Do not
@@ -994,8 +1133,10 @@ const { Feed, feedPath, makeDoc, str, num, bool, obj, arr } = require("@alva/fee
 const { ask } = require("@alva/alvaask");
 
 const feed = new Feed({ path: feedPath("<your-playbook-name>") });
-feed.def("notifications", { events: makeDoc("AI Digest Events", "", [/* see example */]) });
-feed.def("signal",        { targets: makeDoc("Push Signal", "",      [/* see example */]) });
+const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
+
+feed.def("digest", { events: makeDoc("AI Digest Events", "", [/* see §6 */]) });
+feed.def("signal", { targets: makeDoc("Push Signal", "",      [/* see §6 */]) });
 
 (async () => {
   await feed.run(async (ctx) => {
@@ -1020,11 +1161,11 @@ feed.def("signal",        { targets: makeDoc("Push Signal", "",      [/* see exa
     // always write event; push only when material
     const record = { date: now, /* …push_line, body, citations, matches, dedupe_keys… */
       delivery: { pushed: !allOldDup && !tooStale, reason: ... } };
-    await ctx.self.ts("notifications", "events").append([record]);
+    await ctx.self.ts("digest", "events").append([record]);
     if (record.delivery.pushed) {
       await ctx.self.ts("signal", "targets").append([{ date: now,
         instruction: { type: "allocate", weights: [] },
-        meta: { reason: `${record.push_line}\n\n→ ${PLAYBOOK_URL}` } }]);
+        meta: { reason: composePushPayload(record, PLAYBOOK_URL) } }]);
     }
 
     // persist dedupe + throttle


### PR DESCRIPTION
## Summary
- unify AI Digest event storage on `digest/events` while keeping `signal/targets` and `notify/message` as delivery sidecars
- harden the example timeline with safe markdown rendering, HTTP(S)-only links, ET day grouping, and Sources rows for both matches and cited context facts
- rework Telegram push copy into a compact playbook TLDR that reserves the final `Full update` link inside the 500-char platform cap
- remove local README/topic/subscribe UI remnants and add light-theme design guardrails

## Validation
- `git diff --check -- skills/alva/templates/ai-digest/template.md skills/alva/templates/ai-digest/example/index.html`
- `rg "notifications/events|ctx.self.ts\(\"notifications" skills/alva/templates/ai-digest` returned no results
- Node smoke for `composePushPayload`: natural summary, long data-dense summary, and 5-bullet input all stay <= 500 chars and preserve the playbook link