### PR TITLE
docs: add Perplexity finance search to Alva skill

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -514,7 +514,7 @@ available in every script execution.
 | Module group                              | Description                                                               |
 | ----------------------------------------- | ------------------------------------------------------------------------- |
 | `feed_widgets`                            | Per-handle/channel rolling subscriptions — news, Twitter/X, YouTube, Reddit, podcasts (e.g. `getTwitterFeed`). Twitter also has historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
-| `unified_search`                          | Web, social, finance search, and URL scraping tools (X/Grok, Perplexity Finance, Google, Brave, serper, decodo) |
+| `unified_search`                          | Web, social, fallback non-US finance search, and URL scraping tools (X/Grok, Perplexity Finance, Google, Brave, serper, decodo) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)                 |
 
 To discover available modules and their documentation:
@@ -534,12 +534,14 @@ external HTTP APIs within the runtime.
 
 #### Content Search
 
-Search across Twitter/X, finance data, news, Reddit, YouTube, podcasts, and general web.
+Search across Twitter/X, fallback non-US finance data, news, Reddit, YouTube, podcasts, and general web.
 Use whenever the playbook needs content beyond structured data SDKs — from
 targeted queries ("what are people saying about NVDA earnings") to broad
 discovery ("trending crypto discussions this week"), including social
