### PR TITLE
docs(alva): require README on every released playbook

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -617,7 +617,13 @@ outputs read at runtime (no inline literals for data).
 #### Common steps (all users)
 
 1. **Write HTML to ALFS**: `alva fs write --path '~/playbooks/{name}/index.html' --file ./index.html --mkdir-parents`
-2. **Create playbook draft**: `alva release playbook-draft` — creates DB
+2. **Write README to ALFS** *(mandatory)*:
+   `alva fs write --path '~/playbooks/{name}/README.md' --file ./README.md --mkdir-parents`.
+   Every released playbook must ship a README at this exact path. See
+   [README content shape](#readme-content-shape) below for what to put in
+   it. The README is what the platform surfaces in the "How does this
+   work?" modal — releasing without one leaves the playbook unexplained.
+3. **Create playbook draft**: `alva release playbook-draft` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
    This request must include both the URL-safe `name` and the human-readable
    `display_name`. Use `[subject/theme] [analysis angle/strategy logic]`, put
@@ -630,7 +636,7 @@ outputs read at runtime (no inline literals for data).
    resolves each symbol to a full trading pair object and stores the result
    in the playbook metadata. Max 50 symbols per request. Unknown symbols
    are silently skipped.
-3. **Screenshot**: Take a screenshot to verify the released playbook renders
+4. **Screenshot**: Take a screenshot to verify the released playbook renders
    correctly from the deployed published URL (for example,
    `https://<username>.playbook.alva.ai/<playbook_name>/v1.0.0/index.html`):
 
@@ -640,6 +646,62 @@ outputs read at runtime (no inline literals for data).
 
    The CLI handles authentication automatically. See
    [screenshot.md](references/api/screenshot.md) for full parameter details.
+
+When calling `alva release playbook`, always pass
+`--readme-url '{name}/README.md'` (the relative form). The server validates
+this against the README path you wrote in step 2 and rejects any other
+value with `InvalidArgument`. See [release.md](references/api/release.md#release-playbook)
+for the absolute-form alternative and the full validation rules.
+
+#### README content shape
+
+The README is a markdown file at `~/playbooks/{name}/README.md`. It is a
+standalone document — not a copy of `display_name` or `description`. The
+target reader is someone deciding whether to trust this playbook's
+numbers, not someone browsing for ideas.
+
+Reuse the methodology-modal shape from the playbook templates as the
+canonical structure (see
+[screener template § Methodology Modal](templates/screener/template.md#methodology-modal)
+and the [what-if](templates/what-if/template.md) and
+[thesis](templates/thesis/template.md) templates' methodology sections).
+Pick the subsections that apply; skip ones that don't.
+
+Required sections (every playbook):
+
+- **Overview** — one paragraph in plain English: what the playbook
+  computes, on what universe, and the question it answers. Same scope
+  bound as the methodology modal's overview.
+- **Data sources** — every feed/SDK/BYOD source the playbook reads, with
+  the relevant specifics (symbol, interval, exchange, indicator
+  parameters). Match the sources actually called by the feed scripts —
+  do not list aspirational sources.
+- **Methodology** — the rules, formula, or signal logic. For
+  filter/screener-shaped playbooks: every threshold and every excluded
+  category. For scored playbooks: factor list, normalization, weights,
+  and scoring formula stated exactly. For event-study/what-if: the
+  trigger definition, the cutting dimension, and the horizon set.
+- **Update cadence** — cron schedule of the backing feeds and what
+  "fresh" means for this playbook (e.g. "updates every hour, 6am-10pm
+  ET"). Must match the deployed cronjobs; do not claim a cadence the
+  cronjob doesn't enforce.
+- **Limits & blind spots** — known data gaps, sample-size caveats,
+  survivorship issues, regime sensitivity, anything that would change
+  how a reader weighs the output. If there are none, write "None known"
+  — do not omit the section.
+
+Optional sections (include when the shape applies):
+
+- **Worked example** — re-derive the current top result from raw inputs
+  (especially for scored screeners and event studies, where the formula
+  is otherwise opaque).
+- **Reference / further reading** — links to source studies or canonical
+  references the methodology relies on.
+
+Voice: same rules as all other user-facing prose
+([narrative-voice.md](references/narrative-voice.md)). No marketing
+language, no claims unsupported by the feeds, no future tense for
+behavior that isn't already wired up.
 
 #### Pro users (`subscription_tier = "pro"`)
 
@@ -692,6 +754,13 @@ Before calling `alva release playbook`, verify all of the following:
    status. Data source claims match actual SDK/BYOD calls in the feed script.
 6. **Target user is correct**: The playbook is being released under the
    requesting user's namespace (see user scope enforcement above).
+7. **README is present and accurate**: `~/playbooks/{name}/README.md` exists
+   on ALFS, covers all required sections (Overview, Data sources,
+   Methodology, Update cadence, Limits & blind spots — see
+   [README content shape](#readme-content-shape)), and its source/cadence
+   claims match the actual feed scripts and deployed cronjobs. The
+   `--readme-url` flag must be passed on `alva release playbook` and must
+   match this exact path (relative form `{name}/README.md` is preferred).
 
 ### 8. Remix (Create from Existing Playbook)
 
@@ -1029,6 +1098,10 @@ verify these prerequisites:
    confirm HTTP 200 (not 403).
 3. **HTML check** (playbook only) — confirm the playbook HTML file exists in
    ALFS at the expected path.
+4. **README check** (playbook only) — confirm `~/playbooks/{name}/README.md`
+   exists in ALFS and follows the
+   [README content shape](#readme-content-shape). The publish call must
+   pass `--readme-url '{name}/README.md'`.
 
 If the build was interrupted and resumed, re-run this checklist from the top.
 Do not assume prior steps completed successfully.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -620,9 +620,12 @@ outputs read at runtime (no inline literals for data).
 2. **Write README to ALFS** *(mandatory)*:
    `alva fs write --path '~/playbooks/{name}/README.md' --file ./README.md --mkdir-parents`.
    Every released playbook must ship a README at this exact path. See
-   [README content shape](#readme-content-shape) below for what to put in
-   it. The README is what the platform surfaces in the "How does this
-   work?" modal — releasing without one leaves the playbook unexplained.
+   [Playbook README in release.md](references/api/release.md#playbook-readme)
+   for the canonical content shape (Overview, Data sources & freshness,
+   Blind spots, plus shape-specific sections for screener / thesis /
+   what-if). The README is the single source of truth for the playbook's
+   "How does this work?" surface — releasing without one leaves the
+   playbook unexplained.
 3. **Create playbook draft**: `alva release playbook-draft` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
    This request must include both the URL-safe `name` and the human-readable
@@ -650,58 +653,9 @@ outputs read at runtime (no inline literals for data).
 When calling `alva release playbook`, always pass
 `--readme-url '{name}/README.md'` (the relative form). The server validates
 this against the README path you wrote in step 2 and rejects any other
-value with `InvalidArgument`. See [release.md](references/api/release.md#release-playbook)
-for the absolute-form alternative and the full validation rules.
-
-#### README content shape
-
-The README is a markdown file at `~/playbooks/{name}/README.md`. It is a
-standalone document — not a copy of `display_name` or `description`. The
-target reader is someone deciding whether to trust this playbook's
-numbers, not someone browsing for ideas.
-
-Reuse the methodology-modal shape from the playbook templates as the
-canonical structure (see
-[screener template § Methodology Modal](templates/screener/template.md#methodology-modal)
-and the [what-if](templates/what-if/template.md) and
-[thesis](templates/thesis/template.md) templates' methodology sections).
-Pick the subsections that apply; skip ones that don't.
-
-Required sections (every playbook):
-
-- **Overview** — one paragraph in plain English: what the playbook
-  computes, on what universe, and the question it answers. Same scope
-  bound as the methodology modal's overview.
-- **Data sources** — every feed/SDK/BYOD source the playbook reads, with
-  the relevant specifics (symbol, interval, exchange, indicator
-  parameters). Match the sources actually called by the feed scripts —
-  do not list aspirational sources.
-- **Methodology** — the rules, formula, or signal logic. For
-  filter/screener-shaped playbooks: every threshold and every excluded
-  category. For scored playbooks: factor list, normalization, weights,
-  and scoring formula stated exactly. For event-study/what-if: the
-  trigger definition, the cutting dimension, and the horizon set.
-- **Update cadence** — cron schedule of the backing feeds and what
-  "fresh" means for this playbook (e.g. "updates every hour, 6am-10pm
-  ET"). Must match the deployed cronjobs; do not claim a cadence the
-  cronjob doesn't enforce.
-- **Limits & blind spots** — known data gaps, sample-size caveats,
-  survivorship issues, regime sensitivity, anything that would change
-  how a reader weighs the output. If there are none, write "None known"
-  — do not omit the section.
-
-Optional sections (include when the shape applies):
-
-- **Worked example** — re-derive the current top result from raw inputs
-  (especially for scored screeners and event studies, where the formula
-  is otherwise opaque).
-- **Reference / further reading** — links to source studies or canonical
-  references the methodology relies on.
-
-Voice: same rules as all other user-facing prose
-([narrative-voice.md](references/narrative-voice.md)). No marketing
-language, no claims unsupported by the feeds, no future tense for
-behavior that isn't already wired up.
+value with `InvalidArgument`. See
+[release.md](references/api/release.md#playbook-readme) for the absolute
+form, full validation rules, and the canonical content shape.
 
 #### Pro users (`subscription_tier = "pro"`)
 
@@ -755,12 +709,12 @@ Before calling `alva release playbook`, verify all of the following:
 6. **Target user is correct**: The playbook is being released under the
    requesting user's namespace (see user scope enforcement above).
 7. **README is present and accurate**: `~/playbooks/{name}/README.md` exists
-   on ALFS, covers all required sections (Overview, Data sources,
-   Methodology, Update cadence, Limits & blind spots — see
-   [README content shape](#readme-content-shape)), and its source/cadence
-   claims match the actual feed scripts and deployed cronjobs. The
-   `--readme-url` flag must be passed on `alva release playbook` and must
-   match this exact path (relative form `{name}/README.md` is preferred).
+   on ALFS and covers the required sections (see
+   [Playbook README in release.md](references/api/release.md#playbook-readme)).
+   Its source / cadence claims match the actual feed scripts and deployed
+   cronjobs. The `--readme-url` flag must be passed on `alva release playbook`
+   and must match this exact path (relative form `{name}/README.md` is
+   preferred).
 
 ### 8. Remix (Create from Existing Playbook)
 
@@ -1100,8 +1054,8 @@ verify these prerequisites:
    ALFS at the expected path.
 4. **README check** (playbook only) — confirm `~/playbooks/{name}/README.md`
    exists in ALFS and follows the
-   [README content shape](#readme-content-shape). The publish call must
-   pass `--readme-url '{name}/README.md'`.
+   [Playbook README content shape](references/api/release.md#playbook-readme).
+   The publish call must pass `--readme-url '{name}/README.md'`.
 
 If the build was interrupted and resumed, re-run this checklist from the top.
 Do not assume prior steps completed successfully.

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -76,7 +76,7 @@ alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashb
 ## Release Playbook
 
 ```
-alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text"
+alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text" --readme-url "NAME/README.md"
 ```
 
 Release an existing playbook for public hosting. Reads the playbook HTML from
@@ -84,12 +84,18 @@ Release an existing playbook for public hosting. Reads the playbook HTML from
 
 Changelog lives on the release, not the draft — set it when publishing.
 
-| Flag        | Type   | Required | Description                                 |
-| ----------- | ------ | -------- | ------------------------------------------- |
-| --name      | string | yes      | URL-safe playbook name (must already exist) |
-| --version   | string | yes      | SemVer (e.g. `v1.0.0`)                      |
-| --feeds     | array  | yes      | Feed references `[{feed_id, feed_major?}]`  |
-| --changelog | string | yes      | Release changelog                           |
+`--readme-url` is required: it declares the ALFS location of the playbook's
+README and the server validates the value against a fixed convention (see
+**README declaration** below). Write the README to that path **before**
+calling this command.
+
+| Flag         | Type   | Required | Description                                                                                |
+| ------------ | ------ | -------- | ------------------------------------------------------------------------------------------ |
+| --name       | string | yes      | URL-safe playbook name (must already exist)                                                |
+| --version    | string | yes      | SemVer (e.g. `v1.0.0`)                                                                     |
+| --feeds      | array  | yes      | Feed references `[{feed_id, feed_major?}]`                                                 |
+| --changelog  | string | yes      | Release changelog                                                                          |
+| --readme-url | string | yes      | Owner-attested README location. See **README declaration** for the two accepted forms.     |
 
 Feed reference fields:
 
@@ -98,10 +104,31 @@ Feed reference fields:
 | feed_id    | int64 | yes      | Feed ID (own or others' feed)            |
 | feed_major | int32 | no       | Major version (defaults to feed default) |
 
+### README declaration
+
+The server only accepts two forms for `--readme-url`:
+
+1. **Relative** (preferred): `<name>/README.md` — e.g. `btc-dashboard/README.md`.
+2. **Absolute**: `/alva/home/<username>/playbooks/<name>/README.md` —
+   e.g. `/alva/home/alice/playbooks/btc-dashboard/README.md`. Use this only
+   when you cannot avoid hard-coding the username.
+
+Any other value is rejected with `InvalidArgument`. The server does **not**
+write the README file — the owner must place it at
+`~/playbooks/<name>/README.md` on ALFS before calling `alva release playbook`.
+Both URL forms point to that same path; only the spelling differs.
+
 ```
-alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release"
+# 1. Write README to ALFS first.
+alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
+
+# 2. Then release, declaring the README location.
+alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release" --readme-url "btc-dashboard/README.md"
 → {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html", "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
+
+See [Step 7 in SKILL.md](../../SKILL.md#7-release) for the full release
+flow including required README content shape.
 
 After a successful release, output the alva.ai playbook link to the user:
 `https://alva.ai/u/<username>/playbooks/<playbook_name>`

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -86,8 +86,8 @@ Changelog lives on the release, not the draft — set it when publishing.
 
 `--readme-url` is required: it declares the ALFS location of the playbook's
 README and the server validates the value against a fixed convention (see
-**README declaration** below). Write the README to that path **before**
-calling this command.
+[Playbook README](#playbook-readme) below). Write the README to that path
+**before** calling this command.
 
 | Flag         | Type   | Required | Description                                                                                |
 | ------------ | ------ | -------- | ------------------------------------------------------------------------------------------ |
@@ -95,7 +95,7 @@ calling this command.
 | --version    | string | yes      | SemVer (e.g. `v1.0.0`)                                                                     |
 | --feeds      | array  | yes      | Feed references `[{feed_id, feed_major?}]`                                                 |
 | --changelog  | string | yes      | Release changelog                                                                          |
-| --readme-url | string | yes      | Owner-attested README location. See **README declaration** for the two accepted forms.     |
+| --readme-url | string | yes      | Owner-attested README location. See [Playbook README](#playbook-readme) for accepted forms. |
 
 Feed reference fields:
 
@@ -104,22 +104,8 @@ Feed reference fields:
 | feed_id    | int64 | yes      | Feed ID (own or others' feed)            |
 | feed_major | int32 | no       | Major version (defaults to feed default) |
 
-### README declaration
-
-The server only accepts two forms for `--readme-url`:
-
-1. **Relative** (preferred): `<name>/README.md` — e.g. `btc-dashboard/README.md`.
-2. **Absolute**: `/alva/home/<username>/playbooks/<name>/README.md` —
-   e.g. `/alva/home/alice/playbooks/btc-dashboard/README.md`. Use this only
-   when you cannot avoid hard-coding the username.
-
-Any other value is rejected with `InvalidArgument`. The server does **not**
-write the README file — the owner must place it at
-`~/playbooks/<name>/README.md` on ALFS before calling `alva release playbook`.
-Both URL forms point to that same path; only the spelling differs.
-
 ```
-# 1. Write README to ALFS first.
+# 1. Write README to ALFS first (see Playbook README below for content shape).
 alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
 
 # 2. Then release, declaring the README location.
@@ -127,9 +113,109 @@ alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id"
 → {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html", "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
 
-See [Step 7 in SKILL.md](../../SKILL.md#7-release) for the full release
-flow including required README content shape.
-
 After a successful release, output the alva.ai playbook link to the user:
 `https://alva.ai/u/<username>/playbooks/<playbook_name>`
+
+## Playbook README
+
+Every released playbook ships a README at `~/playbooks/<name>/README.md`.
+This is the canonical specification for what that file must contain. The
+HTML's "How does this work?" / methodology modal renders the same content,
+so there is one source of truth — the README — not a separate per-template
+copy.
+
+### Path and `--readme-url` forms
+
+The owner writes the README to ALFS before publish; the server does not
+write the file. The server only accepts two forms for `--readme-url`:
+
+1. **Relative** (preferred): `<name>/README.md` — e.g. `btc-dashboard/README.md`.
+2. **Absolute**: `/alva/home/<username>/playbooks/<name>/README.md` — e.g.
+   `/alva/home/alice/playbooks/btc-dashboard/README.md`. Use this only
+   when hard-coding the username is unavoidable.
+
+Both forms point to the same ALFS path. Any other value is rejected with
+`InvalidArgument`.
+
+### Content shape
+
+The README is a markdown file. It is a standalone document — not a copy of
+`display_name` or `description`. The reader is someone deciding whether
+to trust this playbook's numbers, not someone browsing for ideas.
+
+Structure: required sections (every playbook), then conditional sections
+keyed to playbook shape (screener / thesis / what-if), then optional
+sections.
+
+#### Required (every playbook)
+
+- **One-paragraph overview** — plain English: what the playbook computes,
+  on what universe, the question it answers. Same scope bound as the
+  in-app methodology modal's overview.
+- **Data sources & freshness** — every feed / SDK / BYOD source the
+  playbook reads, with the relevant specifics (symbol, interval, exchange,
+  indicator parameters), plus the cron cadence (in ET) and what "fresh"
+  means for this playbook. Match the sources actually called by the feed
+  scripts and the deployed cronjobs — do not list aspirational sources or
+  cadences the cronjob does not enforce.
+- **Blind spots** — honest list of what this does NOT capture (sample-size
+  caveats, survivorship issues, regime sensitivity, data gaps, anything
+  that would change how a reader weighs the output). If there are none,
+  write "None known" — do not omit the section.
+
+#### Conditional — Screener / filter shape
+
+- **Filter rules** (basket / hard filters) — every threshold, every
+  excluded category. Senate example level of specificity: "excludes ETFs;
+  requires ≥ 2 distinct senators + ≥ $50K total".
+- **Factor weights + scoring formula** (scored only) — factor name, raw
+  measure, normalization, weight. State the formula exactly.
+- **Score bands** (scored only) — score ranges → tier label.
+- **Flag definitions** (when flags exist) — for each flag: label, tier,
+  exact threshold.
+- **Worked example** (scored only) — re-derive the current #1 from raw
+  inputs. Header (id + name + rank + band) plus per-factor rows
+  (`name | raw / 100 × weight% = pts`) plus a total. State the actual
+  display relationship: if the displayed score equals the factor-weighted
+  sum, say so; if it is a rescaling (e.g. `45 + 50 * normalized composite`),
+  state that honestly. Don't claim equality you can't deliver.
+
+#### Conditional — Thesis shape
+
+- **How this playbook works** — quant + ADK pipelines, post-processing
+  matcher, exact list of inputs fed to the narrative agent.
+- **Thesis pillars** (multi-pillar only) — for each pillar: id, name,
+  one-sentence claim, the daily signal that would verify or contradict it.
+- **News matching** — ticker overlap + keyword similarity rules; how
+  unmatched items flow.
+- **TLDR generation** — four-question framework, grounding rule, thrown
+  errors, how `pushLine` is written. Include 1-2 gold few-shot TLDRs
+  (each a `{thesis, pushLine}` pair).
+- **Basket selection** — every name by layer; inclusion criteria;
+  change-log policy. If composite scoring: factor table, composite formula,
+  band thresholds, flag definitions, worked example re-deriving the
+  current #1.
+- **Computation rules** — every derived field: alpha definition, risk
+  priority matrix, delta surfacing rules, etc.
+
+#### Conditional — What-if / event-study shape
+
+- **How we picked events** — the trigger definition: exact rule, lookback,
+  exclusions.
+- **How we measured returns** — the cutting dimension and the horizon set
+  (e.g. 1W / 1M / 3M / 1Y), aggregation rule (mean / median), benchmark.
+- **References** — links to the source for the trigger and the source for
+  the return measurement.
+
+#### Optional
+
+- **Glossary** — domain-specific terms.
+- **Legal disclaimer** — at the bottom, where applicable.
+
+### Voice
+
+Same rules as all other user-facing prose
+([narrative-voice.md](../narrative-voice.md)). No marketing language, no
+claims unsupported by the feeds, no future tense for behavior that is not
+already wired up.
 (use the playbook `name` and the username from `alva whoami`)

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -146,7 +146,7 @@ and only then upload them. Do not write fresh files from scratch.
 7. **Write README** (mandatory) — adapt the source playbook's README to
    your data sources and methodology, then upload:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
-   See [SKILL.md → README content shape](../SKILL.md#readme-content-shape).
+   See [release.md → Playbook README](api/release.md#playbook-readme).
 8. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
 9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url "{new-name}/README.md"`
 

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -143,8 +143,12 @@ and only then upload them. Do not write fresh files from scratch.
 6. **Edit local HTML** (the `./index.html` from Step 2 — update data
    paths to point to your own feed) and upload:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
-7. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
-8. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..."`
+7. **Write README** (mandatory) — adapt the source playbook's README to
+   your data sources and methodology, then upload:
+   `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
+   See [SKILL.md → README content shape](../SKILL.md#readme-content-shape).
+8. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
+9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url "{new-name}/README.md"`
 
 **Important**: The new playbook must use a unique name in your user space. The
 feed scripts must use **your own** ALFS paths (not the original owner's) for

--- a/skills/alva/templates/screener/template.md
+++ b/skills/alva/templates/screener/template.md
@@ -392,36 +392,18 @@ in the digest prompt guarantees the fit.
 
 ## Methodology Modal
 
-Always include — explain how the screener works. Triggered by the README chip
-in the tab-right group. The example wires up the trigger / overlay / panel /
-close behaviors / lazy-render. Only the **content** changes per screener.
+The README chip in the tab-right group opens the methodology modal. The
+example wires up the trigger / overlay / panel / close behaviors and
+lazy-renders the body — only the **content** changes per screener.
 
-Pick subsections that apply; skip ones that don't (a momentum screener has no
-factor weights; a pure-filter screener has no scoring formula):
+Modal content = the playbook's
+[`README.md`](../../references/api/release.md#playbook-readme), rendered
+into the modal body. There is one source of truth for what the playbook
+explains; do not maintain a separate per-template content list here.
 
-- **One-paragraph overview** (always) — plain English: what the screener
-  ranks / filters and why.
-- **Filter rules** (basket / hard filters) — every threshold, every excluded
-  category. The senate example excludes ETFs and requires ≥ 2 distinct
-  senators + ≥ $50K total — that level of specificity.
-- **Factor weights + scoring formula** (scored only) — factor name, raw
-  measure, normalization, weight. State the formula exactly.
-- **Worked example** (scored only) — re-derive the current #1 from raw
-  inputs. Header (id + name + rank + band) plus monospace per-factor rows
-  (`name | raw / 100 × weight% = pts`) plus a total. The verify badge states
-  the actual relationship: if the displayed score is the factor-weighted
-  sum, it equals the total; if the display is a rescaling (like the senate
-  example's `45 + 50 * normalized composite`), state that honestly so users
-  can reconcile. Don't claim equality you can't deliver.
-- **Score bands** — score ranges → tier label.
-- **Flag definitions** — for each flag: label, tier, exact threshold.
-- **Data sources & freshness** — which SDKs / endpoints, when each updates.
-- **Blind spots** — honest list of what this does NOT capture.
-- **Glossary** — domain-specific terms.
-
-**Performance** — lazy-render the modal body the first time it opens, not on
-page load; methodology is rarely the first thing a user wants. The example
-does this.
+**Performance** — lazy-render the modal body the first time it opens, not
+on page load; methodology is rarely the first thing a user wants. The
+example does this.
 
 ---
 

--- a/skills/alva/templates/thesis/template.md
+++ b/skills/alva/templates/thesis/template.md
@@ -281,29 +281,11 @@ matched to a catalyst or risk show a tag indicating which one. No pagination —
 
 ## Methodology Modal
 
-Always include — explains how the playbook works. The example wires up the trigger
-/ overlay / panel / close behaviors / lazy-render. Only the **content** changes
-per thesis.
+The README chip in the tab-right group opens the methodology modal. The
+example wires up the trigger / overlay / panel / close behaviors and
+lazy-renders the body — only the **content** changes per thesis.
 
-Pick subsections that apply; skip ones that don't fit (a single-pillar thesis
-has no pillars list; a default-scored basket has no factor weights table):
-
-- **How this playbook works** — quant + ADK pipelines, post-processing matcher,
-  cadence in ET, exact list of inputs fed to the narrative agent.
-- **Thesis pillars** (multi-pillar only) — for each pillar: id, name, one-sentence
-  claim, the daily signal that would verify or contradict it.
-- **News matching** — ticker overlap + keyword similarity; unmatched flow to Tab 5.
-- **TLDR generation** — four-question framework, grounding rule, thrown errors, how
-  `pushLine` is written. Include 1-2 gold few-shot TLDRs (each a `{thesis,
-  pushLine}` pair).
-- **Basket selection** — every name by layer; inclusion criteria; change-log
-  policy. If composite scoring: factor table (name, measure, normalization,
-  weight), composite formula, band thresholds, flag definitions, a worked
-  example re-deriving the current #1.
-- **Computation rules** — every derived field: alpha definition, risk priority
-  matrix, delta surfacing rules, etc.
-- **Data sources** — OHLCV + fundamentals (Alva SDK); macro (FRED / World Bank /
-  etc.); news (Alva News SDK); social (GrokX or equivalent); narrative (ADK agent
-  + tools).
-- **Blind spots** — honest list of what this does NOT capture.
-- **Glossary** — thesis-specific terms.
+Modal content = the playbook's
+[`README.md`](../../references/api/release.md#playbook-readme), rendered
+into the modal body. There is one source of truth for what the playbook
+explains; do not maintain a separate per-template content list here.

--- a/skills/alva/templates/what-if/template.md
+++ b/skills/alva/templates/what-if/template.md
@@ -180,7 +180,7 @@ Applies to cards, chart titles, axis labels, table headers, tooltips, and method
 - **Time horizons and telegraphic codes**: "a month later" / "a year later" / "sixty trading days after the event". Never `+1M` / `+1Y` / `D+10` / `D+60` / `d21` / `fwd_3m` / `N=15` / bare `21 trading days`.
 - **Banned jargon**: `drawdown`, `cohort`, `regime`, `baseline`, `dispersion`, `reaction`, `realization`, `persistency`, `cumulative return`, `IQR`, `whiskers`, `outliers`, `realized volatility`, `R-squared`. Prefer: "biggest dip", "group", "state", "typical outcome", "range between biggest and smallest past cases", "middle half of past outcomes", "daily price swings", "almost no relationship between the two".
 - **Explain cutoffs inline**: every `since YYYY` / sample filter / threshold carries a one-clause reason on first mention ("since 2011 — that's when this ETF started trading"; "20% volatility threshold — the level that typically flags an early sell-off").
-- **Methodology** (inside the modal) = two short plain paragraphs: "how we picked events" + "how we measured returns". No formulas, no `consensus EPS` / `recovery date` / `sample period`. Any legal disclaimer goes at the bottom of this modal, not on the page.
+- **Methodology** (inside the modal) — modal body renders the playbook's `README.md` (see [release.md → Playbook README](../../references/api/release.md#playbook-readme) for the canonical content shape). For what-if, the README's methodology covers "how we picked events" and "how we measured returns" in plain prose — no formulas, no `consensus EPS` / `recovery date` / `sample period` jargon. Any legal disclaimer lives at the bottom of the README.
 
 ## 4. Data presentation
 
@@ -211,5 +211,5 @@ Triggered by the README chip in the title row (§1). Mirrors the Screener templa
 
 - README chip carries `data-modal-open="methodology-modal"`; the modal root has `id="methodology-modal"`.
 - Modal panel `max-width: 896px` (narrower than the 960px base — methodology content is prose, not wide tables).
-- Body content = the two plain paragraphs defined in §3d ("how we picked events" + "how we measured returns"), followed by references for trigger source and return source. Legal disclaimer, if any, goes at the bottom of this body.
+- Body content = the playbook's [`README.md`](../../references/api/release.md#playbook-readme), rendered into the modal body. One source of truth; do not duplicate the content shape here.
 - Closed by default on page load — methodology is rarely the first thing a reader wants.


### PR DESCRIPTION
## Summary

- Step 7 of the release flow now mandates writing a README to
  `~/playbooks/{name}/README.md` and passing
  `--readme-url '{name}/README.md'` to `alva release playbook`.
- Adds a "README content shape" section reusing the methodology-modal
  shape from the screener / what-if / thesis templates: required
  Overview, Data sources, Methodology, Update cadence, Limits & blind
  spots; optional Worked example and References.
- Updates Pre-Release Validation, Pre-Release Verification, and the
  remix workflow so README + `--readme-url` are checked end-to-end.

## Context

alva-gateway and alva-backend now accept an owner-attested `readme_url`
on `release/playbook`, validated against a fixed ALFS path. Mirrors:

- alva-gateway#337 (HTTP/gRPC plumbing)
- alva-backend#930 (validation + DB persistence)
- toolkit-ts#47 (SDK + CLI `--readme-url`)

This PR makes the skill drive agents through the new flow so every
released playbook ships with a README the platform can surface in the
"How does this work?" modal.

## Breaking change

Releases without a README will no longer pass the skill's
Pre-Release Validation. Agents following the skill will:

1. Write `~/playbooks/{name}/README.md` to ALFS as part of Step 7.
2. Pass `--readme-url '{name}/README.md'` to `alva release playbook`.

## Migration

Depends on toolkit-ts#47 landing and being released — older toolkit-ts
versions will reject `--readme-url` as an unknown flag. Order:

1. Merge + release toolkit-ts#47.
2. Bump the toolkit-ts version any user-facing tooling pins.
3. Merge this PR.

## Test plan

- [ ] Release a playbook end-to-end against staging, with README on ALFS
      and `--readme-url '{name}/README.md'`, and confirm `playbooks.readme_url`
      is persisted (or `playbook.json` surfaces it).
- [ ] Release with the absolute form and confirm acceptance.
- [ ] Release with a non-conformant `--readme-url` and confirm the
      gateway returns `InvalidArgument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)