### PR TITLE
[codex] docs(alva): make feed errors fail fast

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -829,6 +829,13 @@ See [feed-sdk.md](references/feed-sdk.md) for full details.
 Feeds are persistent data pipelines that store time series data, readable via
 filesystem paths.
 
+**Feed error handling is fail-fast.** Do not wrap feed data fetches, upstream
+feed reads, LLM parsing, or `ctx.self.ts().append()` calls in `catch` blocks
+that log and continue with empty arrays, nulls, fallback records, or partial
+outputs. Let unexpected failures throw; the sandbox captures thrown errors and
+exposes the failed run. Use normal conditionals only for expected business
+states such as "no new records since the last watermark."
+
 ```javascript
 const { Feed, feedPath, makeDoc, num } = require("@alva/feed");
 const http = require("net/http");

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -313,6 +313,25 @@ offset workarounds needed.
 
 ## Feed Class API
 
+### Error Handling
+
+Feed scripts should let unexpected failures throw. Do not wrap data fetches,
+upstream feed reads, LLM parsing, or feed writes in catch blocks that log and
+continue with empty arrays, nulls, or fallback records. The sandbox captures
+thrown errors and exposes the failed run, which makes broken data sources and
+bad response shapes visible during development and operations.
+
+Use ordinary conditionals only for expected business states, such as "no new
+records since the last watermark." For required inputs, validate the response
+shape and throw a clear error:
+
+```javascript
+const result = getDataSource({ symbol: "BTCUSDT" });
+if (!result.success || !Array.isArray(result.response?.data)) {
+  throw new Error("getDataSource returned an invalid response");
+}
+```
+
 ### Constructor
 
 ```javascript

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -464,15 +464,15 @@ All three are Feed SDK time-series
 | key | type | notes |
 |---|---|---|
 | `date` | number (ms) | Cron-fire timestamp. Append it on every record; Feed SDK time-series may treat it as the built-in timestamp field rather than a declared schema field. |
-| `delivery` | `{pushed: bool, reason: string}` | `pushed=false` carries a short `reason` (`quiet_day_skipped`, `grounding_failed`, `no_matches`, `all_deduped`, `not_material`, `rate_limited` — freeform, kept short) |
+| `delivery` | `{pushed: bool, reason: string}` | `pushed=false` carries a short `reason` (`quiet_day_skipped`, `no_matches`, `all_deduped`, `not_material`, `rate_limited` — freeform, kept short) |
 | `materiality` | `{is_material: bool, reason: string}` | Deterministic pre-generation decision derived from `CONFIG.push_policy`, matches, and optional context facts |
-| `push_line` | string | ≤ 160 chars plain text. `""` on grounding failure |
-| `body` | string | Markdown with inline `[N]` reference markers. `""` on grounding failure |
-| `citations` | `[{ref, claim, url, source, source_ref}]` | One entry per `[N]` marker. `source_ref` is a match URL, `match.meta.event_key`, or, when using enrichment, `context_facts[].ref_id`. `[]` when body is `""` |
+| `push_line` | string | ≤ 160 chars plain text. |
+| `body` | string | Markdown with inline `[N]` reference markers. |
+| `citations` | `[{ref, claim, url, source, source_ref}]` | One entry per `[N]` marker. `source_ref` is a match URL, `match.meta.event_key`, or, when using enrichment, `context_facts[].ref_id`. |
 | `matches` | `[{source, url, title, ts, snippet, meta}]` | All matches considered this fire (post-relevance, post-dedupe) |
 | `context_facts` | `[{ref_id, source, label, value, ts, evidence, url, method?, rationale?}]` | Optional structured Alva/BYOD/upstream facts used for materiality and grounding. Use `method` / `rationale` for derived calculations so cited facts explain the calculation and why it mattered. Render cited facts as structured fact rows under Sources; do not fake them as news/social sources. `[]` in the lightweight default path. |
 | `dedupe_keys` | `Array<{key: string}>` | Hashes consumed by this record. Feed SDK's `arr()` helper can't describe primitive-string arrays; each entry is wrapped as `{key: hash}`. Declare: `arr("dedupe_keys", [str("key")])`. |
-| `source` | `"alvaask" \| "fallback"` | `"fallback"` when body is `""` |
+| `source` | `"alvaask"` | Generation failures throw instead of writing fallback records. |
 
 ### Why every fire writes a record (even when `pushed=false`)
 
@@ -655,13 +655,11 @@ function filterRelevanceBatch(matches, topic, relevanceModel) {
       ).join("\n\n") +
       `\n\nReturn strict JSON only: {"answers": {"0": "yes"|"no", ..., "${slice.length - 1}": "yes"|"no"}} — keyed by the [n] index of each item.`;
     const { text } = ask(prompt, { model: relevanceModel });
-    try {
-      const { answers } = JSON.parse(text.replace(/^```(?:json)?\s*|\s*```$/g, ""));
-      slice.forEach((m, j) => { if (/^yes/i.test(answers[String(j)] || "")) out.push(m); });
-    } catch (e) {
-      // On parse failure, pass through un-filtered — better than dropping everything.
-      out.push(...slice);
+    const { answers } = JSON.parse(text.replace(/^```(?:json)?\s*|\s*```$/g, ""));
+    if (!answers || typeof answers !== "object") {
+      throw new Error("Relevance filter returned JSON without answers");
     }
+    slice.forEach((m, j) => { if (/^yes/i.test(answers[String(j)] || "")) out.push(m); });
   }
   return out;
 }
@@ -809,7 +807,8 @@ function generate({ newMatches, contextFacts, materiality }) {
     { system: systemPrompt(), model: CONFIG.generation_model },
   );
   const clean = (text || "").replace(/^```(?:json)?\s*|\s*```$/gm, "").trim();
-  try { return JSON.parse(clean); } catch { return null; }
+  if (!clean) throw new Error("Digest generation returned empty content");
+  return JSON.parse(clean);
 }
 ```
 
@@ -827,7 +826,7 @@ harvest 2–3 outputs the author liked and paste them into a local
 
 ### 8.2 Grounding check (all-or-nothing)
 
-Three gates; any failure → fallback. Quiet-day mode (`matches: []` and
+Three gates; any failure → throw so the sandbox exposes the failed run. Quiet-day mode (`matches: []` and
 `context_facts: []`) bypasses Gates B and C after the basic result shape check.
 
 ```javascript
