### PR TITLE
[codex] refresh what-if template example

### DIFF
--- a/skills/alva/templates/what-if/example/feed.js
+++ b/skills/alva/templates/what-if/example/feed.js
@@ -1,7 +1,5 @@
-// Copper/Gold ratio recession signal — feed v1.0.0
-// Remixed from @sheer-alva/copper-gold-ratio-recession-signal
-// Daily copper/gold ratio using CPER / GLD since CPER inception (2011-11-15)
-// Identifies 1-year-low events, computes forward SPX returns
+// SPY 50-day reclaim what-if feed v1.0.0
+// Writes runtime data for an Alva what-if playbook.
 
 const { Feed, feedPath, makeDoc, num, str } = require("@alva/feed");
 const http = require("net/http");
@@ -11,189 +9,259 @@ const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
 const ARRAYS_BASE = "https://data-tools.prd.space.id";
 const ARRAYS_HEADERS = { Authorization: "Bearer " + ARRAYS_JWT };
 
+const FEED_NAME = "spy-50day-reclaim-what-if";
+const SYMBOL = "SPY";
+const START_SEC = Math.floor(Date.UTC(1993, 0, 29) / 1000);
+const END_SEC = Math.floor(Date.UTC(2027, 0, 1) / 1000);
+const COOLDOWN_DAYS = 21;
+const BELOW_50D_DAYS = 5;
+const HORIZONS = [
+  { key: "fwd_week_pct", label: "A week later", days: 5 },
+  { key: "fwd_month_pct", label: "A month later", days: 21 },
+  { key: "fwd_three_months_pct", label: "Three months later", days: 63 },
+  { key: "fwd_six_months_pct", label: "Six months later", days: 126 },
+  { key: "fwd_year_pct", label: "A year later", days: 252 },
+];
+const DISPLAYED_HORIZON_LABELS = new Set(["A week later", "A month later", "Three months later", "A year later"]);
+
 async function arraysGet(path, params) {
   const qs = Object.keys(params)
-    .filter((k) => params[k] !== undefined && params[k] !== null)
-    .map((k) => encodeURIComponent(k) + "=" + encodeURIComponent(params[k]))
+    .filter((key) => params[key] !== undefined && params[key] !== null)
+    .map((key) => encodeURIComponent(key) + "=" + encodeURIComponent(params[key]))
     .join("&");
   const url = ARRAYS_BASE + path + (qs ? "?" + qs : "");
-  const r = await http.fetch(url, { headers: ARRAYS_HEADERS });
-  if (r.status < 200 || r.status >= 300) throw new Error("HTTP " + r.status + " " + path);
-  return JSON.parse(await r.text());
+  const response = await http.fetch(url, { headers: ARRAYS_HEADERS });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error("HTTP " + response.status + " " + path);
+  }
+  return JSON.parse(await response.text());
 }
 
-const COOLDOWN_DAYS = 90;
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
 
