### PR TITLE
[jaxxjj] fix(templates): stage example/ to a working dir, never edit in place

### DIFF
--- a/skills/alva/templates/screener/template.md
+++ b/skills/alva/templates/screener/template.md
@@ -76,11 +76,20 @@ playbook families. The example already conforms — keep it that way.
   the test-debug loop on field-name mismatches disappears. The temptation is
   "my screener is special, one camelCase field won't hurt"; it will, because
   it pushes you back into adapter-shimming the renderers.
-- `cp` example files then mutate in place. Don't `Write` whole files back
-  when 70%+ is identical.
-- Do all mechanical renames in one `sed -i` pass (screener name, theme color +
-  CSS slugs, factor names, feed name, `USER`, API endpoint). `grep -nE` after
-  to catch stragglers.
+- Stage to a writable workdir on first touch, then `Edit` / `sed -i`
+  against the staged copy. `example/` is read-only reference (it lives
+  under `.claude/skills/.../templates/`, which the SDK's config-file
+  safety gate blocks writes to — and a blocked write stalls the
+  session instead of erroring cleanly):
+    ```sh
+    PB=/tmp/<playbook-slug>
+    mkdir -p "$PB" && cp -r .claude/skills/alva/templates/screener/example/. "$PB"/
+    ```
+  Now `$PB/index.html` and `$PB/feeds/...` are yours. Prefer `Edit`
+  over `Write` when 70%+ of a file is identical.
+- Do all mechanical renames in one `sed -i` pass against `$PB/`
+  (screener name, theme color + CSS slugs, factor names, feed name,
+  `USER`, API endpoint). `grep -nE` after to catch stragglers.
 - Don't read the HTML linearly. `grep -n` the marker, then `Read` with
   `offset` + `limit` on that section only.
 - Single feed: `grant` and `deploy create` have no cross-dependencies —

--- a/skills/alva/templates/thesis/template.md
+++ b/skills/alva/templates/thesis/template.md
@@ -72,11 +72,20 @@ playbook families. The example already conforms — keep it that way.
 
 ## Build workflow
 
-- `cp` example files then mutate in place. Don't `Write` whole files back
-  when 70%+ is identical.
-- Do all mechanical renames in one `sed -i` pass (benchmarks, layer/pillar
-  names + CSS slugs + colors map, feed names, `USER`, API endpoint).
-  `grep -nE` after to catch stragglers.
+- Stage to a writable workdir on first touch, then `Edit` / `sed -i`
+  against the staged copy. `example/` is read-only reference (it lives
+  under `.claude/skills/.../templates/`, which the SDK's config-file
+  safety gate blocks writes to — and a blocked write stalls the
+  session instead of erroring cleanly):
+    ```sh
+    PB=/tmp/<playbook-slug>
+    mkdir -p "$PB" && cp -r .claude/skills/alva/templates/thesis/example/. "$PB"/
+    ```
+  Now `$PB/index.html` and `$PB/feeds/...` are yours. Prefer `Edit`
+  over `Write` when 70%+ of a file is identical.
+- Do all mechanical renames in one `sed -i` pass against `$PB/`
+  (benchmarks, layer/pillar names + CSS slugs + colors map, feed names,
+  `USER`, API endpoint). `grep -nE` after to catch stragglers.
 - Schema field renames are radioactive: one benchmark rename (e.g. `pave_ytd` →
   `spy_ytd`) propagates across quant feed schema, narrative copy, HTML
   KPI cards, horizon cards, equity chart series, and attribution filters — 3


### PR DESCRIPTION
## Problem

The screener and thesis templates instruct the agent to:

> `cp` example files then mutate in place. Don't `Write` whole files back when 70%+ is identical.

"Mutate in place" doesn't name a working directory. The agent often interprets it as "cp out, then `sed -i` back at `example/`" — writing into the read-only `templates/` tree.

Claude Code's safety gate (`utils/permissions/filesystem.ts: isClaudeConfigFilePath`) treats any write under `cwd/.claude/{commands,agents,skills}/` as a config-file edit and returns:

> Claude requested permissions to write to `<path>`, but you haven't granted it yet.

In `sandbox-agent-ts` (which runs in `permissionMode: 'bypassPermissions'`) **the prompt has nobody to answer it** → the session stalls indefinitely.

## Production evidence

`carlostor7`'s screener session (2052463913125781504) burned 1267s and two stall-retries before the user worked around the gate manually. Real errors logged by the SDK:

```
This Bash command contains multiple operations. The following parts require approval:
  cp "/workspace/sessions/.../templates/screener/example/index.html" /tmp/bigcap

Claude requested permissions to write to
  /workspace/sessions/.../templates/screener/example/index.html,
  but you haven't granted it yet.
```

The exact same instruction wording exists in `templates/thesis/template.md` line 75 — class bug, not a one-off.

## Fix

Replace the ambiguous "mutate in place" line with an explicit staging pattern:

```sh
PB=/tmp/<your-playbook-slug>          # any writable dir; NOT under .claude/
mkdir -p "$PB"
cp -r .claude/skills/alva/templates/screener/example/. "$PB"/
# then Edit / sed -i against $PB/index.html, $PB/feeds/...
```

Plus explicit "never `sed -i` against `templates/`" guardrail.

Same change applied to both `screener/` and `thesis/` templates (they share the build-workflow section verbatim).

## Why not fix at the SDK layer

The safety gate is correct — it stops agents from rewriting their own skill definitions at runtime. Bypassing it in `sandbox-agent-ts` would also let runaway prompts mutate hooks, settings, and skill registries. The skill prompt should produce code that doesn't trip the gate; this PR makes that the case.

(Companion sandbox-agent-ts PR https://github.com/alva-ai/sandbox-agent-ts/pull/189 fixes the unrelated `compound-Bash splitter` stall — error #1 in the same carlostor7 session. With both PRs landed, that flow has zero permission stalls.)

## Test plan

- [x] `git diff --stat` shows only the two template files
- [x] No structural changes to `Build workflow` order — only the cp/sed-i bullets reworded
- [ ] stg smoke: trigger `use-template:screener` end-to-end, confirm zero `requested permissions` strings in sandbox logs and zero writes recorded under `.claude/skills/.../templates/`
- [ ] stg smoke: same for `use-template:thesis`