@@ -870,9 +869,8 @@ is **not** a grounding gate — the model's claim field drifts too easily
 from body wording to be enforced byte-wise, and A + B + C already block
 the real failure modes.
 
-On failure: write the event with `body: ""`, `push_line: ""`, `citations:
-[]`, `source: "fallback"`, `delivery: { pushed: false, reason:
-"grounding_failed" }`. **Do not push.** All-or-nothing beats partial prose.
+On failure: throw and let the sandbox expose the failed run. Do not write an
+empty fallback event and do not push partial prose.
 
 ---
 
@@ -1038,7 +1036,7 @@ For `audience: "followers"` the output is the `meta.reason` of a
 |---|---|---|
 | Quiet day + `quiet_day_policy: "skip"` | `quiet_day_skipped` | No `ask()` call; record still appended. |
 | Below materiality bar | `not_material` | Deterministic materiality check rejected the run before generation. |
-| Grounding failed | `grounding_failed` | Model output rejected; record appended with empty body. |
+| Grounding failed | n/a | Throw; do not append an empty fallback record. |
 | All new matches were deduped | `all_deduped` | Record appended, `pushed=false`. |
 | Daily push cap reached | `rate_limited` | Enforce `CONFIG.push_policy.max_pushes_per_day` before generation. |
 
@@ -1143,12 +1141,13 @@ claim sub-minute delivery guarantees.
 
 ## 13. Hard Rules
 
-- **Every cron fire appends one `digest/events` record** — even
-  when `pushed=false`. The dedupe + retro workflow depends on it.
+- **Every successful cron fire appends one `digest/events` record** — even
+  when `pushed=false`. Unexpected failures throw before writing a fallback
+  record.
 - **Every number in body must appear verbatim in a match or optional context fact**
   (grounding Gate C). Prevents LLM-fabricated figures.
 - **Use plain `Feed`, not `FeedAltra`, for AI Digest feeds.** See §6 for the
-  full `signal/targets` reasoning and fallback path.
+  full `signal/targets` reasoning.
 - **Use `@alva/alvaask` only for LLM calls.** Relevance and generation both go
   through synchronous `ask()`; see §8 for call-site details.
 - **If you use structured Alva numbers, route them through `context_facts`.**

--- a/skills/alva/templates/screener/example/feeds/inflection-screener-feed.js
+++ b/skills/alva/templates/screener/example/feeds/inflection-screener-feed.js
@@ -100,7 +100,7 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
     }
     const midCapSize = Object.keys(universe).length;
     console.log("screened=" + universeSize + " mid_cap=" + midCapSize);
-    if (midCapSize === 0) { console.log("empty universe — abort"); return; }
+    if (midCapSize === 0) throw new Error("Empty mid-cap universe");
 
     // ── Fetch fundamentals in parallel (2yr window, all tickers) ──
     const [gmRes, omRes, rvRes, crRes] = await Promise.all([
@@ -145,7 +145,7 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
 
     const eligible = Object.values(universe).filter(u => !u._drop);
     console.log("eligible after hard filter=" + eligible.length);
-    if (eligible.length < 5) { console.log("Warning: <5 eligible — abort"); return; }
+    if (eligible.length < 5) throw new Error(`Too few eligible stocks: ${eligible.length}`);
 
     // ── Min-max normalize each factor ──
     const growthVals = eligible.map(s => s.revGrowth);
@@ -188,15 +188,13 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
 
     // ── Enrich with company names in parallel ──
     await Promise.all(top.map(async (s) => {
-      try {
-        const d = await arraysGet("/api/v1/stocks/company/detail", { symbol: s.ticker });
-        const c = d.data && d.data.length ? d.data[0] : null;
-        if (c) {
-          s.name = c.name || s.ticker;
-          s.sector = c.sector || "Unknown";
-          s.industry = c.industry || "Unknown";
-        } else { s.name = s.ticker; s.sector = "Unknown"; s.industry = "Unknown"; }
-      } catch (e) { s.name = s.ticker; s.sector = "Unknown"; s.industry = "Unknown"; }
+      const d = await arraysGet("/api/v1/stocks/company/detail", { symbol: s.ticker });
+      const c = d.data && d.data.length ? d.data[0] : null;
+      if (c) {
+        s.name = c.name || s.ticker;
+        s.sector = c.sector || "Unknown";
+        s.industry = c.industry || "Unknown";
+      } else { s.name = s.ticker; s.sector = "Unknown"; s.industry = "Unknown"; }
     }));
 
     // ── Basket percentiles for soft flags ──
@@ -282,23 +280,19 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
           : klState[s.ticker];
         const startSec = wmSec + 1;
         if (startSec >= nowSec) return { ticker: s.ticker, wmSec, bars: [] };
-        try {
-          const kr = await arraysGet("/api/v1/stocks/kline", {
-            symbol: s.ticker, start_time: startSec, end_time: nowSec, interval: "1d", limit: 10000,
-          });
-          // stocks/kline returns newest-first; reverse to oldest-first
-          const bars = (kr.data || []).slice().reverse().filter(b => b.time_open > wmSec);
-          return { ticker: s.ticker, wmSec, bars, ok: true };
-        } catch (e) {
-          return { ticker: s.ticker, wmSec, bars: [], err: true };
-        }
+        const kr = await arraysGet("/api/v1/stocks/kline", {
+          symbol: s.ticker, start_time: startSec, end_time: nowSec, interval: "1d", limit: 10000,
+        });
+        if (!kr || !Array.isArray(kr.data)) throw new Error(`Invalid kline response for ${s.ticker}`);
+        // stocks/kline returns newest-first; reverse to oldest-first
+        const bars = kr.data.slice().reverse().filter(b => b.time_open > wmSec);
+        return { ticker: s.ticker, wmSec, bars, ok: true };
       }));
 
       const klineRecords = [];
       const newKlState = {};