-discussions, live finance quote/market-data lookup, market narratives, news
-coverage, sentiment, analyst commentary, and community reactions.
+discussions, international-market quote/market-data lookup when structured
+SDK coverage is insufficient, market narratives, news coverage, sentiment,
+analyst commentary, and community reactions. For US equities and deterministic
+time-series/fundamental data, prefer the structured Alva data SDKs first.
 
 Content search modules live in the `unified_search` runtime-library
 partition. Discover them via the same partition API as the other runtime

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -477,7 +477,7 @@ available in every script execution.
 | Module group                              | Description                                                               |
 | ----------------------------------------- | ------------------------------------------------------------------------- |
 | `feed_widgets`                            | Per-handle/channel rolling subscriptions — news, Twitter/X, YouTube, Reddit, podcasts (e.g. `getTwitterFeed`). Twitter also has historical backfill over a time window (`getTwitterBackfill`, Pro-gated). For topic/keyword search, use [Content Search](#content-search). |
-| `unified_search`                          | Web search and URL scraping tools (X/Grok, Google, Brave, serper, decodo) |
+| `unified_search`                          | Web, social, finance search, and URL scraping tools (X/Grok, Perplexity Finance, Google, Brave, serper, decodo) |
 | `technical_indicator_calculation_helpers` | 50+ pure calculation helpers (RSI, MACD, Bollinger, etc.)                 |
 
 To discover available modules and their documentation:
@@ -497,12 +497,12 @@ external HTTP APIs within the runtime.
 
 #### Content Search
 
-Search across Twitter/X, news, Reddit, YouTube, podcasts, and general web.
+Search across Twitter/X, finance data, news, Reddit, YouTube, podcasts, and general web.
 Use whenever the playbook needs content beyond structured data SDKs — from
 targeted queries ("what are people saying about NVDA earnings") to broad
 discovery ("trending crypto discussions this week"), including social
-discussions, market narratives, news coverage, sentiment, analyst commentary,
-and community reactions.
+discussions, live finance quote/market-data lookup, market narratives, news
+coverage, sentiment, analyst commentary, and community reactions.
 
 Content search modules live in the `unified_search` runtime-library
 partition. Discover them via the same partition API as the other runtime

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -9,7 +9,7 @@ backfill its history), use the `feed_widgets` partition instead. The search SDKs
 | SDK | Module | Best for |
 | --- | ------ | -------- |
 | `searchGrokX` | `@arrays/data/search/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
-| `searchPerplexityFinance` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | Live finance search — quotes, market data, filings, and financial facts with sources |
+| `searchPerplexityFinance` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | Fallback live finance search for non-US equities and markets not covered well by structured Alva SDKs |
 | `searchSerper` | `@arrays/data/search/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
 | `searchBrave` | `@arrays/data/search/search-brave:v1.0.0` | Independent index, good Reddit coverage |
 | `scrapeUrl` | `@arrays/data/search/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
@@ -19,9 +19,10 @@ backfill its history), use the `feed_widgets` partition instead. The search SDKs
 ### Finance Search
 
 - **Search**: `searchPerplexityFinance` for live financial quotes, market data, company facts, filings, and sourced finance answers.
-- **Best fit**: use when the user asks for current price, valuation, financial facts, or market-data answers that benefit from sourced live lookup.
+- **Intended role**: fallback for non-US equity / international-market questions, or other finance facts where the structured Alva SDKs do not have enough coverage.
+- **Best fit**: use when the user asks for a current non-US stock quote, valuation, filing, corporate fact, or market-data answer that benefits from sourced live lookup.
 - **Fields**: `summary`, `data`/`arrays` result blocks, `tickers`, `sources`, and provider `usage` metadata when available.
-- **Gotcha**: This is a live search/answer tool, not a historical time-series endpoint. For deterministic OHLCV, fundamentals, earnings, or macro series, prefer the structured Alva data SDKs first and use finance search for current context or source-backed enrichment.
+- **Gotcha**: This is a live search/answer tool, not a historical time-series endpoint. For US equities, deterministic OHLCV, fundamentals, earnings, or macro series, prefer the structured Alva data SDKs first and use finance search only as a fallback for missing coverage, current context, or source-backed enrichment.
 
 ### Twitter/X
 

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -9,11 +9,19 @@ backfill its history), use the `feed_widgets` partition instead. The search SDKs
 | SDK | Module | Best for |
 | --- | ------ | -------- |
 | `searchGrokX` | `@arrays/data/search/search-grok-x:v1.0.0` | Twitter/X — returns engagement directly |
+| `searchPerplexityFinance` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | Live finance search — quotes, market data, filings, and financial facts with sources |
 | `searchSerper` | `@arrays/data/search/serper-search:v1.0.0` | Google index: News, YouTube, Reddit, Web |
 | `searchBrave` | `@arrays/data/search/search-brave:v1.0.0` | Independent index, good Reddit coverage |
 | `scrapeUrl` | `@arrays/data/search/scrape-url:v1.0.0` | Scrape any page to markdown for enrichment |
 
 ## Sources
+
+### Finance Search
+
+- **Search**: `searchPerplexityFinance` for live financial quotes, market data, company facts, filings, and sourced finance answers.
+- **Best fit**: use when the user asks for current price, valuation, financial facts, or market-data answers that benefit from sourced live lookup.
+- **Fields**: `summary`, `data`/`arrays` result blocks, `tickers`, `sources`, and provider `usage` metadata when available.
+- **Gotcha**: This is a live search/answer tool, not a historical time-series endpoint. For deterministic OHLCV, fundamentals, earnings, or macro series, prefer the structured Alva data SDKs first and use finance search for current context or source-backed enrichment.
 
 ### Twitter/X
 

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -587,7 +587,7 @@ type Match = {
 
 | Partition | When to use | Shape |
 |---|---|---|
-| `unified_search` | Topic-keyword and live finance search for this run — "find items about X right now" | `getSerperSearch({q, type, tbs})` / `searchGrokX({query, from_date})` / `searchPerplexityFinance({query})` / `searchBrave({...})` — one-shot queries |
+| `unified_search` | Topic-keyword search and fallback live finance search for non-US markets — "find items about X right now" | `getSerperSearch({q, type, tbs})` / `searchGrokX({query, from_date})` / `searchPerplexityFinance({query})` / `searchBrave({...})` — one-shot queries |
 | `feed_widgets` | Subscribed stream of a **specific handle, channel, subreddit, podcast, or YouTube/RSS-style feed** — "everything from @Acquired, even off-topic" | Declarative `targets[]` stream; results arrive as typed feed items over time |
 
 **AI Digest defaults to `unified_search`** because the user's
@@ -609,7 +609,7 @@ shown here may drift.
 | `news` | `@arrays/data/search/serper-search:v1.0.0` | `getSerperSearch({q, type: "news", tbs: "qdr:d", num})` |
 | `news` (alt) | `@arrays/data/search/search-brave:v1.0.0` | `searchBrave({q, freshness})` |
 | `social` | `@arrays/data/search/search-grok-x:v1.0.0` | `searchGrokX({query, from_date, to_date, max_search_results})` |
-| `finance_search` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | `searchPerplexityFinance({query})` |
+| `finance_search` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | `searchPerplexityFinance({query})` — fallback for non-US equities / international markets when structured SDK coverage is insufficient |
 | `market` | Alva Stock/Crypto SDKs (see `references/api/sdk.md`) | Emit a synthetic match only when the market signal itself is the event; otherwise use optional `context_facts` enrichment |
 | `feed` | Feed SDK upstream or direct ALFS read | Each upstream record becomes one match |
 | `rss` | Direct RSS/Atom URL via `net/http.fetch` | Parse `<item>` / `<entry>` into title, permalink, publish time, description. If parsing fails, fall back to `web` search for the source domain. |

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -582,7 +582,7 @@ type Match = {
 
 | Partition | When to use | Shape |
 |---|---|---|
-| `unified_search` | Topic-keyword search for this run — "find items about X right now" | `getSerperSearch({q, type, tbs})` / `searchGrokX({query, from_date})` / `searchBrave({...})` — one-shot queries |
+| `unified_search` | Topic-keyword and live finance search for this run — "find items about X right now" | `getSerperSearch({q, type, tbs})` / `searchGrokX({query, from_date})` / `searchPerplexityFinance({query})` / `searchBrave({...})` — one-shot queries |
 | `feed_widgets` | Subscribed stream of a **specific handle, channel, subreddit, podcast, or YouTube/RSS-style feed** — "everything from @Acquired, even off-topic" | Declarative `targets[]` stream; results arrive as typed feed items over time |
 
 **AI Digest defaults to `unified_search`** because the user's
@@ -604,6 +604,7 @@ shown here may drift.
 | `news` | `@arrays/data/search/serper-search:v1.0.0` | `getSerperSearch({q, type: "news", tbs: "qdr:d", num})` |
 | `news` (alt) | `@arrays/data/search/search-brave:v1.0.0` | `searchBrave({q, freshness})` |
 | `social` | `@arrays/data/search/search-grok-x:v1.0.0` | `searchGrokX({query, from_date, to_date, max_search_results})` |
+| `finance_search` | `@arrays/data/search/search-perplexity-finance:v1.0.0` | `searchPerplexityFinance({query})` |
 | `market` | Alva Stock/Crypto SDKs (see `references/api/sdk.md`) | Emit a synthetic match only when the market signal itself is the event; otherwise use optional `context_facts` enrichment |
 | `feed` | Feed SDK upstream or direct ALFS read | Each upstream record becomes one match |
 | `rss` | Direct RSS/Atom URL via `net/http.fetch` | Parse `<item>` / `<entry>` into title, permalink, publish time, description. If parsing fails, fall back to `web` search for the source domain. |


### PR DESCRIPTION
## Summary
- add `searchPerplexityFinance` to the Alva content-search reference
- clarify that this module is a **fallback for non-US equity / international-market data lookups** when structured Alva SDK coverage is insufficient
- keep structured Alva SDKs as the preferred path for US equities, deterministic OHLCV, fundamentals, earnings, and macro time series
- update the AI Digest template module reference so agents can choose the finance-search fallback intentionally

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
Can merge after sdkhub PR #504. Runtime availability still requires alva-backend and jagent dependency bumps to deploy.

## Related PRs
- https://github.com/alva-ai/sdkhub/pull/504

## Test Plan
- `git diff --check`