-const feed = new Feed({ path: feedPath("copper-gold-recession-signal") });
+function median(values) {
+  if (!values.length) return null;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function pct(value) {
+  return value == null ? null : +(value * 100).toFixed(4);
+}
+
+function round(value, digits) {
+  if (value == null || !Number.isFinite(value)) return null;
+  const p = Math.pow(10, digits);
+  return Math.round(value * p) / p;
+}
+
+function toIsoDay(bar) {
+  if (bar.time_period_start) return bar.time_period_start.slice(0, 10);
+  return new Date(bar.time_open * 1000).toISOString().slice(0, 10);
+}
+
+const feed = new Feed({ path: feedPath(FEED_NAME) });
 
 feed.def("series", {
-  daily: makeDoc(
-    "Daily copper/gold ratio over full history",
-    "One row per trading day with ratio value",
-    [str("date_iso"), num("ratio"), num("cper_close"), num("gld_close"), num("spy_close")]
-  ),
-});
-
-feed.def("events", {
-  rows: makeDoc(
-    "1-year-low ratio events with forward SPX returns",
-    "One row per new 1-year-low event + forward returns",
-    [str("event_date"), num("ratio_at_event"), num("prior_1y_low"), num("prior_1y_high"), num("fwd_1m_pct"), num("fwd_3m_pct"), num("fwd_6m_pct"), num("fwd_12m_pct"), str("era_label")]
-  ),
-});
-
-feed.def("summary", {
-  stats: makeDoc("Summary stats","",[
-    num("n_events"), num("latest_ratio"), str("latest_ratio_date"),
-    num("median_fwd_1m_pct"), num("median_fwd_3m_pct"), num("median_fwd_6m_pct"), num("median_fwd_12m_pct"),
-    num("mean_fwd_3m_pct"), num("n_positive_fwd_3m"),
-    num("spx_baseline_3m_pct"), num("spx_baseline_12m_pct")
+  daily: makeDoc("SPY daily line", "Daily close, 200-day line, and signal markers", [
+    str("date_iso"),
+    num("close"),
+    num("ma200"),
+    num("is_signal"),
   ]),
 });
 
-async function fetchDaily(symbol, startSec) {
-  const endSec = Math.floor(Date.UTC(2027,5,1)/1000);
-  const j = await arraysGet("/api/v1/stocks/kline", {
-    symbol, start_time: startSec, end_time: endSec, interval: "1d", limit: 10000,
-  });
-  if (!j || !Array.isArray(j.data)) throw new Error(`Invalid OHLCV response for ${symbol}`);
-  const out = [];
-  for (let i = j.data.length - 1; i >= 0; i--) {
-    const b = j.data[i];
-    out.push({ date: b.time_open * 1000, close: b.price_close });
-  }
-  return out;
-}
+feed.def("events", {
+  rows: makeDoc("50-day reclaim setup rows", "One row per de-duplicated setup with forward returns", [
+    str("event_date"),
+    str("entry_date"),
+    num("close_at_event"),
+    num("above_200d_pct"),
+    num("fwd_week_pct"),
+    num("fwd_month_pct"),
+    num("fwd_three_months_pct"),
+    num("fwd_six_months_pct"),
+    num("fwd_year_pct"),
+  ]),
+});
 
-function eraFor(isoDate) {
-  const y = parseInt(isoDate.slice(0,4),10);
-  if (y <= 2008) return "Pre-GFC / GFC era";
-  if (y <= 2013) return "Post-GFC recovery";
-  if (y <= 2019) return "2010s low-rate era";
-  if (y <= 2021) return "COVID era";
-  return "2022-present rate-hike cycle";
-}
+feed.def("horizons", {
+  rows: makeDoc("Forward horizon stats", "Median, mean, positive count, and typical-day comparison by horizon", [
+    str("label"),
+    num("days"),
+    num("event_median_pct"),
+    num("event_mean_pct"),
+    num("positive_count"),
+    num("event_count"),
+    num("typical_day_median_pct"),
+    num("edge_pct"),
+    num("low_pct"),
+    num("high_pct"),
+  ]),
+});
+
+feed.def("summary", {
+  stats: makeDoc("Playbook summary", "Headline values consumed by the verdict card", [
+    num("n_events"),
+    num("start_year"),
+    str("best_label"),
+    num("best_median_pct"),
+    num("best_typical_day_pct"),
+    num("best_edge_pct"),
+    num("best_positive_rate_pct"),
+    num("worst_year_later_pct"),
+    str("latest_signal_date"),
+  ]),
+});
 
 (async () => {
   await feed.run(async (ctx) => {
-    const CPER_START = Math.floor(Date.UTC(2011,10,15)/1000);
-    const [cperBars, gldBars, spyBars] = await Promise.all([
-      fetchDaily("CPER", CPER_START),
-      fetchDaily("GLD", CPER_START),
-      fetchDaily("SPY", CPER_START),
-    ]);
-
-    console.log("CPER bars:", cperBars.length, "GLD bars:", gldBars.length, "SPY bars:", spyBars.length);
-    if (!cperBars.length || !gldBars.length || !spyBars.length) {
-      throw new Error("Missing required bars for CPER, GLD, or SPY");
+    let raw;
+    try {
+      raw = await arraysGet("/api/v1/stocks/kline", {
+        symbol: SYMBOL,
+        start_time: START_SEC,
+        end_time: END_SEC,
+        interval: "1d",
+        limit: 10000,
+      });
+    } catch (error) {
+      throw error;
     }
 
-    function toMap(bars) {
-      const m = new Map();
-      for (const b of bars) m.set(new Date(b.date).toISOString().slice(0,10), b.close);
-      return m;
-    }
-    const cperMap = toMap(cperBars);
-    const gldMap = toMap(gldBars);
-    const spyMap = toMap(spyBars);
-
-    const dates = [...new Set([...cperMap.keys()].filter(d => gldMap.has(d) && spyMap.has(d)))].sort();
-    console.log("aligned days:", dates.length, "first:", dates[0], "last:", dates[dates.length-1]);
-
-    const series = [];
-    for (const d of dates) {
-      const cper = cperMap.get(d);
-      const gld = gldMap.get(d);
-      const spy = spyMap.get(d);
-      const ratio = cper / gld;
-      series.push({date_iso: d, ratio, cper, gld, spy});
+    if (!raw || !Array.isArray(raw.data) || raw.data.length < 300) {
+      throw new Error("Not enough SPY daily bars");
     }
 
+    let rows = raw.data
+      .map((bar) => ({
+        date: toIsoDay(bar),
+        close: Number(bar.price_close),
+      }))
+      .filter((row) => row.date && Number.isFinite(row.close))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    let continuousStart = 0;
+    for (let i = 1; i < rows.length; i++) {
+      const gapDays = (Date.parse(rows[i].date + "T00:00:00Z") - Date.parse(rows[i - 1].date + "T00:00:00Z")) / 86400000;
+      if (gapDays > 10) continuousStart = i;
+    }
+    if (continuousStart > 0) rows = rows.slice(continuousStart);
+
+    for (let i = 49; i < rows.length; i++) {
+      rows[i].ma50 = mean(rows.slice(i - 49, i + 1).map((row) => row.close));
+    }
+    for (let i = 199; i < rows.length; i++) {
+      rows[i].ma200 = mean(rows.slice(i - 199, i + 1).map((row) => row.close));
+    }
+
+    const maxHorizon = Math.max.apply(null, HORIZONS.map((horizon) => horizon.days));
     const events = [];
-    let lastIdx = -COOLDOWN_DAYS - 1;
-    for (let i=252; i<series.length; i++) {
-      let min = Infinity, max = -Infinity;
-      for (let j=i-252; j<i; j++) {
-        if (series[j].ratio < min) min = series[j].ratio;
-        if (series[j].ratio > max) max = series[j].ratio;
+    let lastSignalIndex = -Infinity;
+
+    for (let i = 203; i < rows.length - maxHorizon - 1; i++) {
+      let wasBelow50 = true;
+      for (let j = 1; j <= BELOW_50D_DAYS; j++) {
+        wasBelow50 = wasBelow50 && rows[i - j].ma50 && rows[i - j].close < rows[i - j].ma50;
       }
-      if (series[i].ratio < min && (i - lastIdx) >= COOLDOWN_DAYS) {
-        events.push({idx: i, ratio: series[i].ratio, prior_1y_low: min, prior_1y_high: max, date: series[i].date_iso});
-        lastIdx = i;
+      const reclaim50 = rows[i].ma50 && rows[i].close > rows[i].ma50 && rows[i - 1].close <= rows[i - 1].ma50;
+      const aboveLine = rows[i].ma200 && rows[i].close > rows[i].ma200;
+      const separated = i - lastSignalIndex >= COOLDOWN_DAYS;
+
+      if (wasBelow50 && reclaim50 && aboveLine && separated) {
+        const entryIndex = i + 1;
+        const event = {
+          signalIndex: i,
+          entryIndex,
+          event_date: rows[i].date,
+          entry_date: rows[entryIndex].date,
+          close_at_event: round(rows[i].close, 4),
+          above_200d_pct: pct(rows[i].close / rows[i].ma200 - 1),
+        };
+        HORIZONS.forEach((horizon) => {
+          event[horizon.key] = pct(rows[entryIndex + horizon.days].close / rows[entryIndex].close - 1);
+        });
+        events.push(event);
+        lastSignalIndex = i;
       }
     }
-    console.log("1yr-low events:", events.length);
 
+    const horizonRows = HORIZONS.map((horizon) => {
+      const eventValues = events.map((event) => event[horizon.key]).filter((value) => value != null);
+      const typicalValues = [];
+      for (let i = 199; i < rows.length - horizon.days; i++) {
+        typicalValues.push(pct(rows[i + horizon.days].close / rows[i].close - 1));
+      }
+      const med = median(eventValues);
+      const typicalMed = median(typicalValues);
+      return {
+        label: horizon.label,
+        days: horizon.days,
+        event_median_pct: round(med, 4),
+        event_mean_pct: round(mean(eventValues), 4),
+        positive_count: eventValues.filter((value) => value > 0).length,
+        event_count: eventValues.length,
+        typical_day_median_pct: round(typicalMed, 4),
+        edge_pct: round(med - typicalMed, 4),
+        low_pct: round(Math.min.apply(null, eventValues), 4),
+        high_pct: round(Math.max.apply(null, eventValues), 4),
+      };
+    });
+
+    const best = horizonRows
+      .filter((row) => DISPLAYED_HORIZON_LABELS.has(row.label))
+      .sort((a, b) => b.edge_pct - a.edge_pct)[0] || horizonRows[0];
+    const yearEvents = events.map((event) => event.fwd_year_pct).filter((value) => value != null);
     const runTs = Date.now();
     let seq = 0;
 
-    const serRows = [];
-    for (let i=0; i<series.length; i+=5) {
-      const s = series[i];
-      serRows.push({
-        date: runTs+seq++,
-        date_iso: s.date_iso,
-        ratio: +s.ratio.toFixed(6),
-        cper_close: +s.cper.toFixed(4),
-        gld_close: +s.gld.toFixed(4),
-        spy_close: +s.spy.toFixed(4),
+    const signalDates = new Set(events.map((event) => event.event_date));
+    const seriesRows = [];
+    for (let i = 199; i < rows.length; i++) {
+      seriesRows.push({
+        date: runTs + seq++,
+        date_iso: rows[i].date,
+        close: round(rows[i].close, 4),
+        ma200: round(rows[i].ma200, 4),
+        is_signal: signalDates.has(rows[i].date) ? 1 : 0,
       });
     }
-    if (serRows.length) await ctx.self.ts("series","daily").append(serRows);
-    console.log("series rows written:", serRows.length);
 
-    const evRows = [];
-    for (const ev of events) {
-      const i = ev.idx;
-      const base = series[i].spy;
-      const horizonDays = {fwd_1m: 21, fwd_3m: 63, fwd_6m: 126, fwd_12m: 252};
-      const rowFwd = {};
-      for (const [k, d] of Object.entries(horizonDays)) {
-        const j = i + d;
-        if (j < series.length) rowFwd[k + "_pct"] = +((series[j].spy/base - 1)*100).toFixed(4);
-        else rowFwd[k + "_pct"] = null;
-      }
-      evRows.push({
-        date: runTs+seq++,
-        event_date: ev.date,
-        ratio_at_event: +ev.ratio.toFixed(6),
-        prior_1y_low: +ev.prior_1y_low.toFixed(6),
-        prior_1y_high: +ev.prior_1y_high.toFixed(6),
-        ...rowFwd,
-        era_label: eraFor(ev.date),
-      });
-    }
-    if (evRows.length) await ctx.self.ts("events","rows").append(evRows);
+    const eventRows = events.map((event) => ({
+      date: runTs + seq++,
+      event_date: event.event_date,
+      entry_date: event.entry_date,
+      close_at_event: event.close_at_event,
+      above_200d_pct: event.above_200d_pct,
+      fwd_week_pct: event.fwd_week_pct,
+      fwd_month_pct: event.fwd_month_pct,
+      fwd_three_months_pct: event.fwd_three_months_pct,
+      fwd_six_months_pct: event.fwd_six_months_pct,
+      fwd_year_pct: event.fwd_year_pct,
+    }));
 
-    const baseline3m = [], baseline12m = [];
-    for (let i=0; i<series.length-252; i+=21) {
-      const b = series[i].spy;
-      baseline3m.push((series[i+63].spy/b - 1)*100);
-      baseline12m.push((series[i+252].spy/b - 1)*100);
-    }
-    const mean = a=>a.length?a.reduce((s,v)=>s+v,0)/a.length:null;
-    const median = a=>{if(!a.length)return null;const s=[...a].sort((x,y)=>x-y);return s.length%2?s[(s.length-1)/2]:(s[s.length/2-1]+s[s.length/2])/2;};
-
-    const fwd3 = evRows.map(r=>r.fwd_3m_pct).filter(v=>v!=null);
-    const fwd1 = evRows.map(r=>r.fwd_1m_pct).filter(v=>v!=null);
-    const fwd6 = evRows.map(r=>r.fwd_6m_pct).filter(v=>v!=null);
-    const fwd12 = evRows.map(r=>r.fwd_12m_pct).filter(v=>v!=null);
-
-    const stats = {
-      date: runTs+seq++,
+    const horizonOut = horizonRows.map((row) => ({ date: runTs + seq++, ...row }));
+    const summary = {
+      date: runTs + seq++,
       n_events: events.length,
-      latest_ratio: +series[series.length-1].ratio.toFixed(6),
-      latest_ratio_date: series[series.length-1].date_iso,
-      median_fwd_1m_pct: fwd1.length? +median(fwd1).toFixed(4) : null,
-      median_fwd_3m_pct: fwd3.length? +median(fwd3).toFixed(4) : null,
-      median_fwd_6m_pct: fwd6.length? +median(fwd6).toFixed(4) : null,
-      median_fwd_12m_pct: fwd12.length? +median(fwd12).toFixed(4) : null,
-      mean_fwd_3m_pct: fwd3.length? +mean(fwd3).toFixed(4) : null,
-      n_positive_fwd_3m: fwd3.filter(v=>v>0).length,
-      spx_baseline_3m_pct: baseline3m.length? +median(baseline3m).toFixed(4) : null,
-      spx_baseline_12m_pct: baseline12m.length? +median(baseline12m).toFixed(4) : null,
+      start_year: Number(rows[0].date.slice(0, 4)),
+      best_label: best.label,
+      best_median_pct: best.event_median_pct,
+      best_typical_day_pct: best.typical_day_median_pct,
+      best_edge_pct: best.edge_pct,
+      best_positive_rate_pct: round((best.positive_count / best.event_count) * 100, 2),
+      worst_year_later_pct: round(Math.min.apply(null, yearEvents), 4),
+      latest_signal_date: events.length ? events[events.length - 1].event_date : "",
     };
-    console.log("summary:", JSON.stringify(stats));
-    await ctx.self.ts("summary","stats").append([stats]);
+
+    await ctx.self.ts("series", "daily").append(seriesRows);
+    await ctx.self.ts("events", "rows").append(eventRows);
+    await ctx.self.ts("horizons", "rows").append(horizonOut);
+    await ctx.self.ts("summary", "stats").append([summary]);
+
+    console.log("SPY bars:", rows.length, "signals:", events.length, "best:", best.label, best.edge_pct);
   });
 })();

--- a/skills/alva/templates/what-if/example/index.html
+++ b/skills/alva/templates/what-if/example/index.html
@@ -3,335 +3,499 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>The S&amp;P 500 After a Copper-to-Gold One-Year Low — 15-Year What-If</title>
+<title>SPY 50-Day Reclaim What-If</title>
 <link rel="stylesheet" href="https://alva-ai-static.b-cdn.net/design-system/design-tokens.css" />
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <style>
-  *, *::before, *::after { box-sizing:border-box; -ms-overflow-style:none; scrollbar-width:none; }
-  *::-webkit-scrollbar { display:none; }
-
-  html { height:100%; overflow:hidden; }
-  body {
-    height:100%; overflow-y:auto; overflow-x:hidden; margin:0;
-    background:var(--b0-page); color:var(--text-n9);
-    font-family:'Delight', -apple-system, 'OPPO Sans 4.0', BlinkMacSystemFont, sans-serif;
-    font-weight:400;
-    -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale; text-rendering:optimizeLegibility;
+  *, *::before, *::after {
+    box-sizing: border-box;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
   }
-  a { color:var(--text-n9); text-decoration:underline; }
-  strong, b { font-weight:500; }
+  *::-webkit-scrollbar { display: none; }
+  html { height: 100%; overflow: hidden; }
+  body {
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    margin: 0;
+    background: var(--b0-page);
+    color: var(--text-n9);
+    font-family: "Delight", -apple-system, "OPPO Sans 4.0", BlinkMacSystemFont, sans-serif;
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+  strong, b { font-weight: 500; }
 
   .playbook-container {
-    width:100%; max-width:2048px; margin:0 auto;
-    padding: var(--spacing-m) var(--spacing-xxl) var(--spacing-xxxxl);
+    width: 100%;
+    max-width: 2048px;
+    margin: 0 auto;
+    padding: var(--spacing-l) var(--spacing-xxl) var(--spacing-xxxxl);
   }
-  @media (max-width:768px) {
-    .playbook-container { padding: 0 var(--spacing-m) var(--spacing-xxxxl); }
+  @media (max-width: 768px) {
+    .playbook-container { padding: var(--spacing-m); }
   }
 
-  .section-title {
-    display:flex; width:100%; align-items:center; gap:12px;
-    margin-top: var(--spacing-xxl);
+  .title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-m);
     margin-bottom: var(--spacing-m);
-    flex-wrap: wrap;
   }
-  .playbook-container > .section-title:first-child { margin-top: var(--spacing-xs); }
-  .section-title-text {
-    font-size:20px; font-weight:400;
-    color: var(--text-n9); letter-spacing:0.2px; line-height:28px;
+  .playbook-title {
+    margin: 0;
+    font-size: 20px;
+    line-height: 28px;
+    letter-spacing: 0.2px;
+    font-weight: 400;
+    color: var(--text-n9);
   }
-  .section-readme-btn {
-    margin-left:auto;
-    display:inline-flex; align-items:center; gap: var(--spacing-xxs);
-    height:24px; padding: var(--spacing-xxxs) var(--spacing-xs);
+
+  .pb-meta-link--readme.tab-readme {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xxs);
+    height: 24px;
+    padding: var(--spacing-xxxs) var(--spacing-xs);
     background: var(--b-r02);
     border: 0.5px solid var(--line-l2);
     border-radius: var(--radius-ct-s);
-    font-family: inherit; font-size:12px; line-height:20px; letter-spacing:0.12px;
-    color: var(--text-n9); cursor:pointer;
-    transition: background .15s ease, border-color .15s ease;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 20px;
+    letter-spacing: 0.12px;
+    color: var(--text-n9);
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
   }
-  .section-readme-btn:hover,
-  .section-readme-btn:active {
+  .pb-meta-link--readme.tab-readme .pb-meta-icon-badge {
+    width: 14px;
+    height: 14px;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+  }
+  .pb-meta-link--readme.tab-readme .pb-meta-icon-img {
+    width: 14px;
+    height: 14px;
+  }
+  .pb-meta-link--readme.tab-readme:hover,
+  .pb-meta-link--readme.tab-readme:active,
+  .pb-meta-link--readme.tab-readme.is-open {
     background: var(--b-r03);
     border-color: var(--line-l9);
+    opacity: 1;
   }
-  .section-readme-icon {
-    width:14px; height:14px; flex-shrink:0;
-    background-color: currentColor;
-    -webkit-mask: url('https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg') center / contain no-repeat;
-            mask: url('https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg') center / contain no-repeat;
-  }
+  .pb-meta-link--readme.tab-readme:hover .pb-meta-icon-img { filter: brightness(0); }
 
   .widget-grid {
-    display:grid; grid-template-columns: repeat(8, 1fr);
-    gap: var(--spacing-xl); align-items: stretch;
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: var(--spacing-xl);
+    align-items: stretch;
   }
   .widget-grid + .widget-grid { margin-top: var(--spacing-xl); }
   .col-2 { grid-column: span 2; }
-  .col-4 { grid-column: span 4; }
+  .col-3 { grid-column: span 3; }
+  .col-5 { grid-column: span 5; }
   .col-8 { grid-column: span 8; }
+  .col-thirds {
+    grid-column: span 8;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-xl);
+    align-items: stretch;
+  }
   @media (max-width: 768px) {
-    .widget-grid { grid-template-columns: repeat(4, 1fr); gap: var(--spacing-l); }
+    .widget-grid {
+      grid-template-columns: repeat(4, 1fr);
+      gap: var(--spacing-l);
+    }
     .col-2 { grid-column: span 2; }
-    .col-4, .col-8 { grid-column: span 4; }
+    .col-3, .col-5, .col-8, .col-thirds { grid-column: span 4; }
+    .col-thirds { grid-template-columns: 1fr; }
   }
 
   .widget-card {
     background: transparent;
-    display:flex; flex-direction:column;
-    position:relative; overflow:visible;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: visible;
   }
+  .widget-card:has(.chart-body) { overflow: hidden; }
   .widget-title {
-    display:flex; align-items:center; justify-content:space-between;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: var(--spacing-m);
   }
   .widget-title-text {
-    font-size:16px; font-weight:400; color:var(--text-n9);
-    letter-spacing:0.16px; line-height:26px;
-  }
-  .widget-subtitle {
-    font-size:12px; line-height:20px; letter-spacing:0.12px;
-    color: var(--text-n5);
-    margin-top: calc(-1 * var(--spacing-xs));
-    margin-bottom: var(--spacing-m);
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--text-n9);
+    letter-spacing: 0.14px;
+    line-height: 22px;
   }
   .widget-body {
-    display:flex; border-radius: var(--radius-ct-s);
-  }
-  .alva-watermark {
-    position:absolute; bottom: var(--spacing-m); right: var(--spacing-m);
-    opacity:0.2; line-height:0; pointer-events:none;
+    display: flex;
+    border-radius: var(--radius-ct-s);
   }
 
-  .free-text-body { padding: var(--spacing-l); width:100%; }
-  .markdown-container {
-    width:100%; display:flex; flex-direction:column;
-    gap: var(--spacing-m);
-  }
-  .markdown-container p {
-    font-family:'Delight', sans-serif;
-    font-size:16px; line-height:26px; letter-spacing:0.16px;
-    color: var(--text-n9); margin:0; white-space:pre-wrap;
-  }
-  .markdown-container--m { gap: var(--spacing-xs); }
-  .markdown-container--m p {
-    font-size:14px; line-height:22px; letter-spacing:0.14px;
-  }
-  .markdown-container .pos { color: var(--main-m3); font-weight:500; }
-  .markdown-container .neg { color: var(--main-m4); font-weight:500; }
-
-  .kpi-body {
+  .hero,
+  .belief,
+  .rail-card,
+  .case-card,
+  .range-card,
+  .free-text-body {
     background: var(--grey-g01);
     border-radius: var(--radius-ct-s);
-    padding: var(--spacing-l);
-    display:flex; flex-direction:column; gap: var(--spacing-xxs);
-    position:relative;
+    padding: var(--spacing-xl);
   }
-  .kpi-label {
-    font-size:12px; line-height:20px; letter-spacing:0.12px;
-    color: var(--text-n7);
-  }
-  .kpi-value {
-    font-size:28px; line-height:36px; letter-spacing:0.28px;
-    color: var(--text-n9); font-weight:400;
-    font-variant-numeric: tabular-nums;
-  }
-  .kpi-value.pos { color: var(--main-m3); }
-  .kpi-value.neg { color: var(--main-m4); }
-  .kpi-foot {
-    font-size:12px; line-height:18px; letter-spacing:0.12px;
-    color: var(--text-n5);
-  }
-
-  .widget-card:has(.chart-body) { overflow:hidden; }
-  .chart-dotted-background {
-    background-image: radial-gradient(circle, rgba(0,0,0,0.18) 0.6px, transparent 0.6px);
-    background-size: 3px 3px;
-  }
-  .chart-body {
-    flex:1; padding: var(--spacing-m);
-    position:relative;
-    border-radius: var(--radius-ct-s);
-  }
-  .chart-container { width:100%; height:100%; min-height:180px; }
-
-  .table-card {
-    display:flex; flex-direction:column;
-    width:100%; isolation:isolate;
-    overflow-x:auto;
-  }
-  .table-row {
-    display:flex; width:100%;
+  .hero {
+    min-height: 184px;
+    display: flex;
+    flex-direction: column;
     gap: var(--spacing-m);
-    border-bottom: 1px solid var(--line-l07);
-    padding: 12px 0;
   }
-  .table-row.table-header { padding: 0 0 12px 0; }
-  .table-row:last-child { border-bottom: none; }
-  .table-cell {
-    font-size:14px; line-height:22px; letter-spacing:0.14px;
-    font-weight:400; white-space:nowrap;
-    display:flex; align-items:center;
+  .chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xs);
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 0 var(--spacing-s);
+    border-radius: var(--radius-ct-s);
+    background: var(--b0-page);
+    color: var(--text-n7);
+    font-size: 12px;
+    line-height: 18px;
+  }
+  .chip:first-child {
+    background: var(--main-m5-10);
     color: var(--text-n9);
   }
-  .table-row.table-header .table-cell { color: var(--text-n7); }
+  .hero-sentence {
+    margin: 0;
+    max-width: 1160px;
+    font-size: 28px;
+    line-height: 38px;
+    font-weight: 400;
+    letter-spacing: 0;
+  }
+  .support,
+  .muted,
+  .section-note {
+    color: var(--text-n7);
+    font-size: 14px;
+    line-height: 22px;
+  }
+  .support {
+    margin: 0;
+    max-width: 960px;
+  }
+  .belief-strip {
+    grid-column: span 8;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-xl);
+  }
+  @media (max-width: 768px) {
+    .belief-strip { grid-column: span 4; grid-template-columns: 1fr; }
+    .hero-sentence { font-size: 22px; line-height: 30px; }
+  }
+  .eyebrow {
+    margin: 0 0 var(--spacing-xs);
+    color: var(--text-n5);
+    font-size: 12px;
+    line-height: 18px;
+  }
+  .belief-text {
+    margin: 0;
+    color: var(--text-n9);
+    font-size: 18px;
+    line-height: 26px;
+  }
+
+  .chart-body {
+    flex: 1;
+    position: relative;
+    padding: var(--spacing-m);
+    overflow: hidden;
+  }
+  .chart-body.primary { min-height: 440px; }
+  .chart-body.short { min-height: 340px; }
+  .chart-dotted-background {
+    background-image: radial-gradient(circle, rgba(0, 0, 0, 0.18) 0.6px, transparent 0.6px);
+    background-size: 3px 3px;
+  }
+	  .chart-container {
+	    width: 100%;
+	    height: 100%;
+	    min-height: 180px;
+	  }
+	  .case-bar-chart .chart-container { min-height: 300px; }
+  .alva-watermark {
+    position: absolute;
+    bottom: var(--spacing-m);
+    right: var(--spacing-m);
+    opacity: 0.2;
+    line-height: 0;
+    pointer-events: none;
+  }
+  .alva-watermark img {
+    width: 56px;
+    height: auto;
+  }
+
+  .insight-rail,
+  .range-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+  }
+  .rail-card { flex: 1; }
+  .rail-card strong,
+  .range-card strong {
+    display: block;
+    color: var(--text-n9);
+    font-size: 22px;
+    line-height: 30px;
+    font-weight: 400;
+    margin-top: var(--spacing-xs);
+  }
+  .rail-card p,
+  .range-card p {
+    margin: var(--spacing-xs) 0 0;
+    color: var(--text-n7);
+    font-size: 14px;
+    line-height: 22px;
+  }
+
+  .metric-body {
+    position: relative;
+    background: var(--grey-g01);
+    padding: var(--spacing-l);
+    flex-direction: column;
+    align-items: flex-start;
+    min-height: 160px;
+  }
+  .metric-value {
+    display: block;
+    margin-top: var(--spacing-s);
+    font-size: 28px;
+    line-height: 36px;
+    font-weight: 400;
+    font-variant-numeric: tabular-nums;
+  }
+  .metric-body p {
+    margin: var(--spacing-xs) 0 0;
+    color: var(--text-n7);
+    font-size: 13px;
+    line-height: 20px;
+  }
+  .positive { color: var(--main-m3); }
+  .negative { color: var(--main-m4); }
+  .neutral { color: var(--text-n9); }
+
+  .case-card { min-height: 188px; }
+  .case-title {
+    color: var(--text-n9);
+    font-size: 20px;
+    line-height: 28px;
+  }
+  .case-result {
+    margin-top: var(--spacing-m);
+    color: var(--text-n9);
+    font-size: 17px;
+    line-height: 25px;
+  }
+  .case-card p {
+    margin: var(--spacing-xs) 0 0;
+    color: var(--text-n7);
+    font-size: 14px;
+    line-height: 22px;
+  }
+
+	  .table-card {
+	    display: flex;
+	    flex-direction: column;
+	    width: 100%;
+	    isolation: isolate;
+	    overflow-x: auto;
+	  }
+	  .table-caption {
+	    margin: 0 0 var(--spacing-m);
+	    color: var(--text-n5);
+	    font-size: 12px;
+	    line-height: 18px;
+	  }
+	  .audit-toggle {
+	    display: inline-flex;
+	    align-items: center;
+	    min-height: 28px;
+	    padding: 0 var(--spacing-s);
+	    background: var(--b-r02);
+	    border: 0.5px solid var(--line-l2);
+	    border-radius: var(--radius-ct-s);
+	    color: var(--text-n7);
+	    font-family: inherit;
+	    font-size: 12px;
+	    line-height: 18px;
+	    cursor: pointer;
+	    transition: background 0.15s, border-color 0.15s, color 0.15s;
+	  }
+	  .audit-toggle:hover {
+	    background: var(--b-r03);
+	    border-color: var(--line-l9);
+	    color: var(--text-n9);
+	  }
+	  .table-row {
+	    display: flex;
+	    width: 100%;
+	    gap: var(--spacing-m);
+	    border-bottom: 1px solid var(--line-l07);
+  }
+  .table-row:last-child { border-bottom: none; }
+  .table-cell {
+    font-size: 14px;
+    line-height: 22px;
+    letter-spacing: 0.14px;
+    font-weight: 400;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    color: var(--text-n9);
+  }
+  .table-header .table-cell {
+    color: var(--text-n7);
+    padding: 0 0 12px 0;
+  }
+  .table-body-row .table-cell { padding: 12px 0; }
   .cell-right { justify-content: flex-end; }
-  .cell-pos { color: var(--main-m3); }
-  .cell-neg { color: var(--main-m4); }
-  .cell-muted { color: var(--text-n5); }
+
+  .free-text-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    position: relative;
+  }
+  .free-text-body p {
+    margin: 0;
+    color: var(--text-n7);
+    font-size: 14px;
+    line-height: 22px;
+  }
+
+  .state {
+    grid-column: span 8;
+    background: var(--grey-g01);
+    border-radius: var(--radius-ct-s);
+    padding: var(--spacing-xl);
+    color: var(--text-n7);
+  }
 
   .modal-overlay {
-    display:none; position:fixed; inset:0; z-index:1000;
-    background: rgba(0,0,0,0.4);
-    padding: var(--spacing-xxxxl) var(--spacing-m);
-    align-items:center; justify-content:center;
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    width: 100%;
+    height: 100%;
+    background: var(--main-m7);
+    padding: var(--spacing-xxxxxl) var(--spacing-m);
+    align-items: center;
+    justify-content: center;
   }
-  .modal-overlay.open { display:flex; }
+  .modal-overlay.open { display: flex; }
   .modal-panel {
-    background: var(--b0-container, #fff);
-    width:100%; max-width: 896px;
-    max-height: 100%;
-    border-radius: 12px;
+    background: var(--b0-container);
+    max-width: 896px;
+    width: 100%;
+    flex: 1 0 0;
+    border-radius: var(--radius-pop-dialog);
     border: 0.5px solid var(--line-l2);
     padding: var(--spacing-xxl);
-    display:flex; flex-direction:column; gap: var(--spacing-m);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
   }
   .modal-title {
-    display:flex; align-items:center; justify-content:space-between;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     gap: var(--spacing-s);
-    font-family: 'Delight', sans-serif; font-weight:500;
-    font-size:18px; line-height:28px; letter-spacing:0.18px;
+    font-weight: 500;
+    font-size: 18px;
+    line-height: 28px;
+    letter-spacing: 0.18px;
     color: var(--text-n9);
   }
   .modal-close {
-    width:18px; height:18px; flex-shrink:0; cursor:pointer;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    cursor: pointer;
     background-color: var(--text-n9);
-    -webkit-mask: url('https://alva-ai-static.b-cdn.net/icons/close-l1.svg') center / contain no-repeat;
-            mask: url('https://alva-ai-static.b-cdn.net/icons/close-l1.svg') center / contain no-repeat;
-    transition: opacity .15s ease;
+    -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
+    mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center / contain no-repeat;
+    transition: opacity 0.15s ease;
   }
   .modal-close:hover { opacity: 0.6; }
-  .modal-body { flex:1 1 auto; width:100%; overflow-y:auto; }
-
-  .method-section { margin-bottom: var(--spacing-xl); }
-  .method-section:last-child { margin-bottom: 0; }
-  .method-section h3 {
-    font-size:16px; font-weight:500; letter-spacing:0.16px; line-height:22px;
-    color: var(--text-n9);
-    margin: 0 0 var(--spacing-m) 0;
+  .modal-body {
+    flex: 1 0 0;
+    width: 100%;
+    overflow-y: auto;
   }
   .method-body {
     background: var(--grey-g01);
-    border-radius: var(--radius-ct-l);
+    border-radius: var(--radius-ct-s);
     padding: var(--spacing-l);
-    display:flex; flex-direction:column; gap: var(--spacing-xs);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
   }
-  .method-body p {
-    font-size:14px; line-height:22px; letter-spacing:0.14px;
-    color: var(--text-n9); margin:0;
+	  .method-body p {
+	    margin: 0;
+	    font-size: 14px;
+	    line-height: 22px;
+	    letter-spacing: 0.14px;
+	    color: var(--text-n9);
+	  }
+	  .method-body .method-heading {
+	    margin-top: var(--spacing-xs);
+	    color: var(--text-n5);
+	    font-size: 12px;
+	    line-height: 18px;
+	  }
+  .method-body em {
+    color: var(--text-n5);
+    font-style: italic;
   }
-  .method-body p + p { margin-top: var(--spacing-xs); }
-  .method-body em { color: var(--text-n5); font-style: italic; }
-
-  .loading { color: var(--text-n5); font-style: italic; }
 </style>
 </head>
 <body>
-
 <div class="playbook-container">
-
-  <div class="section-title">
-    <span class="section-title-text">The S&amp;P 500 After a Copper-to-Gold One-Year Low — 15-Year What-If</span>
-    <button type="button" class="section-readme-btn" data-modal-open="methodology-modal" aria-label="Open README">
-      <span class="section-readme-icon" aria-hidden="true"></span>
+  <div class="title-row">
+    <h1 class="playbook-title">Did the Reclaim Help? - S&P 500 Signal What-If</h1>
+    <button class="pb-meta-link pb-meta-link--readme tab-readme" type="button" data-modal-open="methodology-modal">
+      <span class="pb-meta-icon-badge" aria-hidden="true">
+        <img class="pb-meta-icon-img" src="https://alva-ai-static.b-cdn.net/icons/researcher-l1.svg" width="14" height="14" alt="" />
+      </span>
       <span>README</span>
     </button>
   </div>
 
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-body" style="background:var(--grey-g01); border-radius: var(--radius-ct-s);">
-        <div class="free-text-body">
-          <div class="markdown-container markdown-container--m">
-            <p id="hero-sentence"><span class="loading">Loading live data…</span></p>
-          </div>
-        </div>
-        <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-      </div>
-    </div>
+  <div class="widget-grid" id="app">
+    <div class="state">Loading live data...</div>
   </div>
-
-  <div class="widget-grid" id="summary-cards"></div>
-
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-title"><span class="widget-title-text">The copper-to-gold ratio since 2011, with every past one-year low marked</span></div>
-      <div class="widget-subtitle">Daily copper ETF (CPER) divided by gold ETF (GLD). Red dots mark days the ratio closed at a fresh one-year low, with a 90-day gap so the same decline is not double-counted.</div>
-      <div class="chart-body chart-dotted-background">
-        <div id="chart-ratio" class="chart-container" style="height:400px;"></div>
-        <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-title"><span class="widget-title-text">Typical S&amp;P 500 move at each horizon, event vs plain historical average</span></div>
-      <div class="widget-subtitle">Green bars: the typical move after past one-year-low events. Grey bars: the S&amp;P 500's plain historical average over the same sample. Dashed line is zero.</div>
-      <div class="chart-body chart-dotted-background">
-        <div id="chart-horizon" class="chart-container" style="height:320px;"></div>
-        <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-title"><span class="widget-title-text">How the S&amp;P 500 moved three months after each past event</span></div>
-      <div class="widget-subtitle">One bar per past one-year-low event, sorted best to worst. Green means the S&amp;P 500 was higher three months later; red means lower. Dashed line is zero.</div>
-      <div class="chart-body chart-dotted-background">
-        <div id="chart-fwd3m" class="chart-container" style="height:320px;"></div>
-        <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-title"><span class="widget-title-text">Every past one-year-low event, row by row</span></div>
-      <div class="widget-subtitle">Newest first. Event day, market era at the time, the ratio on that day, and how the S&amp;P 500 moved a month, three months, six months, and a year later. Dashes mean the horizon has not yet finished.</div>
-      <div class="table-card" id="event-table">
-        <div class="table-row table-header">
-          <div class="table-cell">Event day</div>
-          <div class="table-cell">Era</div>
-          <div class="table-cell cell-right">Ratio</div>
-          <div class="table-cell cell-right">A month later</div>
-          <div class="table-cell cell-right">Three months later</div>
-          <div class="table-cell cell-right">Six months later</div>
-          <div class="table-cell cell-right">A year later</div>
-        </div>
-        <div id="event-table-body"><div class="table-row"><div class="table-cell cell-muted">Loading…</div></div></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="widget-grid">
-    <div class="widget-card col-8">
-      <div class="widget-title"><span class="widget-title-text">References</span></div>
-      <div class="widget-body" style="background:var(--grey-g01); border-radius: var(--radius-ct-s);">
-        <div class="free-text-body">
-          <div class="markdown-container markdown-container--m">
-            <p><strong>Trigger source:</strong> every trading day since a copper ETF (CPER) launched in November 2011 where the copper-to-gold ratio closed at a fresh one-year low, with a 90-day gap so the same decline is not double-counted. The ratio is daily CPER close divided by a gold ETF (GLD) daily close.</p>
-            <p><strong>Data source:</strong> Alva SDK adjusted daily closes for CPER, GLD, and the S&amp;P 500 (via SPY). Forward moves are SPY close on the event day compared to SPY close 21, 63, 126, and 252 trading days later — roughly a month, three months, six months, and a year.</p>
-          </div>
-        </div>
-        <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-      </div>
-    </div>
-  </div>
-
 </div>
 
 <div class="modal-overlay" id="methodology-modal" aria-hidden="true">
@@ -341,264 +505,674 @@
       <div class="modal-close" data-modal-close="methodology-modal" aria-label="Close"></div>
     </div>
     <div class="modal-body">
-      <div class="method-section">
-        <h3>Why copper-to-gold</h3>
-        <div class="method-body">
-          <p>The copper-to-gold price ratio is a long-running macro barometer. Copper reflects industrial demand and growth expectations; gold reflects fear, inflation hedging, and rate expectations. When the ratio breaks to a fresh one-year low, it is usually because growth expectations have cooled or fear has spiked — a classic "something is off" signal that investors have historically watched as a recession tell.</p>
-        </div>
-      </div>
-      <div class="method-section">
-        <h3>How we picked events</h3>
-        <div class="method-body">
-          <p>We built a daily copper-to-gold ratio from a copper ETF (CPER) divided by a gold ETF (GLD), starting from CPER's November 2011 launch through today. A new event fires when the ratio closes below its lowest print of the prior 252 trading days, with a 90-day cooldown so we do not double-count the same decline.</p>
-          <p>That rule produced a small number of past events over 15 years, which is the main thing to keep in mind reading this page: the sample is thin, so the medians below should be read as suggestive, not conclusive.</p>
-        </div>
-      </div>
-      <div class="method-section">
-        <h3>How we measured the follow-through</h3>
-        <div class="method-body">
-          <p>For each past event we took the S&amp;P 500 (via SPY) close on the event day and compared it to SPY close 21, 63, 126, and 252 trading days later — roughly a month, three months, six months, and a year out.</p>
-          <p>The plain historical average uses the same SPY series and the same horizons, sampled across the same window, so the event number and the plain-average number are measured the same way.</p>
-          <p><em>Historical observation only — not investment advice.</em></p>
-        </div>
-      </div>
+      <div class="method-body">
+	        <p>We picked events from SPY daily closes. A day qualifies when price closes back above its 50-day line after at least five sessions below it, remains above the 200-day line, and no other signal fired in the prior 21 trading days.</p>
+	        <p>For each signal, the entry is the next available close. We compare that entry price with closes a week, a month, three months, six months, and a year later. The normal-period comparison uses every eligible day in the same SPY history, measured with the same forward windows.</p>
+	        <p class="method-heading">References</p>
+	        <p><strong>Trigger source:</strong> SPY daily closes from Alva stock kline data. A signal fires after the close reclaims the 50-day line following at least five sessions below it, while still above the 200-day line.</p>
+	        <p><strong>Return source:</strong> The same daily close series. Forward moves compare the next available close after the signal with the close a week, a month, three months, six months, and a year later.</p>
+	        <p><em>Historical observation only. This is research output, not investment advice.</em></p>
+	      </div>
     </div>
   </div>
 </div>
 
 <script>
-  (async () => {
-    const ENDPOINT = "https://api-llm.prd.alva.ai";
-    const USER = "sheer-ruan";
-    const FEED = "copper-gold-recession-signal";
-    const BASE = `${ENDPOINT}/api/v1/fs/read?path=/alva/home/${USER}/feeds/${FEED}/v1/data`;
+(async function () {
+  const ENDPOINT = "https://api-llm.prd.alva.ai";
+  const USER = "steven";
+  const FEED = "spy-50day-reclaim-what-if";
+  const BASE = ENDPOINT + "/api/v1/fs/read?path=/alva/home/" + USER + "/feeds/" + FEED + "/v1/data";
+  const WATERMARK = "https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg";
+  const app = document.getElementById("app");
+  const FONT = "'Delight', -apple-system, 'OPPO Sans 4.0', BlinkMacSystemFont, sans-serif";
+  const palette = {
+    positive: "#2c9a6b",
+    negative: "#e05a67",
+    normal: "rgba(0,0,0,0.34)",
+	    caseLine: "rgba(0,0,0,0.12)"
+  };
+  const TT_COLORS = {
+    bg: "rgba(255,255,255,0.96)",
+    border: "rgba(0,0,0,0.08)",
+    title: "rgba(0,0,0,0.7)",
+    text: "rgba(0,0,0,0.9)"
+  };
+  const AX = {
+    axisLine: { show: false },
+    axisTick: { show: false },
+    axisLabel: { fontSize: 10, color: "rgba(0,0,0,0.7)", fontFamily: FONT, margin: 8 },
+    splitLine: { show: false }
+  };
+  const GRID = { top: 20, right: 20, bottom: 20, left: 20, containLabel: true };
+  const TT = {
+    trigger: "axis",
+    axisPointer: { type: "line", lineStyle: { color: "rgba(0,0,0,0.2)" } },
+    backgroundColor: TT_COLORS.bg,
+    borderColor: TT_COLORS.border,
+    borderWidth: 1,
+    borderRadius: 6,
+    padding: 12,
+    extraCssText: "box-shadow:none;",
+    textStyle: { fontFamily: FONT, fontSize: 12, color: TT_COLORS.text }
+  };
 
-    const TT_COLORS = { bg:"rgba(255,255,255,0.96)", border:"rgba(0,0,0,0.08)", title:"rgba(0,0,0,0.7)", text:"rgba(0,0,0,0.9)" };
-
-    function setError(msg) {
-      document.querySelectorAll(".loading").forEach((el) => { el.textContent = msg; el.classList.remove("loading"); });
-    }
-    async function fetchJSON(path) {
-      const r = await fetch(`${BASE}${path}`);
-      if (!r.ok) throw new Error(`${path}: ${r.status}`);
-      return r.json();
-    }
-    const fmtPct = (v, d=1) => v == null ? "—" : (v >= 0 ? "+" : "") + v.toFixed(d) + "%";
-    const signClass = (v) => v == null ? "cell-muted" : (v >= 0 ? "cell-pos" : "cell-neg");
-
-    let events, summary, series;
-    try {
-      [events, summary, series] = await Promise.all([
-        fetchJSON(`/events/rows/@last/200`),
-        fetchJSON(`/summary/stats/@last/20`),
-        fetchJSON(`/series/daily/@last/2000`),
-      ]);
-    } catch (err) { setError("Could not load live data: " + err.message); return; }
-
-    const byE = new Map();
-    events.forEach((r) => { const p = byE.get(r.event_date); if (!p || (p.date||0) < (r.date||0)) byE.set(r.event_date, r); });
-    events = Array.from(byE.values()).sort((a,b) => a.event_date.localeCompare(b.event_date));
-
-    const byS = new Map();
-    series.forEach((r) => { const p = byS.get(r.date_iso); if (!p || (p.date||0) < (r.date||0)) byS.set(r.date_iso, r); });
-    series = Array.from(byS.values()).sort((a,b) => a.date_iso.localeCompare(b.date_iso));
-
-    summary = [...summary].sort((a,b) => (b.date||0) - (a.date||0))[0] || {};
-
-    const heroPos = (summary.median_fwd_3m_pct != null && summary.median_fwd_3m_pct >= 0) ? "pos" : "neg";
-    const heroYrPos = (summary.median_fwd_12m_pct != null && summary.median_fwd_12m_pct >= 0) ? "pos" : "neg";
-    const basePos3m = (summary.spx_baseline_3m_pct != null && summary.spx_baseline_3m_pct >= 0) ? "pos" : "neg";
-    const basePos12m = (summary.spx_baseline_12m_pct != null && summary.spx_baseline_12m_pct >= 0) ? "pos" : "neg";
-    document.getElementById("hero-sentence").innerHTML =
-      `Across <strong>${summary.n_events}</strong> past copper-to-gold one-year lows since 2011, the S&P 500 (via SPY) typically drifted <span class="${heroPos}">${fmtPct(summary.median_fwd_3m_pct)} three months later</span> and <span class="${heroYrPos}">${fmtPct(summary.median_fwd_12m_pct)} a year later</span>. Over the same window the plain historical average was <span class="${basePos3m}">${fmtPct(summary.spx_baseline_3m_pct)}</span> and <span class="${basePos12m}">${fmtPct(summary.spx_baseline_12m_pct)}</span>, so the signal does not move the S&P 500 much beyond its usual drift higher over time.`;
-
-    const median = (a) => { if (!a.length) return null; const s = [...a].sort((x,y)=>x-y); return s.length%2?s[(s.length-1)/2]:(s[s.length/2-1]+s[s.length/2])/2; };
-
-    const horizons = [
-      { key: "fwd_1m_pct",  title: "A month later",       base: null, summaryKey: "median_fwd_1m_pct" },
-      { key: "fwd_3m_pct",  title: "Three months later", base: summary.spx_baseline_3m_pct,  summaryKey: "median_fwd_3m_pct" },
-      { key: "fwd_6m_pct",  title: "Six months later",   base: null, summaryKey: "median_fwd_6m_pct" },
-      { key: "fwd_12m_pct", title: "A year later",       base: summary.spx_baseline_12m_pct, summaryKey: "median_fwd_12m_pct" },
-    ];
-    const cardsEl = document.getElementById("summary-cards");
-    cardsEl.innerHTML = "";
-    horizons.forEach((h) => {
-      const vals = events.map((e) => e[h.key]).filter((v) => v != null);
-      const med = summary[h.summaryKey] != null ? summary[h.summaryKey] : median(vals);
-      const posN = vals.filter((v) => v >= 0).length;
-      const posRate = vals.length ? Math.round((posN / vals.length) * 100) : 0;
-      const cls = med == null ? "" : (med >= 0 ? "pos" : "neg");
-      const baseLine = h.base != null
-        ? `plain historical average ${fmtPct(h.base)}`
-        : `across ${vals.length} past ${vals.length === 1 ? "event" : "events"}`;
-      const el = document.createElement("div");
-      el.className = "widget-card col-2";
-      el.innerHTML = `
-        <div class="kpi-body">
-          <div class="kpi-label">${h.title}</div>
-          <div class="kpi-value ${cls}">${fmtPct(med)}</div>
-          <div class="kpi-foot">positive in ${posN} of ${vals.length} past ${vals.length === 1 ? "event" : "events"} · ${baseLine}</div>
-          <div class="alva-watermark"><img src="https://alva-ai-static.b-cdn.net/icons/alva-watermark.svg" alt="Alva" /></div>
-        </div>`;
-      cardsEl.appendChild(el);
+  function esc(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+  function fmtPct(value, digits) {
+    if (value == null || !Number.isFinite(Number(value))) return "-";
+    const d = digits == null ? 1 : digits;
+    return (value >= 0 ? "+" : "") + Number(value).toFixed(d) + "%";
+  }
+  function toneClass(value) {
+    const raw = typeof value === "string" ? Number(value.replace(/[%+]/g, "")) : Number(value);
+    if (!Number.isFinite(raw)) return "neutral";
+    return raw >= 0 ? "positive" : "negative";
+  }
+  function median(values) {
+    const clean = values.filter(function (value) { return value != null && Number.isFinite(Number(value)); }).sort(function (a, b) { return a - b; });
+    if (!clean.length) return null;
+    const mid = Math.floor(clean.length / 2);
+    return clean.length % 2 ? clean[mid] : (clean[mid - 1] + clean[mid]) / 2;
+  }
+  function percentile(values, pct) {
+    const clean = values.filter(function (value) { return value != null && Number.isFinite(Number(value)); }).sort(function (a, b) { return a - b; });
+    if (!clean.length) return null;
+    const idx = Math.max(0, Math.min(clean.length - 1, Math.round((clean.length - 1) * pct)));
+    return clean[idx];
+  }
+  function dedupeLatest(rows, key) {
+    const map = new Map();
+    rows.forEach(function (row) {
+      const k = row[key];
+      const prior = map.get(k);
+      if (!prior || (prior.date || 0) < (row.date || 0)) map.set(k, row);
     });
+    return Array.from(map.values());
+  }
+  async function fetchJSON(path) {
+    const response = await fetch(BASE + path);
+    if (!response.ok) throw new Error(path + ": " + response.status);
+    return response.json();
+  }
 
-    const AX = { axisLine: { show: false }, axisTick: { show: false }, axisLabel: { fontSize: 10, color: "rgba(0,0,0,0.7)", fontFamily: "'Delight', sans-serif", margin: 8 }, splitLine: { show: false } };
-    const GRID = { top: 20, right: 24, bottom: 48, left: 16, containLabel: true };
-    const GRID_NO_LEGEND = { top: 20, right: 24, bottom: 12, left: 16, containLabel: true };
+	  function buildPathOverlay(series, events) {
+	    const byDate = new Map(series.map(function (row, index) { return [row.date_iso, index]; }));
+	    const offsets = [];
+	    for (let offset = -60; offset <= 252; offset += 1) offsets.push(offset);
+	    function rounded(value) {
+	      return value == null ? null : +Number(value).toFixed(2);
+	    }
 
-    /* Ratio chart */
-    const eventSet = new Set(events.map((e) => e.event_date));
-    const ratioDates = series.map((r) => r.date_iso);
-    const ratioVals = series.map((r) => r.ratio);
-    const markPoints = events.map((e) => ({
-      name: e.event_date,
-      coord: [e.event_date, e.ratio_at_event],
-      value: "",
-      symbol: "circle",
-      symbolSize: 10,
-      itemStyle: { color: "#e05a67", borderColor: "#fff", borderWidth: 1.5 },
-    }));
-    const chartRatio = echarts.init(document.getElementById("chart-ratio"));
-    chartRatio.setOption({
-      grid: GRID_NO_LEGEND,
-      tooltip: { trigger:"axis", axisPointer: { type: "line", lineStyle: { color: "rgba(0,0,0,0.2)" } },
-        backgroundColor:TT_COLORS.bg, borderColor:TT_COLORS.border, borderWidth:1, borderRadius:6, padding:12, extraCssText:"box-shadow:none;",
-        textStyle: { fontFamily:"'Delight', sans-serif", fontSize:12, color:TT_COLORS.text },
-        formatter: (ps) => {
-          const p = ps[0];
-          const date = p.axisValue;
-          const v = p.value;
-          const isEvent = eventSet.has(date);
-          return `<div style="color:${TT_COLORS.title};margin-bottom:6px;">${date}</div>`
-               + `<div>copper/gold <strong>${v == null ? "—" : v.toFixed(4)}</strong></div>`
-               + (isEvent ? `<div style="color:var(--main-m4);">one-year low event</div>` : "");
-        }
-      },
-      xAxis: { type: "category", data: ratioDates, ...AX,
-        axisLabel: { ...AX.axisLabel, formatter: (v) => v ? v.slice(0, 7) : "", showMaxLabel: true, interval: Math.floor(ratioDates.length / 8) }
-      },
-      yAxis: { type: "value", ...AX, axisLabel: { ...AX.axisLabel, formatter: (v) => v.toFixed(3) } },
-      series: [{
-        type:"line", smooth:true, showSymbol:false, data: ratioVals,
-        lineStyle: { color: "#5f75c9", width: 1.5 },
-        areaStyle: { color: { type: "linear", x: 0, y: 0, x2: 0, y2: 1, colorStops: [ { offset: 0, color: "rgba(95,117,201,0.28)" }, { offset: 1, color: "rgba(95,117,201,0.02)" } ] } },
-        markPoint: { data: markPoints, silent: false, label: { show: false } }
-      }],
+    const paths = events.map(function (event) {
+      const index = byDate.get(event.event_date);
+      if (index == null || index < 60 || index + 252 >= series.length) return null;
+      const base = series[index].close;
+      return {
+        date: event.event_date,
+        values: offsets.map(function (offset) {
+          const point = series[index + offset];
+          return point && base ? +(point.close / base * 100).toFixed(2) : null;
+        })
+      };
+    }).filter(Boolean);
+
+	    const normalAnchors = [];
+	    for (let i = 60; i + 252 < series.length; i += 21) {
+	      const base = series[i].close;
+	      normalAnchors.push(offsets.map(function (offset) {
+	        return +(series[i + offset].close / base * 100).toFixed(2);
+	      }));
+	    }
+	    const rowsForDisplay = paths.slice().sort(function (a, b) { return a.date.localeCompare(b.date); });
+	    const picked = new Map();
+	    const targetCount = 16;
+	    const step = rowsForDisplay.length <= 1 ? 1 : (rowsForDisplay.length - 1) / (targetCount - 1);
+	    for (let i = 0; i < Math.min(targetCount, rowsForDisplay.length); i++) {
+	      const path = rowsForDisplay[Math.round(i * step)];
+	      picked.set(path.date, path);
+	    }
+	    const sortableEnd = rowsForDisplay
+	      .filter(function (path) { return Number.isFinite(path.values[path.values.length - 1]); })
+	      .sort(function (a, b) { return a.values[a.values.length - 1] - b.values[b.values.length - 1]; });
+	    if (sortableEnd[0]) picked.set(sortableEnd[0].date, sortableEnd[0]);
+	    if (sortableEnd[sortableEnd.length - 1]) picked.set(sortableEnd[sortableEnd.length - 1].date, sortableEnd[sortableEnd.length - 1]);
+	    if (rowsForDisplay[rowsForDisplay.length - 1]) picked.set(rowsForDisplay[rowsForDisplay.length - 1].date, rowsForDisplay[rowsForDisplay.length - 1]);
+	    const p25Path = offsets.map(function (_, i) { return rounded(percentile(paths.map(function (path) { return path.values[i]; }), 0.25)); });
+	    const p75Path = offsets.map(function (_, i) { return rounded(percentile(paths.map(function (path) { return path.values[i]; }), 0.75)); });
+
+	    return {
+	      offsets,
+	      individualPaths: paths,
+	      displayPaths: Array.from(picked.values()),
+	      p25Path,
+	      p75Path,
+	      middleRangeSpread: p75Path.map(function (upper, i) {
+	        return upper == null || p25Path[i] == null ? null : +(upper - p25Path[i]).toFixed(2);
+	      }),
+	      medianPath: offsets.map(function (_, i) { return rounded(median(paths.map(function (path) { return path.values[i]; }))); }),
+	      normalPath: offsets.map(function (_, i) { return rounded(median(normalAnchors.map(function (path) { return path[i]; }))); })
+	    };
+	  }
+
+  function initTableAlignment(tableEl) {
+    var rows = tableEl.querySelectorAll(".table-row");
+    if (rows.length === 0) return;
+    var colCount = rows[0].querySelectorAll(".table-cell").length;
+    rows.forEach(function (row) {
+      row.style.removeProperty("min-width");
+      var cells = row.querySelectorAll(".table-cell");
+      for (var i = 0; i < cells.length; i++) cells[i].removeAttribute("style");
     });
-    chartRatio.resize();
+    var colWidths = [];
+    for (var col = 0; col < colCount; col++) {
+      var maxW = 0;
+      rows.forEach(function (row) {
+        var cell = row.querySelectorAll(".table-cell")[col];
+        if (cell) maxW = Math.max(maxW, cell.scrollWidth);
+      });
+      colWidths.push(maxW);
+    }
+    var totalContent = 0;
+    for (var j = 0; j < colWidths.length; j++) totalContent += colWidths[j];
+    var gapTotal = (colCount - 1) * 16;
+    var available = tableEl.clientWidth - gapTotal;
+    var resolved = [];
+    for (var c = 0; c < colCount; c++) {
+      var proportional = Math.round((colWidths[c] / totalContent) * available);
+      resolved.push(Math.max(colWidths[c], proportional));
+    }
+    var totalWidth = gapTotal;
+    for (var c2 = 0; c2 < colCount; c2++) {
+      totalWidth += resolved[c2];
+      rows.forEach(function (row) {
+        var cell = row.querySelectorAll(".table-cell")[c2];
+        if (cell) cell.style.flex = "0 0 " + resolved[c2] + "px";
+      });
+    }
+    rows.forEach(function (row) { row.style.minWidth = totalWidth + "px"; });
+  }
 
-    /* Horizon comparison */
-    const horizonLabels = ["A month later", "Three months later", "Six months later", "A year later"];
-    const horizonKeys = ["median_fwd_1m_pct", "median_fwd_3m_pct", "median_fwd_6m_pct", "median_fwd_12m_pct"];
-    const baselineKeys = [null, "spx_baseline_3m_pct", null, "spx_baseline_12m_pct"];
-    const eventVals = horizonKeys.map((k) => summary[k]);
-    const baselineVals = baselineKeys.map((k) => k == null ? null : summary[k]);
-    const chartHorizon = echarts.init(document.getElementById("chart-horizon"));
-    chartHorizon.setOption({
-      grid: GRID_NO_LEGEND,
-      tooltip: { trigger:"axis", axisPointer: { type: "shadow" }, backgroundColor:TT_COLORS.bg, borderColor:TT_COLORS.border, borderWidth:1, borderRadius:6, padding:12, extraCssText:"box-shadow:none;",
-        textStyle: { fontFamily:"'Delight', sans-serif", fontSize:12, color:TT_COLORS.text },
-        formatter: (ps) => {
-          let out = `<div style="color:${TT_COLORS.title};margin-bottom:6px;">${ps[0].axisValue}</div>`;
-          ps.forEach((p) => {
-            if (p.value == null) return;
-            const sign = p.value >= 0 ? "pos" : "neg";
-            const color = p.value >= 0 ? "var(--main-m3)" : "var(--main-m4)";
-            out += `<div>${p.seriesName} <strong style="color:${color};">${fmtPct(p.value)}</strong></div>`;
+  function renderPathChart(data) {
+    const chart = echarts.init(document.getElementById("path-chart"));
+    const pathOverlay = data.pathOverlay;
+    const offsets = pathOverlay.offsets.map(function (offset) { return String(offset); });
+    chart.setOption({
+      animationDuration: 650,
+      grid: { ...GRID, top: 30, right: 28, bottom: 26, left: 20 },
+      tooltip: {
+	        ...TT,
+	        formatter: function (params) {
+	          const offset = Number(params[0].axisValue);
+	          const dayLabel = offset === 0 ? "Signal day" : offset < 0 ? Math.abs(offset) + " days before" : offset + " days after";
+	          const hiddenSeries = new Set(["Past cases", "Range base", "Middle range"]);
+	          let output = '<div style="font-size:12px;color:' + TT_COLORS.title + ';margin-bottom:6px;">' + dayLabel + '</div>';
+	          params.filter(function (point) { return !hiddenSeries.has(point.seriesName) && point.value != null; }).forEach(function (point) {
+	            output += '<div style="display:flex;align-items:center;gap:6px;line-height:20px;">' +
+	              '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + point.color + ';"></span>' +
+	              '<span>' + esc(point.seriesName) + '</span>' +
+              '<span style="margin-left:auto;">' + Number(point.value).toFixed(1) + '</span>' +
+              '</div>';
           });
-          return out;
+          return output;
         }
       },
-      legend: { data: ["After a past event", "Plain historical average"], top: 0, right: 8, itemWidth: 12, itemHeight: 8, textStyle: { fontSize: 11, color: "rgba(0,0,0,0.7)", fontFamily: "'Delight', sans-serif" } },
-      xAxis: { type: "category", data: horizonLabels, ...AX, axisLabel: { ...AX.axisLabel, interval: 0 } },
-      yAxis: { type: "value", ...AX, axisLabel: { ...AX.axisLabel, formatter: (v) => v + "%" } },
-      series: [
-        { name: "After a past event", type: "bar", barMaxWidth: 22,
-          itemStyle: { color: "#2c9a6b", borderRadius: [2,2,0,0] },
-          data: eventVals,
-          markLine: { silent: true, symbol: "none", lineStyle: { color: "rgba(0,0,0,0.35)", type: "dashed", width: 1 },
-            data: [{ yAxis: 0, label: { show: false } }] }
+      legend: {
+        top: 4,
+        right: 20,
+        textStyle: { fontSize: 10, color: "rgba(0,0,0,0.7)", fontFamily: FONT },
+	        itemWidth: 18,
+	        itemHeight: 2,
+	        selectedMode: false,
+	        data: ["Past cases", "Typical after signal", "Normal periods"]
+      },
+      xAxis: {
+        type: "category",
+        data: offsets,
+        boundaryGap: false,
+        ...AX,
+        axisLabel: {
+          ...AX.axisLabel,
+          interval: function (index, value) { return [-60, 0, 63, 126, 252].includes(Number(value)); },
+          formatter: function (value) {
+            const offset = Number(value);
+            if (offset === -60) return "60 days before";
+            if (offset === 0) return "Signal day";
+            if (offset === 63) return "3 mo after";
+            if (offset === 126) return "6 mo after";
+            if (offset === 252) return "1 yr after";
+            return "";
+          }
         },
-        { name: "Plain historical average", type: "bar", barMaxWidth: 22,
-          itemStyle: { color: "#b5b9c2", borderRadius: [2,2,0,0] },
-          data: baselineVals }
-      ],
-    });
-    chartHorizon.resize();
-
-    /* Per-event 3-month move */
-    const fwd3Sorted = [...events].filter((e) => e.fwd_3m_pct != null).sort((a,b) => b.fwd_3m_pct - a.fwd_3m_pct);
-    const chartFwd3m = echarts.init(document.getElementById("chart-fwd3m"));
-    chartFwd3m.setOption({
-      grid: GRID_NO_LEGEND,
-      tooltip: { trigger:"item", backgroundColor:TT_COLORS.bg, borderColor:TT_COLORS.border, borderWidth:1, borderRadius:6, padding:12, extraCssText:"box-shadow:none;",
-        textStyle: { fontFamily:"'Delight', sans-serif", fontSize:12, color:TT_COLORS.text },
-        formatter: (p) => {
-          const r = fwd3Sorted[p.dataIndex];
-          const sign = r.fwd_3m_pct >= 0 ? "pos" : "neg";
-          const color = r.fwd_3m_pct >= 0 ? "var(--main-m3)" : "var(--main-m4)";
-          return `<div style="color:${TT_COLORS.title};margin-bottom:6px;">${r.event_date}</div>`
-               + `<div>three months later <strong style="color:${color};">${fmtPct(r.fwd_3m_pct)}</strong></div>`
-               + `<div style="color:${TT_COLORS.title};">${r.era_label || ""}</div>`;
-        }
+        splitLine: { show: true, interval: 5, lineStyle: { color: "rgba(0,0,0,0.11)", type: [1, 4], width: 1 } }
       },
-      xAxis: { type: "category", data: fwd3Sorted.map((r) => r.event_date), ...AX, axisLabel: { ...AX.axisLabel, formatter: () => "" } },
-      yAxis: { type: "value", ...AX, axisLabel: { ...AX.axisLabel, formatter: (v) => v + "%" } },
-      series: [{
-        type:"bar", barMaxWidth: 18,
-        data: fwd3Sorted.map((r) => ({ value: r.fwd_3m_pct, itemStyle: { color: r.fwd_3m_pct >= 0 ? "#2c9a6b" : "#e05a67" } })),
-        markLine: { silent: true, symbol: "none", lineStyle: { color: "rgba(0,0,0,0.35)", type: "dashed", width: 1 },
-          data: [{ yAxis: 0, label: { show: false } }] }
-      }],
+      yAxis: {
+        type: "value",
+        scale: true,
+        ...AX,
+        axisLabel: { ...AX.axisLabel, formatter: function (value) { return Number(value).toFixed(0); } },
+        splitLine: { show: true, lineStyle: { color: "rgba(0,0,0,0.11)", type: [1, 4], width: 1 } }
+      },
+	      series: [
+	        {
+	          name: "Range base",
+	          type: "line",
+	          data: pathOverlay.p25Path,
+	          stack: "middleRange",
+	          smooth: 0.1,
+	          symbol: "none",
+	          showSymbol: false,
+	          silent: true,
+	          lineStyle: { width: 0, opacity: 0 },
+	          areaStyle: { opacity: 0 },
+	          tooltip: { show: false },
+	          z: 0
+	        },
+	        {
+	          name: "Middle range",
+	          type: "line",
+	          data: pathOverlay.middleRangeSpread,
+	          stack: "middleRange",
+	          smooth: 0.1,
+	          symbol: "none",
+	          showSymbol: false,
+	          silent: true,
+	          lineStyle: { width: 0, opacity: 0 },
+	          areaStyle: { color: "rgba(44,154,107,0.08)" },
+	          tooltip: { show: false },
+	          z: 0
+	        },
+	        ...pathOverlay.displayPaths.map(function (path) {
+	          return {
+	            name: "Past cases",
+	            type: "line",
+	            data: path.values,
+	            smooth: 0.1,
+	            symbol: "none",
+	            showSymbol: false,
+	            lineStyle: { width: 0.8, color: palette.caseLine },
+	            itemStyle: { color: palette.caseLine },
+	            tooltip: { show: false },
+	            z: 1
+          };
+        }),
+        {
+          name: "Typical after signal",
+          type: "line",
+          data: pathOverlay.medianPath,
+          smooth: 0.1,
+          symbol: "none",
+          showSymbol: false,
+          lineStyle: { width: 1.6, color: palette.positive },
+          itemStyle: { color: palette.positive },
+          markLine: {
+            silent: true,
+            symbol: "none",
+            data: [{ xAxis: "0" }],
+            lineStyle: { color: "rgba(0,0,0,0.34)", type: [3, 2], width: 1 },
+            label: { show: false }
+          },
+          z: 4
+        },
+        {
+          name: "Normal periods",
+          type: "line",
+          data: pathOverlay.normalPath,
+          smooth: 0.1,
+          symbol: "none",
+          showSymbol: false,
+          lineStyle: { width: 1.2, color: palette.normal },
+          itemStyle: { color: palette.normal },
+          z: 3
+        }
+      ]
     });
-    chartFwd3m.resize();
+    return chart;
+  }
 
-    window.addEventListener('resize', () => {
-      chartRatio.resize(); chartHorizon.resize(); chartFwd3m.resize();
+	  function renderCaseChart(events) {
+	    const cases = events
+	      .filter(function (row) { return row.fwd_year_pct != null; })
+	      .slice()
+	      .sort(function (a, b) { return a.event_date.localeCompare(b.event_date); });
+	    const values = cases.map(function (item) { return item.fwd_year_pct; });
+	    const medianValue = median(values);
+	    const yearTickIndexes = new Set();
+	    const seenYears = new Set();
+	    cases.forEach(function (item, index) {
+	      const year = Number(item.event_date.slice(0, 4));
+	      if (!seenYears.has(year)) {
+	        seenYears.add(year);
+	        if (year % 2 === 0 || index === 0) yearTickIndexes.add(index);
+	      }
+	    });
+	    if (cases.length) {
+	      yearTickIndexes.add(0);
+	      yearTickIndexes.add(cases.length - 1);
+	    }
+	    const chart = echarts.init(document.getElementById("case-chart"));
+	    chart.setOption({
+	      animationDuration: 650,
+	      grid: { ...GRID, top: 24, right: 22, bottom: 38, left: 20 },
+	      tooltip: {
+	        ...TT,
+	        trigger: "item",
+	        formatter: function (params) {
+	          const item = cases[params.dataIndex];
+	          return '<div style="font-size:12px;color:' + TT_COLORS.title + ';margin-bottom:6px;">' + esc(item.event_date) + '</div>' +
+	            '<div>one year later <strong>' + fmtPct(item.fwd_year_pct) + '</strong></div>';
+	        }
+	      },
+	      xAxis: {
+	        type: "category",
+	        data: cases.map(function (item) { return item.event_date; }),
+	        boundaryGap: true,
+	        ...AX,
+	        axisTick: {
+	          show: true,
+	          alignWithLabel: true,
+	          interval: function (index) { return yearTickIndexes.has(index); },
+	          lineStyle: { color: "rgba(0,0,0,0.2)" }
+	        },
+	        axisLabel: {
+	          ...AX.axisLabel,
+	          interval: function (index) { return yearTickIndexes.has(index); },
+	          formatter: function (value) { return value.slice(0, 4); }
+	        },
+	        splitLine: {
+	          show: true,
+	          interval: function (index) { return yearTickIndexes.has(index); },
+	          lineStyle: { color: "rgba(0,0,0,0.1)", type: [1, 4], width: 1 }
+	        }
+	      },
+	      yAxis: {
+	        type: "value",
+	        ...AX,
+	        axisLabel: { ...AX.axisLabel, formatter: function (value) { return value + "%"; } },
+	        splitLine: { show: true, lineStyle: { color: "rgba(0,0,0,0.11)", type: [1, 4], width: 1 } }
+	      },
+	      series: [{
+	        name: "One-year outcome",
+	        type: "bar",
+	        data: cases.map(function (item) {
+	          return {
+	            value: item.fwd_year_pct,
+	            itemStyle: {
+	              color: item.fwd_year_pct >= 0 ? palette.positive : palette.negative,
+	              opacity: item.fwd_year_pct >= 0 ? 0.9 : 0.86,
+	              borderRadius: item.fwd_year_pct >= 0 ? [2, 2, 0, 0] : [0, 0, 2, 2]
+	            }
+	          };
+	        }),
+	        barMaxWidth: 9,
+	        barCategoryGap: "34%",
+	        emphasis: { itemStyle: { opacity: 1 } },
+	        markLine: {
+	          silent: true,
+	          symbol: "none",
+	          data: [
+	            {
+	              yAxis: 0,
+	              label: { show: false },
+	              lineStyle: { color: "rgba(0,0,0,0.3)", type: [3, 2], width: 1 }
+	            },
+	            {
+	              yAxis: +medianValue.toFixed(1),
+	              label: { show: false },
+	              lineStyle: { color: palette.positive, type: "solid", width: 1 }
+	            }
+	          ]
+	        }
+	      }]
+	    });
+	    return chart;
+	  }
+
+	  function buildFeaturedCases(events) {
+	    const complete = events.filter(function (row) { return row.fwd_year_pct != null; });
+	    const strongest = complete.slice().sort(function (a, b) { return b.fwd_year_pct - a.fwd_year_pct; })[0];
+	    const softest = complete.slice().sort(function (a, b) { return a.fwd_year_pct - b.fwd_year_pct; })[0];
+    const latest = complete[complete.length - 1];
+    return [
+      { label: "Strongest case", row: strongest, note: "The setup carried into a full risk-on year." },
+      { label: "Softest case", row: softest, note: "Short-term stabilization did not protect the next year." },
+      { label: "Latest complete case", row: latest, note: "Useful as a recency check, not a forecast." }
+    ].map(function (item) {
+      return {
+        label: item.label,
+        date: item.row.event_date,
+        trigger: fmtPct(item.row.above_200d_pct) + " above the 200-day line at the signal.",
+        result: fmtPct(item.row.fwd_year_pct) + " a year later",
+        note: item.note
+	      };
+	    });
+	  }
+	  function buildAuditRow(row, year) {
+	    return '<div class="table-row table-body-row">' +
+	      '<div class="table-cell">' + esc(row.event_date) + '</div>' +
+	      '<div class="table-cell">' + esc(row.entry_date) + '</div>' +
+	      '<div class="table-cell cell-right ' + toneClass(row.above_200d_pct) + '">' + fmtPct(row.above_200d_pct) + '</div>' +
+	      '<div class="table-cell cell-right ' + toneClass(row.fwd_week_pct) + '">' + fmtPct(row.fwd_week_pct) + '</div>' +
+	      '<div class="table-cell cell-right ' + toneClass(row.fwd_month_pct) + '">' + fmtPct(row.fwd_month_pct) + '</div>' +
+	      '<div class="table-cell cell-right ' + toneClass(row.fwd_three_months_pct) + '">' + fmtPct(row.fwd_three_months_pct) + '</div>' +
+	      '<div class="table-cell cell-right ' + toneClass(row.fwd_year_pct) + '">' + fmtPct(row.fwd_year_pct) + '</div>' +
+	      '<div class="table-cell">' + (row.fwd_year_pct > year.typical_day_median_pct ? "Yes" : "No") + '</div>' +
+	    '</div>';
+	  }
+	  function buildAuditRows(rows, year) {
+	    return rows.map(function (row) { return buildAuditRow(row, year); }).join("");
+	  }
+
+	  function render(data) {
+	    const summaryOrder = ["A week later", "A month later", "Three months later", "A year later"];
+	    const summaryCards = summaryOrder.map(function (label) {
+	      return data.horizons.find(function (row) { return row.label === label; });
+	    }).filter(Boolean);
+	    const best = summaryCards.find(function (row) { return row.label === data.summary.best_label; }) ||
+	      summaryCards.slice().sort(function (a, b) { return b.edge_pct - a.edge_pct; })[0] ||
+	      data.horizons[0];
+	    const year = data.horizons.find(function (row) { return row.label === "A year later"; }) || data.horizons[data.horizons.length - 1];
+    const threeMonths = data.horizons.find(function (row) { return row.label === "Three months later"; }) || data.horizons[2];
+    const events = data.events;
+    const yearValues = events.map(function (row) { return row.fwd_year_pct; }).filter(function (value) { return value != null; });
+    const p25 = percentile(yearValues, 0.25);
+    const p75 = percentile(yearValues, 0.75);
+    const strongest = Math.max.apply(null, yearValues);
+	    const softest = Math.min.apply(null, yearValues);
+	    const featuredCases = buildFeaturedCases(events);
+	    const auditRows = events.slice().reverse();
+	    const auditPreviewCount = 8;
+	    const hasLongAudit = auditRows.length > 12;
+	    const initialAuditRows = hasLongAudit ? auditRows.slice(0, auditPreviewCount) : auditRows;
+
+	    app.innerHTML =
+      '<article class="hero col-8">' +
+        '<div class="chip-row">' +
+          '<span class="chip">SPY</span>' +
+          '<span class="chip">50D reclaim</span>' +
+          '<span class="chip">Cases: ' + esc(data.summary.n_events) + '</span>' +
+        '</div>' +
+        '<p class="hero-sentence">The reclaim looked modestly helpful: the S&P 500 was ' + fmtPct(best.event_median_pct) + ' ' + esc(best.label.toLowerCase()) + ' after past 50-day reclaims, versus normal periods at ' + fmtPct(best.typical_day_median_pct) + '.</p>' +
+        '<p class="support">The useful question is not whether the index eventually rose. It is whether buying after a short loss of the 50-day line beat normal periods with similar holding windows.</p>' +
+      '</article>' +
+
+      '<div class="belief-strip">' +
+        '<article class="belief">' +
+          '<p class="eyebrow">Common expectation</p>' +
+          '<p class="belief-text">A reclaim of the 50-day line is often read as a reset: short-term weakness may have passed, while the longer trend is still intact.</p>' +
+        '</article>' +
+        '<article class="belief">' +
+          '<p class="eyebrow">What history showed</p>' +
+          '<p class="belief-text">The setup was most useful when the reclaim held quickly. Longer windows need to be read against ordinary S&P 500 drift.</p>' +
+        '</article>' +
+      '</div>' +
+
+      '<article class="widget-card col-5">' +
+        '<div class="widget-title"><span class="widget-title-text">What did the path look like after the signal?</span></div>' +
+        '<div class="chart-body primary chart-dotted-background">' +
+          '<div class="chart-container" id="path-chart"></div>' +
+          '<div class="alva-watermark"><img alt="Alva" src="' + WATERMARK + '" /></div>' +
+        '</div>' +
+	        '<p class="section-note">Signal day is rebased to 100; thin lines are sampled past cases, with the middle half shaded.</p>' +
+      '</article>' +
+
+      '<aside class="widget-card col-3">' +
+        '<div class="widget-title"><span class="widget-title-text">Readout</span></div>' +
+        '<div class="insight-rail">' +
+          '<article class="rail-card"><p class="eyebrow">Main readout</p><strong>' + fmtPct(best.event_median_pct) + ' ' + esc(best.label.toLowerCase()) + '</strong><p>That is the median result across ' + esc(best.event_count) + ' complete past cases.</p></article>' +
+          '<article class="rail-card"><p class="eyebrow">Comparison readout</p><strong>' + fmtPct(best.edge_pct) + ' versus normal</strong><p>Normal periods were ' + fmtPct(best.typical_day_median_pct) + ' over the same holding window.</p></article>' +
+          '<article class="rail-card"><p class="eyebrow">Reliability readout</p><strong>' + esc(best.positive_count) + ' of ' + esc(best.event_count) + ' cases</strong><p>Small-sample language uses counts rather than over-selling a percentage.</p></article>' +
+        '</div>' +
+      '</aside>' +
+
+	      summaryCards.map(function (card) {
+        return '<article class="widget-card col-2">' +
+          '<div class="widget-title"><span class="widget-title-text">' + esc(card.label) + '</span></div>' +
+          '<div class="widget-body metric-body">' +
+            '<p class="eyebrow">After signal</p>' +
+            '<span class="metric-value ' + toneClass(card.event_median_pct) + '">' + fmtPct(card.event_median_pct) + '</span>' +
+            '<p>Normal periods: ' + fmtPct(card.typical_day_median_pct) + '</p>' +
+            '<p>Gap: ' + fmtPct(card.edge_pct) + '</p>' +
+            '<p>' + esc(card.positive_count) + ' of ' + esc(card.event_count) + ' positive</p>' +
+            '<div class="alva-watermark"><img alt="Alva" src="' + WATERMARK + '" /></div>' +
+          '</div>' +
+        '</article>';
+      }).join("") +
+
+	      '<article class="widget-card col-5">' +
+	        '<div class="widget-title"><span class="widget-title-text">How each past case finished one year later</span></div>' +
+	        '<div class="chart-body short chart-dotted-background case-bar-chart">' +
+	          '<div class="chart-container" id="case-chart"></div>' +
+	          '<div class="alva-watermark"><img alt="Alva" src="' + WATERMARK + '" /></div>' +
+	        '</div>' +
+	        '<p class="section-note">One bar per case; the x-axis labels only mark selected years, while hover shows exact dates.</p>' +
+	      '</article>' +
+
+      '<aside class="widget-card col-3">' +
+        '<div class="widget-title"><span class="widget-title-text">Past-case range</span></div>' +
+        '<div class="range-stack">' +
+          '<article class="range-card"><p class="eyebrow">Strongest case</p><strong class="' + toneClass(strongest) + '">' + fmtPct(strongest) + '</strong></article>' +
+          '<article class="range-card"><p class="eyebrow">Middle range</p><strong>' + fmtPct(p25) + ' to ' + fmtPct(p75) + '</strong></article>' +
+          '<article class="range-card"><p class="eyebrow">Softest case</p><strong class="' + toneClass(softest) + '">' + fmtPct(softest) + '</strong></article>' +
+        '</div>' +
+      '</aside>' +
+
+      '<div class="col-thirds">' +
+        featuredCases.map(function (item) {
+          return '<article class="case-card">' +
+            '<p class="eyebrow">' + esc(item.label) + '</p>' +
+            '<div class="case-title">' + esc(item.date) + '</div>' +
+            '<p>' + esc(item.trigger) + '</p>' +
+            '<div class="case-result">' + esc(item.result) + '</div>' +
+            '<p>' + esc(item.note) + '</p>' +
+          '</article>';
+        }).join("") +
+      '</div>' +
+
+	      '<article class="widget-card col-8">' +
+	        '<div class="widget-title"><span class="widget-title-text">Historical audit ledger</span>' +
+	          (hasLongAudit ? '<button class="audit-toggle" id="audit-toggle" type="button" aria-expanded="false">Show all ' + esc(auditRows.length) + ' cases</button>' : '') +
+	        '</div>' +
+	        '<p class="table-caption" id="audit-caption">' + (hasLongAudit ? 'Showing latest ' + esc(auditPreviewCount) + ' of ' + esc(auditRows.length) + ' complete cases.' : 'Showing all ' + esc(auditRows.length) + ' complete cases.') + '</p>' +
+	        '<div class="table-card" id="audit-table">' +
+	          '<div class="table-row table-header">' +
+	            '<div class="table-cell">Signal date</div>' +
+            '<div class="table-cell">Entry date</div>' +
+            '<div class="table-cell cell-right">Above 200-day line</div>' +
+            '<div class="table-cell cell-right">A week later</div>' +
+            '<div class="table-cell cell-right">A month later</div>' +
+            '<div class="table-cell cell-right">Three months later</div>' +
+	            '<div class="table-cell cell-right">A year later</div>' +
+	            '<div class="table-cell">Beat normal year?</div>' +
+	          '</div>' +
+	          '<div id="audit-table-rows">' + buildAuditRows(initialAuditRows, year) + '</div>' +
+	        '</div>' +
+	      '</article>';
+
+	    const pathChart = renderPathChart(data);
+	    const caseChart = renderCaseChart(events);
+	    initTableAlignment(document.getElementById("audit-table"));
+	    const auditToggle = document.getElementById("audit-toggle");
+	    if (auditToggle) {
+	      const auditRowsEl = document.getElementById("audit-table-rows");
+	      const auditCaption = document.getElementById("audit-caption");
+	      let auditExpanded = false;
+	      auditToggle.addEventListener("click", function () {
+	        auditExpanded = !auditExpanded;
+	        auditRowsEl.innerHTML = buildAuditRows(auditExpanded ? auditRows : auditRows.slice(0, auditPreviewCount), year);
+	        auditToggle.setAttribute("aria-expanded", auditExpanded ? "true" : "false");
+	        auditToggle.textContent = auditExpanded ? "Show latest " + auditPreviewCount : "Show all " + auditRows.length + " cases";
+	        auditCaption.textContent = auditExpanded ? "Showing all " + auditRows.length + " complete cases." : "Showing latest " + auditPreviewCount + " of " + auditRows.length + " complete cases.";
+	        initTableAlignment(document.getElementById("audit-table"));
+	      });
+	    }
+	    window.addEventListener("resize", function () {
+	      pathChart.resize();
+	      caseChart.resize();
+      initTableAlignment(document.getElementById("audit-table"));
     });
+  }
 
-    /* Table */
-    const tbody = document.getElementById("event-table-body");
-    const rows = [...events].sort((a,b) => b.event_date.localeCompare(a.event_date));
-    tbody.innerHTML = rows.map((r) => `
-      <div class="table-row">
-        <div class="table-cell">${r.event_date}</div>
-        <div class="table-cell">${r.era_label || ""}</div>
-        <div class="table-cell cell-right">${r.ratio_at_event == null ? "—" : r.ratio_at_event.toFixed(4)}</div>
-        <div class="table-cell cell-right ${signClass(r.fwd_1m_pct)}">${fmtPct(r.fwd_1m_pct)}</div>
-        <div class="table-cell cell-right ${signClass(r.fwd_3m_pct)}">${fmtPct(r.fwd_3m_pct)}</div>
-        <div class="table-cell cell-right ${signClass(r.fwd_6m_pct)}">${fmtPct(r.fwd_6m_pct)}</div>
-        <div class="table-cell cell-right ${signClass(r.fwd_12m_pct)}">${fmtPct(r.fwd_12m_pct)}</div>
-      </div>`).join("");
+  try {
+    const loaded = await Promise.all([
+      fetchJSON("/summary/stats/@last/30"),
+      fetchJSON("/horizons/rows/@last/100"),
+      fetchJSON("/events/rows/@last/300"),
+      fetchJSON("/series/daily/@last/5000")
+    ]);
+    const summary = loaded[0].slice().sort(function (a, b) { return (b.date || 0) - (a.date || 0); })[0] || {};
+    const horizons = dedupeLatest(loaded[1], "label").sort(function (a, b) { return a.days - b.days; });
+    const events = dedupeLatest(loaded[2], "event_date").sort(function (a, b) { return a.event_date.localeCompare(b.event_date); });
+    const series = dedupeLatest(loaded[3], "date_iso").sort(function (a, b) { return a.date_iso.localeCompare(b.date_iso); });
+    render({ summary, horizons, events, series, pathOverlay: buildPathOverlay(series, events) });
+  } catch (error) {
+    app.innerHTML = '<div class="state">Data is loading. Please check back in a few minutes.</div>';
+    console.error(error);
+  }
 
-    function initTableAlignment(tableEl){
-      var rs = tableEl.querySelectorAll(".table-row");
-      if (rs.length === 0) return;
-      var colCount = rs[0].querySelectorAll(".table-cell").length;
-      rs.forEach(function(row){ row.style.removeProperty("min-width"); var cs = row.querySelectorAll(".table-cell"); for (var i=0;i<cs.length;i++) cs[i].removeAttribute("style"); });
-      var cws = [];
-      for (var c=0;c<colCount;c++){ var mx=0; rs.forEach(function(row){ var cell = row.querySelectorAll(".table-cell")[c]; if (cell) mx = Math.max(mx, cell.scrollWidth); }); cws.push(mx); }
-      var tc = 0; for (var i=0;i<cws.length;i++) tc += cws[i];
-      var gap = (colCount - 1) * 16;
-      var avail = tableEl.clientWidth - gap;
-      var rv = [];
-      for (var c2=0;c2<colCount;c2++){ var p = Math.round((cws[c2] / tc) * avail); rv.push(Math.max(cws[c2], p)); }
-      var tw = gap;
-      for (var c3=0;c3<colCount;c3++){ tw += rv[c3]; rs.forEach(function(row){ var cell = row.querySelectorAll(".table-cell")[c3]; if (!cell) return; cell.style.flex = "0 0 " + rv[c3] + "px"; }); }
-      rs.forEach(function(row){ row.style.minWidth = tw + "px"; });
+  function openModal(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.classList.add("open");
+    el.setAttribute("aria-hidden", "false");
+    document.body.style.overflow = "hidden";
+    var trigger = document.querySelector('[data-modal-open="' + id + '"]');
+    if (trigger) trigger.classList.add("is-open");
+  }
+  function closeModal(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove("open");
+    el.setAttribute("aria-hidden", "true");
+    document.body.style.overflow = "";
+    var trigger = document.querySelector('[data-modal-open="' + id + '"]');
+    if (trigger) trigger.classList.remove("is-open");
+  }
+  document.querySelectorAll("[data-modal-open]").forEach(function (button) {
+    button.addEventListener("click", function () { openModal(button.getAttribute("data-modal-open")); });
+  });
+  document.querySelectorAll("[data-modal-close]").forEach(function (button) {
+    button.addEventListener("click", function (event) {
+      event.stopPropagation();
+      closeModal(button.getAttribute("data-modal-close"));
+    });
+  });
+  document.querySelectorAll(".modal-overlay").forEach(function (overlay) {
+    overlay.addEventListener("click", function (event) {
+      if (event.target === overlay) closeModal(overlay.id);
+    });
+  });
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      document.querySelectorAll(".modal-overlay.open").forEach(function (modal) { closeModal(modal.id); });
     }
-    var tableEl = document.getElementById("event-table");
-    initTableAlignment(tableEl);
-    window.addEventListener("resize", function(){ initTableAlignment(tableEl); });
-
-    function openModal(id){ var el = document.getElementById(id); if (!el) return; el.classList.add("open"); el.setAttribute("aria-hidden","false"); document.body.style.overflow="hidden"; }
-    function closeModal(id){ var el = document.getElementById(id); if (!el) return; el.classList.remove("open"); el.setAttribute("aria-hidden","true"); document.body.style.overflow=""; }
-    document.querySelectorAll("[data-modal-open]").forEach(function(btn){ btn.addEventListener("click", function(){ openModal(btn.getAttribute("data-modal-open")); }); btn.addEventListener("keydown", function(e){ if (e.key==="Enter"||e.key===" "){ openModal(btn.getAttribute("data-modal-open")); } }); });
-    document.querySelectorAll("[data-modal-close]").forEach(function(btn){ btn.addEventListener("click", function(e){ e.stopPropagation(); closeModal(btn.getAttribute("data-modal-close")); }); });
-    document.querySelectorAll(".modal-overlay").forEach(function(ov){ ov.addEventListener("click", function(e){ if (e.target === ov) closeModal(ov.id); }); });
-    document.addEventListener("keydown", function(e){ if (e.key === "Escape") document.querySelectorAll(".modal-overlay.open").forEach(function(m){ closeModal(m.id); }); });
-  })();
+  });
+})();
 </script>
 </body>
 </html>

--- a/skills/alva/templates/what-if/template.md
+++ b/skills/alva/templates/what-if/template.md
@@ -58,7 +58,27 @@ One sentence, ≤45 words, conclusion-first. Carries 2-3 headline numbers — no
 
 **Widget:** Free Text Card with `markdown-container--m` (Medium). See `references/design-widgets.md` → Free Text Card and `references/design-components.md` → Markdown.
 
-### 2a. Counter-narrative card (optional)
+### 2a. Hero chips
+
+The hero starts with exactly three compact chips. Keep them mechanical; do not use interpretive labels such as `Trend intact`, `Short-term edge`, `Strong setup`, or `Risk-on`.
+
+Format:
+
+1. **Asset chip** — the shortest recognizable asset or market label.
+2. **Trigger chip** — the shortest readable trigger label.
+3. **Case count chip** — fixed as `Cases: {n_events}`.
+
+Examples:
+
+- `SPY` / `50D reclaim` / `Cases: 44`
+- `QQQ` / `3 down days` / `Cases: 71`
+- `S&P 500` / `Golden cross` / `Cases: 38`
+- `Gold` / `New high` / `Cases: 52`
+- `VIX` / `Above 30` / `Cases: 29`
+
+Keep the first two chips to 1–3 words each. The asset chip should not include `Asset:` and the trigger chip should not add `signal` unless the trigger would otherwise be unclear.
+
+### 2b. Counter-narrative card (optional)
 
 A second card under the hero is only allowed when it carries a counter-narrative that can't fit in the main sentence. The single most memorable counter-intuitive finding, if one exists, belongs here — never buried in methodology.
 
@@ -72,21 +92,25 @@ A second card under the hero is only allowed when it carries a counter-narrative
 One vertically-scrolling page. Top-to-bottom order:
 
 1. **Title** (section 1) — title text + README chip (right-aligned) on the same row.
-2. **Verdict hero** (section 2) — one full-width card, data-driven. **Widget:** Free Text Card (`markdown-container--m`).
-3. **Summary cards** — typically 3–6 cards (4 is the default), more if the dimension has that many meaningful buckets. Metric Cards are auto-height and wrap, so the row stack can extend to a second/third row. Every card across all rows shares ONE cutting dimension (see §3a); don't mix returns, hit rates, and per-ticker picks. **Time is one valid dimension, not the default** — choose whichever best answers the crowd question. **Widget:** Metric Card.
-4. **Supporting charts** — one or more visualizations that contextualize the metrics. Typical options: distribution bar+range, normalized price trajectory overlay, per-event heatmap, win-rate comparison, baseline comparison (if the strategy explicitly needs one). Pick whichever combination best tells the story; order them from most summary to most granular. **Widget:** Chart Card for all chart types.
-5. **Event / row detail table** — one row per event, basket member, or regime bucket, with the key per-row metric columns. **Widget:** Table Card.
-6. **References** — trigger source + data source. **Widget:** Free Text Card.
+2. **Verdict hero** (section 2) — one full-width card with the three hero chips, conclusion sentence, and one support sentence. **Widget:** Free Text Card (`markdown-container--m`).
+3. **Belief cards** — two half-width cards: `Common expectation` and `What history showed`. They translate the signal into plain language before the charts.
+4. **Main path chart + readout rail** — normalized event path chart on the left (`.col-5`), three-card readout rail on the right (`.col-3`).
+5. **Four horizon cards** — exactly four metric cards (`.col-2` × 4): a week, a month, three months, and a year later.
+6. **One-year case bar chart + past-case range** — bar chart on the left (`.col-5`), range rail on the right (`.col-3`).
+7. **Featured case cards** — three equal cards: strongest case, softest case, latest complete case.
+8. **Historical audit ledger** — one row per event, default-collapsed for large samples. **Widget:** Table Card.
 
-Methodology does not live on the scroll — it lives in a modal opened by the README chip in the title row (see §1 and [Methodology modal](#methodology-modal)).
+Methodology and references do not live on the scroll — they live in a modal opened by the README chip in the title row (see §1 and [Methodology modal](#methodology-modal)). Do not add a bottom `References` section.
 
-No tabs, no hidden panels other than the Methodology modal — everything else is on the single scroll.
+No tabs, no hidden panels other than the Methodology modal and the audit-ledger expand/collapse behavior — everything else is on the single scroll.
 
 **Canonical reasoning flow:** headline → aggregate slice (across chosen dimension) → aggregate spread → reliability → per-event / per-member paths → historical context → raw rows. Each step answers the objection raised by the previous. Methodology is available on-demand via the README chip, not inline in the flow.
 
 ### 3a. Cutting dimensions for the summary cards row
 
 Pick ONE based on the crowd question:
+
+For the default what-if event-study layout, use **Time** and render only the four canonical horizon cards: a week, a month, three months, and a year later. The hero and readout rail choose their headline horizon from those same four cards, so the headline always has a visible supporting card. Use other dimensions only when the user's question explicitly requires them.
 
 | Dimension | Use when the question is | Example cards |
 |---|---|---|
@@ -132,6 +156,22 @@ Every chart in the supporting-charts layer (§3 step 4) is a **Chart Card**. Fol
 
 **One override for this template:** Chart Card height = **560px** (the design-widgets default is 320px). Per-event charts in What-If carry more horizon and more individual paths than a typical dashboard tile, so they need the extra vertical room. All charts on the page — including side-by-side pairs (`.col-4` × 2) — use 560px.
 
+**Main path chart rules**
+
+- Rebase signal day to 100.
+- Do not draw every past case as a full-opacity line. Show only a representative sample of past paths and add a subtle middle-half band.
+- Show the typical-after-signal line and the normal-period line.
+- Tooltip hides helper/sampled-path series and shows only useful readout lines.
+
+**One-year case chart rules**
+
+- Must be a bar chart, one bar per completed case.
+- Do not label every case on the x-axis.
+- Show sparse year anchors only: first year, last year, and roughly every other calendar year.
+- Exact signal date and value belong in hover tooltip.
+- Green bars are positive, red bars are negative.
+- Keep the zero line and median line, but avoid text labels that can clip.
+
 ### 3d. Plain language (every user-visible surface)
 
 Applies to cards, chart titles, axis labels, table headers, tooltips, and methodology — not just cards. LLM defaults trend toward trading-desk jargon; override them.
@@ -155,7 +195,15 @@ Applies to cards, chart titles, axis labels, table headers, tooltips, and method
 
 - **No** "last updated / refreshed / as of" timestamp anywhere on the page.
 - **No** filters, dropdowns, selectors.
-- **Only interactivity allowed:** chart hover tooltips, and the README chip opening the Methodology modal.
+- **Only interactivity allowed:** chart hover tooltips, the README chip opening the Methodology modal, and the audit-ledger expand/collapse button when event count is high.
+
+**Audit ledger collapse rule**
+
+- If event count is 12 or fewer, show all rows.
+- If event count is above 12, show the latest 8 rows by default.
+- Add one compact `Show all N cases` button in the ledger title row.
+- When expanded, the button becomes `Show latest 8`.
+- Use the row-first flex table and `initTableAlignment`; do not use a native HTML table.
 
 ## 6. Methodology modal
 
@@ -163,5 +211,5 @@ Triggered by the README chip in the title row (§1). Mirrors the Screener templa
 
 - README chip carries `data-modal-open="methodology-modal"`; the modal root has `id="methodology-modal"`.
 - Modal panel `max-width: 896px` (narrower than the 960px base — methodology content is prose, not wide tables).
-- Body content = the two plain paragraphs defined in §3d ("how we picked events" + "how we measured returns"). Legal disclaimer, if any, goes at the bottom of this body.
+- Body content = the two plain paragraphs defined in §3d ("how we picked events" + "how we measured returns"), followed by references for trigger source and return source. Legal disclaimer, if any, goes at the bottom of this body.
 - Closed by default on page load — methodology is rarely the first thing a reader wants.


### PR DESCRIPTION
## Summary

Refreshes the Alva what-if template around the current approved event-study presentation and replaces the example with one stable SPY 50-day reclaim playbook.

## What changed

- Adds a strict hero chip contract: asset / trigger / `Cases: N`, with short mechanical labels instead of interpretive chips.
- Locks the default what-if layout to the approved flow: verdict hero, belief cards, path chart + readout rail, four horizon cards, one-year bar chart, range rail, featured cases, and collapsed audit ledger.
- Moves methodology references into the README modal and removes the bottom references section from the page flow.
- Replaces the old copper/gold example with a SPY 50-day reclaim example and matching feed script.

## Validation

- `node --check skills/alva/templates/what-if/example/feed.js`
- Parsed the inline script from `skills/alva/templates/what-if/example/index.html` with `new Function(...)`
- `git diff --check`
- Ran the SPY feed locally: 5,700 bars, 44 signals
- Verified public feed read returns 200 for `/alva/home/steven/feeds/spy-50day-reclaim-what-if/v1/data/summary/stats/@last/1`
