### PR TITLE
[jaxxjj] docs(alva): document `alva deploy trigger` for build-time verification

### DIFF
--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -13,8 +13,9 @@ The deployment workflow:
 1. **Write** a script (feed or task) and upload it to the filesystem
 2. **Test** it manually via `alva run`
 3. **Deploy** it as a cronjob via `alva deploy create`
-4. **Monitor** the cronjob status via `alva deploy list` / `alva deploy get`
-5. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`
+4. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run)
+5. **Monitor** the cronjob status via `alva deploy list` / `alva deploy get`
+6. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`
 
 Cronjobs execute the script through the same jagent runtime as `alva run`.
 The script receives the same environment (`require("env").args` contains the
@@ -105,6 +106,31 @@ alva deploy resume --id 42
 ```
 
 Both return the updated cronjob object.
+
+### Trigger an Out-of-Schedule Run
+
+Fire the cronjob once, immediately. Returns the Hatchet workflow run id
+at enqueue — async; the `cronjob_runs` row appears only after the worker
+finishes the run.
+
+```bash
+alva deploy trigger --id 42
+# { "workflow_run_id": "hatchet-wf-..." }
+```
+
+To verify completion, poll `runs` and match by `workflow_run_id`:
+
+```bash
+WF=$(alva deploy trigger --id 42 | jq -r .workflow_run_id)
+while ! ROW=$(alva deploy runs --id 42 --first 5 \
+               | jq -e ".runs[] | select(.workflow_run_id==\"$WF\")"); do
+  sleep 5
+done
+echo "$ROW" | jq '{id, status, error}'
+```
+
+Use *after* deploy to confirm the full cronjob path is wired correctly.
+For iterating on script logic without Hatchet, use `alva run` instead.
 
 ### Debugging Runs
 


### PR DESCRIPTION
## Summary

Documents the new \`alva deploy trigger\` subcommand (shipping in [alva-ai/toolkit-ts#42](https://github.com/alva-ai/toolkit-ts/pull/42), backed by [alva-ai/alva-gateway#334](https://github.com/alva-ai/alva-gateway/pull/334) and merged [alva-ai/alva-backend#938](https://github.com/alva-ai/alva-backend/pull/938)).

The trigger fires a cronjob once on demand, bypassing its schedule. Build agents need this to confirm a freshly-deployed cronjob actually runs end-to-end (Hatchet → jagent → ALFS) without waiting for the first natural tick.

## Changes to \`references/deployment.md\`

- **Intro workflow** gains a step 4 ("Verify the deployment") between \`deploy create\` and the list/runs flow
- New **"Trigger an Out-of-Schedule Run"** subsection between Pause/Resume and Debugging Runs (matches the CLI subcommand ordering)
- **Canonical shell recipe** for poll-by-workflow_run_id (\`WF=\$(...) ; while ! ROW=\$(...)\`) — same pattern shipped in toolkit-ts CLI help, so the round-trip is consistent
- **\`alva run\` vs \`alva deploy trigger\`** comparison table — easy to confuse, different layers (script in isolation vs deployed cronjob path)
- **Common errors** table (404/412/503) — so callers know which are retryable vs which need a different action

## Sequencing

- ✅ [alva-ai/alva-backend#938](https://github.com/alva-ai/alva-backend/pull/938) merged
- 🟡 [alva-ai/alva-gateway#334](https://github.com/alva-ai/alva-gateway/pull/334) — REST endpoint
- 🟡 [alva-ai/toolkit-ts#42](https://github.com/alva-ai/toolkit-ts/pull/42) — SDK + CLI
- 🟡 this PR — skill reference doc

This PR is purely docs — safe to merge whenever, but most useful to land alongside or just after toolkit-ts#42 publishes the new CLI version so users don't see "command not found" when they try the example.

## Test plan

- [x] Skim render of the updated section
- [x] Shell recipe is copy-pasteable (no smart quotes, no template-literal issues)
- [ ] After toolkit publishes: dry-run the recipe end-to-end on stg