-      let klSuccess = 0, klFail = 0;
+      let klSuccess = 0;
       for (const res of klResults) {
-        if (res.err) { newKlState[res.ticker] = res.wmSec; klFail++; continue; }
         if (!res.bars.length) { newKlState[res.ticker] = res.wmSec; continue; }
         let maxSec = res.wmSec;
         for (const b of res.bars) {
@@ -315,7 +309,7 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
 
       if (klineRecords.length > 0) await ctx.self.ts("screener", "klines").append(klineRecords);
       await ctx.kv.put("klState", JSON.stringify(newKlState));
-      console.log("K-line bars appended: " + klineRecords.length + " (ok=" + klSuccess + " fail=" + klFail + ")");
+      console.log("K-line bars appended: " + klineRecords.length + " (ok=" + klSuccess + ")");
     }
 
     console.log("Done! Top 5: " + top.slice(0, 5).map(s => s.ticker + "=" + s.score).join(", "));

--- a/skills/alva/templates/screener/template.md
+++ b/skills/alva/templates/screener/template.md
@@ -205,10 +205,10 @@ delta           {new_ids, dropped_ids}    vs prior snapshot; first run: both []
 
 ```
 date         int
-body         str   ADK-generated markdown — bullets, prose, or one line. "" on grounding failure.
-push_line    str   ADK-generated standalone headline, ≤ 160 chars plain text. "" on grounding failure.
+body         str   ADK-generated markdown — bullets, prose, or one line.
+push_line    str   ADK-generated standalone headline, ≤ 160 chars plain text.
 churn_line   str   deterministic "🆕 X · 👋 Y", always present, may be ""
-source       str   "adk" | "fallback"
+source       str   "adk"
 ```
 
 ### Three bedrock rules
@@ -226,8 +226,8 @@ source       str   "adk" | "fallback"
 - `< 2` snapshots in history → hide the basket trend chart entirely; show the
   `.trend-empty` hint.
 - Only 1 snapshot in history → hide the snapshot picker entirely.
-- `tldr.source === "fallback"` → render `churn_line` only (no body); skip
-  push when churn is also empty.
+- If TLDR generation or grounding fails, throw so the sandbox exposes the
+  failed run.
 
 ---
 
@@ -352,9 +352,8 @@ ADK prompt. Without it, output drifts to research-report tone within a week.
 - Output is structured JSON: `{body: "<markdown>", push_line: "<plain>"}`.
 - Length caps: `push_line ≤ 160` chars; `body ≤ ~800` chars rendered.
 - **Numeric grounding** — extract every number (regex `-?\d+(\.\d+)?%?`) from
-  both fields. If **any** unverified number appears, mark the whole digest
-  as fallback (`body: ""`, `push_line: ""`, `source: "fallback"`) and let the
-  UI render `churn_line` alone. All-or-nothing beats patching partial prose.
+  both fields. If **any** unverified number appears, throw and let the sandbox
+  expose the failed run. All-or-nothing beats patching partial prose.
 - Persist per snapshot to `screener/tldr`. Regenerate only when a new snapshot
   appears.
 
@@ -382,8 +381,9 @@ line 3:  Full snapshot → <playbook URL>
   churn in top-N, new flags, a factor driver swap.
 - Basket variant with both churn sides empty → **do not send** "nothing
   happened" pings.
-- `tldr.source === "fallback"` and churn empty → skip.
-- `push_line === ""` (fallback) → omit line 1; push is churn line + URL only.
+- Empty churn → skip.
+- `push_line === ""` is invalid when a push is requested; throw instead of
+  sending a partial notification.
 
 Length budget: lines 1+2 ≤ 280 chars combined — the 160-char `push_line` cap
 in the digest prompt guarantees the fit.

--- a/skills/alva/templates/thesis/example/feeds/ai-bottleneck-narrative.js
+++ b/skills/alva/templates/thesis/example/feeds/ai-bottleneck-narrative.js
@@ -13,8 +13,7 @@ const env = require("env");
 //   4. What's the next catalyst to watch?
 //
 // Every number cited must be traceable to the input snapshot (grounding).
-// If grounding fails, we write a deterministic fallback one-liner and flag
-// source="fallback". Push only fires when there's real signal.
+// If grounding fails, throw so the sandbox surfaces the failed run.
 
 const feed = new Feed({ path: feedPath("ai-bottleneck-narrative") });
 
@@ -25,7 +24,7 @@ feed.def("narrative", {
     str("recordDate"),               // "YYYY-MM-DD"
     str("thesis"),                   // markdown TLDR body, 3-5 sentences active / 1-2 quiet
     str("pushLine"),                 // plain-text headline, ≤160 chars
-    str("source"),                   // "adk" | "fallback"
+    str("source"),                   // "adk"
     str("deltasJson"),               // JSON array of Delta objects
     str("catalystsJson"),            // JSON array of Catalyst objects
     str("risksJson"),                // JSON array of Risk objects
@@ -46,22 +45,16 @@ feed.def("signal", {
 
 async function readFeed(feedName, group, series, count) {
   const path = `/alva/home/${env.username}/feeds/${feedName}/v1/data/${group}/${series}/@last/${count||1}`;
-  try {
-    const txt = await alfs.readFile(path);
-    if (!txt) return null;
-    return JSON.parse(String(txt));
-  } catch (e) { return null; }
+  const txt = await alfs.readFile(path);
+  if (!txt) throw new Error(`Empty upstream feed read: ${path}`);
+  return JSON.parse(String(txt));
 }
 
-function safeParse(s){ try { return JSON.parse(s); } catch (e) { return null; } }
+function safeParse(s){ return s ? JSON.parse(s) : null; }
 function parseJson(s){
-  if (!s) return null;
+  if (!s) throw new Error("ADK returned empty content");
   const cleaned = s.replace(/^```(?:json)?/, "").replace(/```$/, "").trim();
-  try { return JSON.parse(cleaned); } catch (e) {
-    const m = cleaned.match(/\{[\s\S]*\}/);
-    if (m) { try { return JSON.parse(m[0]); } catch (e2) { return null; } }
-    return null;
-  }
+  return JSON.parse(cleaned);
 }
 
 // Grounding: extract every number-like token from the output and verify it
@@ -302,80 +295,62 @@ function clampEnum(val, enumMap, fallback){
     let catalysts = [];
     let risks = [];
 
-    if (!parsed) {
-      log(`ADK returned non-JSON. Raw: ${(result.content || "").slice(0, 400)}`);
-      source = "fallback";
-    } else {
-      thesis = parsed.thesis || "";
-      pushLine = (parsed.pushLine || "").slice(0, 240);
-      deltas = Array.isArray(parsed.deltas) ? parsed.deltas : [];
-      catalysts = Array.isArray(parsed.catalysts) ? parsed.catalysts : [];
-      risks = Array.isArray(parsed.risks) ? parsed.risks : [];
+    thesis = parsed.thesis || "";
+    pushLine = (parsed.pushLine || "").slice(0, 240);
+    deltas = Array.isArray(parsed.deltas) ? parsed.deltas : [];
+    catalysts = Array.isArray(parsed.catalysts) ? parsed.catalysts : [];
+    risks = Array.isArray(parsed.risks) ? parsed.risks : [];
 
-      // ─── Enum validation (safety net — clamp any free-text labels to template enums) ───
-      deltas = deltas.map((d)=> Object.assign({}, d, {
-          sentiment: clampEnum(d.sentiment, SENTIMENTS_3, "Neutral"),
-          category: clampEnum(d.category, DELTA_CATEGORIES, "News"),
-          pillar: d.pillar ? clampEnum(d.pillar, PILLARS, null) : null,
-        }));
-      catalysts = catalysts.map((c)=> Object.assign({}, c, {
-          status: clampEnum(c.status, CATALYST_STATUSES, "Upcoming"),
-          sentiment: clampEnum(c.sentiment, SENTIMENTS_4, "Ambiguous"),
-          pillar: c.pillar ? clampEnum(c.pillar, PILLARS, null) : null,
-          ids: Array.isArray(c.ids) ? c.ids : [],
-        }));
-      risks = risks.map((r)=> Object.assign({}, r, {
-          category: clampEnum(r.category, RISK_CATEGORIES, "Execution"),
-          divergenceType: clampEnum(r.divergenceType, DIVERGENCE_TYPES, "Fundamental"),
-          priority: clampEnum(r.priority, PRIORITIES, "Medium"),
-          pillar: r.pillar ? clampEnum(r.pillar, PILLARS, null) : null,
-        }));
+    // ─── Enum validation (safety net — clamp any free-text labels to template enums) ───
+    deltas = deltas.map((d)=> Object.assign({}, d, {
+        sentiment: clampEnum(d.sentiment, SENTIMENTS_3, "Neutral"),
+        category: clampEnum(d.category, DELTA_CATEGORIES, "News"),
+        pillar: d.pillar ? clampEnum(d.pillar, PILLARS, null) : null,
+      }));
+    catalysts = catalysts.map((c)=> Object.assign({}, c, {
+        status: clampEnum(c.status, CATALYST_STATUSES, "Upcoming"),
+        sentiment: clampEnum(c.sentiment, SENTIMENTS_4, "Ambiguous"),
+        pillar: c.pillar ? clampEnum(c.pillar, PILLARS, null) : null,
+        ids: Array.isArray(c.ids) ? c.ids : [],
+      }));
+    risks = risks.map((r)=> Object.assign({}, r, {
+        category: clampEnum(r.category, RISK_CATEGORIES, "Execution"),
+        divergenceType: clampEnum(r.divergenceType, DIVERGENCE_TYPES, "Fundamental"),
+        priority: clampEnum(r.priority, PRIORITIES, "Medium"),
+        pillar: r.pillar ? clampEnum(r.pillar, PILLARS, null) : null,
+      }));
 
-      // Grounding check: every number in thesis + pushLine must exist in context.
-      const combined = `${thesis} ${pushLine}`;
-      const nums = extractNumbers(combined);
-      let grounded = true;
-      for (let i=0;i<nums.length;i++){
-        if (!isGrounded(nums[i].value, contextJson)) {
-          log(`Grounding fail: ${nums[i].raw} not found in snapshot`);
-          grounded = false;
-          break;
-        }
+    // Grounding check: every number in thesis + pushLine must exist in context.
+    const combined = `${thesis} ${pushLine}`;
+    const nums = extractNumbers(combined);
+    for (let i=0;i<nums.length;i++){
+      if (!isGrounded(nums[i].value, contextJson)) {
+        throw new Error(`Grounding failed: ${nums[i].raw} not found in snapshot`);
       }
-      if (!grounded) source = "fallback";
-
-      // ─── Post-processing: match relatedNews to catalysts and risks ───
-      // Template: "Post-processing populates as [{type, title, url, snippet}]"
-      // Always attach as an array (empty OK) — UI expects the field.
-      const allItems = (news || []).concat(social || []);
-      catalysts = catalysts.map((c)=> {
-        let matched = [];
-        if (allItems.length){
-          const target = `${c.title || ""} ${c.notes || ""}`;
-          matched = matchRelatedNews(target, c.ids || [], allItems, 5);
-        }
-        c.relatedNews = matched;
-        return c;
-      });
-      risks = risks.map((r)=> {
-        let matched = [];
-        if (allItems.length){
-          const target = `${r.description || ""} ${r.exitTrigger || ""}`;
-          matched = matchRelatedNews(target, [], allItems, 5);
-        }
-        r.relatedNews = matched;
-        return r;
-      });
     }
 
-    // Deterministic fallback one-liner if grounding fails.
-    if (source === "fallback") {
-      const s = (summary?.[0]) ? summary[0] : {};
-      const fbPush = `Basket ${s.basket_ytd >= 0 ? "+" : ""}${(s.basket_ytd || 0).toFixed(1)}% YTD vs PAVE ${s.pave_ytd >= 0 ? "+" : ""}${(s.pave_ytd || 0).toFixed(1)}% · alpha ${s.alpha_pave_ytd >= 0 ? "+" : ""}${(s.alpha_pave_ytd || 0).toFixed(1)} pp. Narrative refresh pending.`;
-      pushLine = fbPush.slice(0, 240);
-      thesis = `Narrative generation did not produce a grounded record today. Quant tabs remain live. ${fbPush}`;
-      deltas = []; catalysts = []; risks = [];
-    }
+    // ─── Post-processing: match relatedNews to catalysts and risks ───
+    // Template: "Post-processing populates as [{type, title, url, snippet}]"
+    // Always attach as an array (empty OK) — UI expects the field.
+    const allItems = (news || []).concat(social || []);
+    catalysts = catalysts.map((c)=> {
+      let matched = [];
+      if (allItems.length){
+        const target = `${c.title || ""} ${c.notes || ""}`;
+        matched = matchRelatedNews(target, c.ids || [], allItems, 5);
+      }
+      c.relatedNews = matched;
+      return c;
+    });
+    risks = risks.map((r)=> {
+      let matched = [];
+      if (allItems.length){
+        const target = `${r.description || ""} ${r.exitTrigger || ""}`;
+        matched = matchRelatedNews(target, [], allItems, 5);
+      }
+      r.relatedNews = matched;
+      return r;
+    });
 
     await ctx.self.ts("narrative","records").append([{
       date: todayMs,
@@ -395,8 +370,6 @@ function clampEnum(val, enumMap, fallback){
     //   any catalyst status flipped vs prior           → send
     //   risks.length changed vs prior                  → send
     //   High-priority risk count changed vs prior      → send
-    //   fallback source + no signals                   → skip push (avoid noise)
-    //   fallback source + signals                      → send deterministic substitute
     const priorCatalysts = prior ? (safeParse(prior.catalystsJson) || []) : [];
     const priorRisks = prior ? (safeParse(prior.risksJson) || []) : [];
     function catalystSig(arr){ return (arr||[]).map((c)=> `${c.title||''}|${c.status||''}`).sort().join('##'); }
@@ -415,28 +388,16 @@ function clampEnum(val, enumMap, fallback){
     else if (catalystFlipped) { shouldPush = true; pushReason = "catalyst_flip"; }
     else if (riskCountChanged) { shouldPush = true; pushReason = "risk_count_change"; }
     else if (highChanged) { shouldPush = true; pushReason = "high_risk_change"; }
-    if (source === "fallback" && !(deltas?.length) && !catalystFlipped && !riskCountChanged && !highChanged) {
-      shouldPush = false;
-    }
 
     if (shouldPush) {
       const dateLabel = recordDate.slice(5).replace("-","/");
       const title = `The Next AI Bottleneck · ${dateLabel}`;
       let pushText;
-      if (source === "fallback" || !pushLine) {
-        // Deterministic substitute when grounding failed but signals exist.
-        const sParts = [];
-        if (catalystFlipped) sParts.push("catalyst status flip");
-        if (riskCountChanged) sParts.push(`risk count changed (${priorRisks.length}→${risks.length})`);
-        if (highChanged) sParts.push(`High-priority risks ${highCount(priorRisks)}→${highCount(risks)}`);
-        if (deltas?.length) sParts.push(`${deltas.length} new deltas`);
-        pushText = `${title}\n\n${sParts.length ? sParts.join(" · ") : "Narrative refresh pending"}`;
-      } else {
-        pushText = `${title}\n\n${pushLine}`;
-        if (deltas.length) {
-          const d0 = deltas[0];
-          pushText += `\n\n→ ${d0.label || ""}${d0.body ? ` — ${d0.body}` : ""}`;
-        }
+      if (!pushLine) throw new Error("Push requested but ADK returned an empty pushLine");
+      pushText = `${title}\n\n${pushLine}`;
+      if (deltas.length) {
+        const d0 = deltas[0];
+        pushText += `\n\n→ ${d0.label || ""}${d0.body ? ` — ${d0.body}` : ""}`;
       }
       if (pushText.length > 490) pushText = `${pushText.slice(0, 487)}…`;
 
@@ -447,7 +408,7 @@ function clampEnum(val, enumMap, fallback){
       }]);
       log(`Push fired (${pushReason}): ${pushText.length} chars`);
     } else {
-      log("Push suppressed (no signal, fallback + quiet day).");
+      log("Push suppressed (no signal).");
     }
 
     log(`ai-bottleneck narrative: source=${source}, ${deltas.length} deltas, ${catalysts.length} catalysts, ${risks.length} risks.`);

--- a/skills/alva/templates/thesis/example/feeds/ai-bottleneck-news.js
+++ b/skills/alva/templates/thesis/example/feeds/ai-bottleneck-news.js
@@ -176,67 +176,65 @@ const TAG_MAP = {
     // News via Brave
     for (let i=0;i<NEWS_QUERIES.length;i++){
       const q = NEWS_QUERIES[i];
-      try {
-        const r = searchBrave({ query: q.q, freshness: "pw", count: 10 });
-        if (r.success && r.response) {
-          const items = (r.response.news_results?.length) ? r.response.news_results : (r.response.data || []);
-          for (let j=0;j<items.length;j++){
-            const it = items[j];
-            if (!it.url || seenNewsUrls[it.url]) continue;
-            seenNewsUrls[it.url] = true;
-            const desc = (it.description || "").replace(/<[^>]+>/g, "");
-            newsRecords.push({
-              date: it.date || now,
-              title: (it.title || "").slice(0, 240),
-              snippet: desc.slice(0, 400),
-              url: it.url,
-              source: domainOf(it.url) || "web",
-              ids: q.ids.join(","),
-              engagement: 0,
-              sentiment: sentimentGuess(`${it.title||""} ${desc}`),
-              thumbnail: "",
-            });
-          }
-        }
-      } catch (e) { log(`News err ${q.q}: ${e.message}`); }
+      const r = searchBrave({ query: q.q, freshness: "pw", count: 10 });
+      if (!r.success || !r.response) {
+        throw new Error(`Brave news search failed for "${q.q}": ${JSON.stringify(r).slice(0, 500)}`);
+      }
+      const items = (r.response.news_results?.length) ? r.response.news_results : (r.response.data || []);
+      for (let j=0;j<items.length;j++){
+        const it = items[j];
+        if (!it.url || seenNewsUrls[it.url]) continue;
+        seenNewsUrls[it.url] = true;
+        const desc = (it.description || "").replace(/<[^>]+>/g, "");
+        newsRecords.push({
+          date: it.date || now,
+          title: (it.title || "").slice(0, 240),
+          snippet: desc.slice(0, 400),
+          url: it.url,
+          source: domainOf(it.url) || "web",
+          ids: q.ids.join(","),
+          engagement: 0,
+          sentiment: sentimentGuess(`${it.title||""} ${desc}`),
+          thumbnail: "",
+        });
+      }
     }
 
     // Social via GrokX
     const combinedSocialQuery = "AI bottleneck: $NVDA Blackwell allocation, $AVGO custom ASIC, $MU HBM, $TSM CoWoS, $ASML EUV, $GEV turbine backlog, $CEG nuclear PPA, $VST ERCOT, $ETN switchgear, $PWR EPC crews, $FIX data center HVAC, $EQIX renewal spreads — supply constraint power compute deployment";
-    try {
-      const r = searchGrokX({ query: combinedSocialQuery, from_date: from, max_search_results: 25 });
-      if (r.success && r.response) {
-        if (r.response.summary) summaries.push({ query: combinedSocialQuery, summary: r.response.summary });
-        const tweets = r.response.data || r.response.tweets || [];
-        for (let j=0;j<tweets.length;j++){
-          const tw = tweets[j];
-          const id = tw.id || tw.url;
-          if (!id || seenSocialIds[id]) continue;
-          seenSocialIds[id] = true;
-          const likes = tw.like_count||0;
-          const rts = tw.retweet_count||0;
-          const reps = tw.reply_count||0;
-          const eng = likes + rts + reps;
-          if (eng === 0 && !tw.author_verified) continue;
-          const lowerC = (tw.content || "").toLowerCase();
-          const hits = [];
-          for (const key in TAG_MAP){ if (lowerC.indexOf(key) >= 0 && hits.indexOf(TAG_MAP[key]) < 0) hits.push(TAG_MAP[key]); }
-          socialRecords.push({
-            date: tw.created_at || tw.date || now,
-            content: (tw.content || "").slice(0, 600),
-            url: tw.url || "",
-            author_name: tw.author_name || "",
-            author_handle: tw.author_username || "",
-            followers: tw.author_followers_count || 0,
-            verified: tw.author_verified ? 1 : 0,
-            ids: hits.length ? hits.join(",") : "",
-            engagement: eng,
-            sentiment: sentimentGuess(tw.content),
-            likes: likes, retweets: rts, replies: reps,
-          });
-        }
-      }
-    } catch (e) { log(`Social err: ${e.message}`); }
+    const r = searchGrokX({ query: combinedSocialQuery, from_date: from, max_search_results: 25 });
+    if (!r.success || !r.response) {
+      throw new Error(`GrokX social search failed: ${JSON.stringify(r).slice(0, 500)}`);
+    }
+    if (r.response.summary) summaries.push({ query: combinedSocialQuery, summary: r.response.summary });
+    const tweets = r.response.data || r.response.tweets || [];
+    for (let j=0;j<tweets.length;j++){
+      const tw = tweets[j];
+      const id = tw.id || tw.url;
+      if (!id || seenSocialIds[id]) continue;
+      seenSocialIds[id] = true;
+      const likes = tw.like_count||0;
+      const rts = tw.retweet_count||0;
+      const reps = tw.reply_count||0;
+      const eng = likes + rts + reps;
+      if (eng === 0 && !tw.author_verified) continue;
+      const lowerC = (tw.content || "").toLowerCase();
+      const hits = [];
+      for (const key in TAG_MAP){ if (lowerC.indexOf(key) >= 0 && hits.indexOf(TAG_MAP[key]) < 0) hits.push(TAG_MAP[key]); }
+      socialRecords.push({
+        date: tw.created_at || tw.date || now,
+        content: (tw.content || "").slice(0, 600),
+        url: tw.url || "",
+        author_name: tw.author_name || "",
+        author_handle: tw.author_username || "",
+        followers: tw.author_followers_count || 0,
+        verified: tw.author_verified ? 1 : 0,
+        ids: hits.length ? hits.join(",") : "",
+        engagement: eng,
+        sentiment: sentimentGuess(tw.content),
+        likes: likes, retweets: rts, replies: reps,
+      });
+    }
 
     newsRecords.sort((a,b)=> b.date - a.date);
     socialRecords.sort((a,b)=> b.engagement - a.engagement);
@@ -249,47 +247,42 @@ const TAG_MAP = {
     socialRecords = socialRecords.slice(0, 40);
 
     // LLM sentiment pass — AI bottleneck lens
-    try {
-      const items = [];
-      for (let i=0;i<newsRecords.length;i++) items.push({ kind:"news", id:i, text: `${newsRecords[i].title||""} — ${(newsRecords[i].snippet||"").slice(0,180)}` });
-      for (let j=0;j<socialRecords.length;j++) items.push({ kind:"social", id:j, text: (socialRecords[j].content||"").slice(0,220) });
+    const items = [];
+    for (let i=0;i<newsRecords.length;i++) items.push({ kind:"news", id:i, text: `${newsRecords[i].title||""} — ${(newsRecords[i].snippet||"").slice(0,180)}` });
+    for (let j=0;j<socialRecords.length;j++) items.push({ kind:"social", id:j, text: (socialRecords[j].content||"").slice(0,220) });
 
-      if (items.length) {
-        const sysPrompt = [
-          "You tag items for an AI-buildout bottleneck tracker. Thesis: AI deployment is constrained across three supply-side dimensions — Power (turbines, nuclear, grid, switchgear), Compute (GPUs, HBM, fab capacity, EUV), and Deployment (EPC crews, data-center real estate, permits).",
-          "",
-          "For each item return one label (Title Case):",
-          "  Bull = supply is getting tighter or slower: backlogs extending, lead times lengthening, allocation tightening, PPAs signed, skilled-trades scarcity, fab capacity oversubscribed, data-center renewal spreads widening.",
-          "  Bear = supply is loosening or delivering: capacity adds, second sources, substitution, permits fast-tracked, CoWoS capacity expanding faster than expected, hyperscaler capex pause.",
-          "  Neutral = general commentary, macro, demand-side news without supply-behavior signal.",
-          "",
-          "Default to Neutral when uncertain. A demand-growth headline is Neutral, not Bull. We trade supply behavior only.",
-          "",
-          "Return ONLY a JSON array of {\"i\":<index>,\"s\":\"Bull|Bear|Neutral\"}. No prose.",
-        ].join("\n");
-        const userPrompt = `Items (index → text):\n${items.map((it,idx)=> `${idx}. ${it.text}`).join("\n")}`;
+    if (items.length) {
+      const sysPrompt = [
+        "You tag items for an AI-buildout bottleneck tracker. Thesis: AI deployment is constrained across three supply-side dimensions — Power (turbines, nuclear, grid, switchgear), Compute (GPUs, HBM, fab capacity, EUV), and Deployment (EPC crews, data-center real estate, permits).",
+        "",
+        "For each item return one label (Title Case):",
+        "  Bull = supply is getting tighter or slower: backlogs extending, lead times lengthening, allocation tightening, PPAs signed, skilled-trades scarcity, fab capacity oversubscribed, data-center renewal spreads widening.",
+        "  Bear = supply is loosening or delivering: capacity adds, second sources, substitution, permits fast-tracked, CoWoS capacity expanding faster than expected, hyperscaler capex pause.",
+        "  Neutral = general commentary, macro, demand-side news without supply-behavior signal.",
+        "",
+        "Default to Neutral when uncertain. A demand-growth headline is Neutral, not Bull. We trade supply behavior only.",
+        "",
+        "Return ONLY a JSON array of {\"i\":<index>,\"s\":\"Bull|Bear|Neutral\"}. No prose.",
+      ].join("\n");
+      const userPrompt = `Items (index → text):\n${items.map((it,idx)=> `${idx}. ${it.text}`).join("\n")}`;
 
-        const res = await adk.agent({ system: sysPrompt, prompt: userPrompt, tools: [], maxTurns: 1 });
-        const raw = (res?.content) ? res.content.replace(/^```(?:json)?/,"").replace(/```$/,"").trim() : "";
-        const m = raw.match(/\[[\s\S]*\]/);
-        if (m) {
-          let labels;
-          try { labels = JSON.parse(m[0]); } catch(e) { labels = null; }
-          if (Array.isArray(labels)) {
-            for (const l of labels) {
-              const idx = l && typeof l.i === "number" ? l.i : -1;
-              const s = l && typeof l.s === "string" ? l.s : "";
-              if (idx < 0 || idx >= items.length) continue;
-              if (s !== "Bull" && s !== "Bear" && s !== "Neutral") continue;
-              const item = items[idx];
-              if (item.kind === "news") newsRecords[item.id].sentiment = s;
-              else socialRecords[item.id].sentiment = s;
-            }
-            log(`LLM sentiment: re-scored ${labels.length} of ${items.length} items`);
-          }
-        }
+      const res = await adk.agent({ system: sysPrompt, prompt: userPrompt, tools: [], maxTurns: 1 });
+      const raw = (res?.content) ? res.content.replace(/^```(?:json)?/,"").replace(/```$/,"").trim() : "";
+      const m = raw.match(/\[[\s\S]*\]/);
+      if (!m) throw new Error(`LLM sentiment returned non-array JSON: ${raw.slice(0, 400)}`);
+      const labels = JSON.parse(m[0]);
+      if (!Array.isArray(labels)) throw new Error("LLM sentiment JSON is not an array");
+      for (const l of labels) {
+        const idx = l && typeof l.i === "number" ? l.i : -1;
+        const s = l && typeof l.s === "string" ? l.s : "";
+        if (idx < 0 || idx >= items.length) continue;
+        if (s !== "Bull" && s !== "Bear" && s !== "Neutral") continue;
+        const item = items[idx];
+        if (item.kind === "news") newsRecords[item.id].sentiment = s;
+        else socialRecords[item.id].sentiment = s;
       }
-    } catch (e) { log(`LLM sentiment pass failed: ${e.message}`); }
+      log(`LLM sentiment: re-scored ${labels.length} of ${items.length} items`);
+    }
 
     if (newsRecords.length) await ctx.self.ts("items","news").append(newsRecords);
     if (socialRecords.length) await ctx.self.ts("items","social").append(socialRecords);

--- a/skills/alva/templates/thesis/example/feeds/ai-bottleneck.js
+++ b/skills/alva/templates/thesis/example/feeds/ai-bottleneck.js
@@ -178,35 +178,39 @@ function r1(v){ return Math.round(v*10)/10; }
 function r0(v){ return Math.round(v); }
 
 async function loadDaily(ticker, startSec, endSec) {
-  try {
-    const j = await arraysGet("/api/v1/stocks/kline", {
-      symbol: ticker, start_time: startSec, end_time: endSec, interval: "1d", limit: 10000,
+  const j = await arraysGet("/api/v1/stocks/kline", {
+    symbol: ticker, start_time: startSec, end_time: endSec, interval: "1d", limit: 10000,
+  });
+  if (!j || !Array.isArray(j.data)) {
+    throw new Error(`Invalid OHLCV response for ${ticker}`);
+  }
+  // HTTP returns newest-first; reverse to oldest-first
+  const out = [];
+  for (let i = j.data.length - 1; i >= 0; i--) {
+    const b = j.data[i];
+    out.push({
+      date: b.time_open * 1000,
+      endTime: b.time_close * 1000,
+      open: b.price_open,
+      high: b.price_high,
+      low: b.price_low,
+      close: b.price_close,
+      volume: b.volume_traded,
     });
-    if (!j || !Array.isArray(j.data)) return [];
-    // HTTP returns newest-first; reverse to oldest-first
-    const out = [];
-    for (let i = j.data.length - 1; i >= 0; i--) {
-      const b = j.data[i];
-      out.push({
-        date: b.time_open * 1000,
-        endTime: b.time_close * 1000,
-        open: b.price_open,
-        high: b.price_high,
-        low: b.price_low,
-        close: b.price_close,
-        volume: b.volume_traded,
-      });
-    }
-    return out;
-  } catch (e) { console.log(`OHLCV err ${ticker}: ${e.message}`); return []; }
+  }
+  return out;
 }
 
 async function metricSeries(path, params) {
-  try {
-    const j = await arraysGet(path, params);
-    if (!j || !Array.isArray(j.data) || !j.data.length) return [];
-    return j.data[0].values || [];
-  } catch (e) { console.log(`metric err ${path}: ${e.message}`); return []; }
+  const j = await arraysGet(path, params);
+  if (!j || !Array.isArray(j.data)) {
+    throw new Error(`Invalid metric response for ${path}`);
+  }
+  if (!j.data.length) return [];
+  if (!Array.isArray(j.data[0].values)) {
+    throw new Error(`Invalid metric values for ${path}`);
+  }
+  return j.data[0].values;
 }
 
 async function latestMarketMetric(symbol, indicator, startMs, endMs) {
@@ -280,6 +284,10 @@ function classifyValByPct(pePct) {
     const barsArr = await Promise.all(ALL.map(t => loadDaily(t, startSec, nowSec)));
     const bars = {};
     for (let i = 0; i < ALL.length; i++) bars[ALL[i]] = barsArr[i];
+    const missingBars = ALL.filter((t) => !bars[t] || bars[t].length < 2);
+    if (missingBars.length) {
+      throw new Error(`Missing OHLCV bars for: ${missingBars.join(", ")}`);
+    }
 
     // ─── Fundamentals + P/E percentile in parallel ───
     const m30ms = now - 30*86400*1000;

--- a/skills/alva/templates/thesis/template.md
+++ b/skills/alva/templates/thesis/template.md
@@ -13,7 +13,7 @@ swap in your thesis.
 
 The example is the source of truth for **all implementation detail** — CSS,
 widget chassis, ECharts options, sticky behavior, table column alignment, modal
-scaffolding, date-picker wiring, grounding regex, fallback string, push-trigger
+scaffolding, date-picker wiring, grounding regex, error handling, push-trigger
 conditions, methodology copy structure. Do not re-derive any of that from this
 template; read the file.
 
@@ -25,7 +25,7 @@ Files:
   feed: basket, prices, fundamentals, alpha snapshot, hero-push signal.
 - [`example/feeds/ai-bottleneck-narrative.js`](./example/feeds/ai-bottleneck-narrative.js)
   — ADK narrative feed: TLDR + pushLine + deltas + catalysts + risks per day,
-  grounding check, fallback path.
+  grounding check, and thrown errors for failed runs.
 - [`example/feeds/ai-bottleneck-news.js`](./example/feeds/ai-bottleneck-news.js)
   — news + social feed and the post-processing matcher that attaches items to
   catalysts/risks.
@@ -78,7 +78,7 @@ playbook families. The example already conforms — keep it that way.
   names + CSS slugs + colors map, feed names, `USER`, API endpoint).
   `grep -nE` after to catch stragglers.
 - Schema field renames are radioactive: one benchmark rename (e.g. `pave_ytd` →
-  `spy_ytd`) propagates across quant feed schema, narrative fallback copy, HTML
+  `spy_ytd`) propagates across quant feed schema, narrative copy, HTML
   KPI cards, horizon cards, equity chart series, and attribution filters — 3
   feeds + 2500-line HTML in lockstep. Always `sed -i` the bulk rename across all
   files first, then do a single `Read` pass to verify, then use `Edit` only for
@@ -120,7 +120,7 @@ Tab 5.
 
 Implementation lives in `feeds/ai-bottleneck-narrative.js` and
 `feeds/ai-bottleneck-news.js` — read those for the prompt shape, grounding check,
-fallback handling, and matcher rules. Do not re-derive from prose.
+error handling, and matcher rules. Do not re-derive from prose.
 
 ---
 
@@ -152,7 +152,7 @@ recordDate    str   "YYYY-MM-DD"
 generatedAt   int   epoch ms when the agent produced this record
 thesis        str   markdown TLDR body
 pushLine      str   plain-text headline, ≤ 160 chars, used verbatim by push
-source        str   "adk" | "fallback"  — "fallback" blanks thesis & pushLine
+source        str   "adk"
 deltasJson    str   JSON-encoded array of Delta objects
 catalystsJson str   JSON-encoded array of Catalyst objects
 risksJson     str   JSON-encoded array of Risk objects
@@ -293,7 +293,7 @@ has no pillars list; a default-scored basket has no factor weights table):
 - **Thesis pillars** (multi-pillar only) — for each pillar: id, name, one-sentence
   claim, the daily signal that would verify or contradict it.
 - **News matching** — ticker overlap + keyword similarity; unmatched flow to Tab 5.
-- **TLDR generation** — four-question framework, grounding rule, fallback, how
+- **TLDR generation** — four-question framework, grounding rule, thrown errors, how
   `pushLine` is written. Include 1-2 gold few-shot TLDRs (each a `{thesis,
   pushLine}` pair).
 - **Basket selection** — every name by layer; inclusion criteria; change-log

--- a/skills/alva/templates/what-if/example/feed.js
+++ b/skills/alva/templates/what-if/example/feed.js
@@ -56,7 +56,7 @@ async function fetchDaily(symbol, startSec) {
   const j = await arraysGet("/api/v1/stocks/kline", {
     symbol, start_time: startSec, end_time: endSec, interval: "1d", limit: 10000,
   });
-  if (!j || !Array.isArray(j.data)) return [];
+  if (!j || !Array.isArray(j.data)) throw new Error(`Invalid OHLCV response for ${symbol}`);
   const out = [];
   for (let i = j.data.length - 1; i >= 0; i--) {
     const b = j.data[i];
@@ -85,7 +85,7 @@ function eraFor(isoDate) {
 
     console.log("CPER bars:", cperBars.length, "GLD bars:", gldBars.length, "SPY bars:", spyBars.length);
     if (!cperBars.length || !gldBars.length || !spyBars.length) {
-      console.log("ERROR: missing bars"); return;
+      throw new Error("Missing required bars for CPER, GLD, or SPY");
     }
 
     function toMap(bars) {


### PR DESCRIPTION
## Summary

- Document fail-fast feed error handling in the Alva skill entrypoint and Feed SDK reference.
- Update Alva templates and example feeds so unexpected data, upstream feed, LLM parsing, grounding, and write failures throw instead of writing fallback or partial output.
- Keep expected business states, such as no new records since a watermark, as normal conditional paths.

## Why

Feed failures were being hidden by catch-and-continue patterns, fallback records, or empty arrays. Letting errors throw allows the sandbox to capture failed runs and expose broken data sources or invalid response shapes directly.

## Validation

- `git diff --check`
- `node --check` on the updated feed examples:
  - `skills/alva/templates/thesis/example/feeds/ai-bottleneck-news.js`
  - `skills/alva/templates/thesis/example/feeds/ai-bottleneck.js`
  - `skills/alva/templates/thesis/example/feeds/ai-bottleneck-narrative.js`
  - `skills/alva/templates/screener/example/feeds/inflection-screener-feed.js`
  - `skills/alva/templates/what-if/example/feed.js`
- `rg` scan for feed catch/fallback residuals in Alva templates and references
