### PR TITLE
[codex] Clarify feed push notification semantics

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -548,44 +548,23 @@ This rule covers any feed that computes equity curves, drawdown, Sharpe,
 returns, position tracking, or rebalancing — not only feeds that emit
 `signal/targets`. It also applies to ALL feed types that produce signal
 output — monitoring feeds, alert feeds, notification feeds, and backtest
-strategies alike. If the feed pushes signals to Telegram or triggers alerts,
-it MUST use `FeedAltra`.
+strategies alike. If the feed produces `signal/targets`, it MUST use
+`FeedAltra`.
 
-**Push notifications for followers:** Feeds can produce actionable,
-subscription-worthy signals that get pushed to playbook followers via Telegram.
-To make a feed push-capable:
+**Push notification streams:** Subscriptions target feed/playbook resources,
+not output paths. The output path only chooses the notification event:
 
-1. Add a `signal/targets` output to the feed script (see
-   [feed-sdk.md](references/feed-sdk.md) Pattern D) and write signal records
-   using the Altra target format (`{date, instruction, meta}`), where
-   `meta.reason` is the human-readable message followers will see.
-2. Set `--push-notify` in the `alva deploy create` command, or
-   update the existing cronjob with `alva deploy update --id ID --push-notify`.
+| Output stream | Event | Use for | Recipients |
+| --- | --- | --- | --- |
+| `signal/targets` | `playbook_data_ready` | Playbook/follower signals | Playbook followers and groups subscribed to the playbook |
+| `notify/message` | `feed_run_complete` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts | Feed owner and groups subscribed to the feed |
 
-The platform reads `/data/signal/targets` after each successful
-execution and pushes the signal content to all eligible followers.
+Rules:
 
-**AlvaAsk + owner notifications:** Feeds can use `@alva/alvaask` to call
-Alva's agent and push the result to the feed owner — useful for scheduled
-reports, heartbeat monitoring, and proactive alerts. Write to
-`notify/message` (see [feed-sdk.md](references/feed-sdk.md) Pattern E):
-
-```javascript
-const result = ask("Brief crypto market update with key levels.");
-await ctx.self.ts("notify", "message").append([{
-  date: Date.now(),
-  title: "Daily Briefing",
-  text: result.text,
-}]);
-```
-
-The platform reads `/data/notify/message/@last/1` and pushes `title` + `text`
-to the owner on all connected channels (Telegram, Discord, Web). No playbook
-or followers required.
-
-**Two-step deploy is mandatory for Pattern E.** `--push-notify` alone is not
-enough; without `alva release feed` the platform fires the push but the body
-arrives empty. Always pair them:
+- Do not require `signal/targets` for feed group delivery. A group subscribed
+  to a feed can receive `feed_run_complete` from `notify/message`.
+- A push-capable feed needs `--push-notify` and a feed release bound to the
+  cronjob:
 
 ```bash
 alva deploy create --name <feed> --path '~/feeds/<feed>/v1/src/index.js' \
@@ -594,11 +573,8 @@ alva release feed --name <feed> --version 1.0.0 \
   --cronjob-id <ID_FROM_DEPLOY> --description "<one-sentence purpose>"
 ```
 
-Pattern D (followers, `signal/targets`) needs only `--push-notify`, but it
-also needs at least one playbook follower — a subscribed playbook with no
-followers pushes to nobody.
-
-See **Step 9** below for the full post-release subscription flow.
+Keep schema examples in [feed-sdk.md](references/feed-sdk.md) Patterns D/E.
+See **Step 9** below for the post-release subscription flow.
 
 ### 6. Build the Playbook Web App
 
@@ -749,8 +725,9 @@ Present a concrete recommendation, not a generic "want push?":
 - **User says no** → accept and move on. Do not ask again.
 - **User requests push for a different feed** → honor their choice.
 
-If the feed already has `signal/targets` and `push_notify: true`, skip — it's
-already configured.
+If the feed already has the right push sidecar for the intended event
+(`signal/targets` for playbook signals, `notify/message` for feed completion)
+and `push_notify: true`, skip — it's already configured.
 
 #### Configure and verify
 
@@ -758,13 +735,13 @@ A push is "set up" only after every step below succeeds. Stopping early is
 the most common cause of "configured but nothing arrives" — do not skip
 verification.
 
-1. **Add `signal/targets` output to the feed script** (see
-   [feed-sdk.md](references/feed-sdk.md) Pattern D). `meta.reason` is the
-   text followers receive.
+1. **Add the intended push sidecar** to the feed script:
+   `signal/targets` for playbook signals (Pattern D), or `notify/message` for
+   feed completion / AlvaAsk reports (Pattern E).
 2. **Enable the flag on the cronjob:** `alva deploy update --id <ID> --push-notify`.
 3. **Verify a real run produced push content:** trigger a run (or wait for
-   the next cron fire) and read `@last/1` of `signal/targets`. Confirm the
-   record is fresh and `meta.reason` is non-empty.
+   the next cron fire) and read `@last/1` of the configured sidecar. Confirm
+   the record is fresh and the message body is non-empty.
 4. **Confirm to the user** with the specifics: which feed, what the next
    push will say, when it will fire.
 

--- a/skills/alva/references/api/deploy-cronjob.md
+++ b/skills/alva/references/api/deploy-cronjob.md
@@ -26,10 +26,12 @@ alva deploy create \
 | --path        | string | yes      | Path to entry script (home-relative or absolute)                              |
 | --cron        | string | yes      | Standard cron expression (min interval: 1 minute)                             |
 | --args        | JSON   | no       | JSON passed to `require("env").args` on each execution                        |
-| --push-notify | flag   | no       | Enable push notifications for playbook followers                              |
+| --push-notify | flag   | no       | Enable push fanout after successful feed runs                                 |
 
-When `--push-notify` is set, every successful execution reads the feed's
-`/data/signal/targets/@last/1` and pushes it to playbook followers (Telegram).
+When `--push-notify` is set, every successful execution checks the feed's push
+sidecars: `signal/targets` dispatches `playbook_data_ready`, while
+`notify/message` dispatches `feed_run_complete` to the owner and groups
+subscribed to that feed.
 
 Response:
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -39,12 +39,12 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 | --cron          | string | yes      | Standard cron expression                               |
 | --name          | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
 | --args          | JSON   | no       | JSON passed to `require("env").args` on each execution |
-| --push-notify   | flag   | no       | Enable push notifications for playbook followers       |
+| --push-notify   | flag   | no       | Enable push fanout after successful feed runs          |
 
 When `--push-notify` is set, every successful cronjob execution triggers a
-notification fan-out: the platform reads the feed's
-`/data/signal/targets/@last/1`, and pushes the signal content to all playbook
-followers who have enabled Telegram notifications.
+notification fanout. `signal/targets` dispatches `playbook_data_ready`;
+`notify/message` dispatches `feed_run_complete` to the owner and any groups
+subscribed to that feed.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -162,13 +162,13 @@ await feed.run(async (ctx) => {
 
 Read `@last/N` (where N >= batch size) to get the most recent batch.
 
-### Pattern D: Signal / Push Notification
+### Pattern D: Signal / Playbook Push Notification
 
-For feeds that produce actionable signals worth pushing to playbook followers.
-Write signal records to the **`signal`** group with a **`targets`** output --
-the resulting path `~/feeds/{name}/v{major}/data/signal/targets` is the
-convention the platform reads when notifying followers via Telegram (or other
-push channels).
+For feeds that produce actionable signals worth pushing to playbook followers
+or groups subscribed to a playbook. Write signal records to the **`signal`**
+group with a **`targets`** output -- the resulting path
+`~/feeds/{name}/v{major}/data/signal/targets` is the convention the platform
+reads when dispatching the `playbook_data_ready` notification event.
 
 The target format follows the same structure used by Altra trading strategies:
 
@@ -178,7 +178,7 @@ const { Feed, feedPath, makeDoc, str, num, obj, arr, fld } = require("@alva/feed
 const feed = new Feed({ path: feedPath("my-signal") });
 
 feed.def("signal", {
-  targets: makeDoc("Signal Targets", "Actionable signals for followers", [
+  targets: makeDoc("Signal Targets", "Actionable signals for playbook notifications", [
     obj("instruction", [
       str("type"),       // "allocate" | "orders"
       arr("weights", [   // for type: "allocate"
@@ -217,32 +217,34 @@ await feed.run(async (ctx) => {
 ```
 
 When this feed runs as a cronjob, the platform reads
-`/data/signal/targets` and pushes the signal content (truncated to
-500 chars) to all playbook followers who have enabled Telegram notifications.
+`/data/signal/targets` and dispatches the signal content (truncated to
+500 chars) as `playbook_data_ready` to eligible playbook notification targets.
 
 **Key points:**
 
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
 - Use `meta.reason` to provide a human-readable message -- this is what
-  followers see in their push notification.
+  recipients see in their push notification.
 - One record per run is typical; the platform reads `@last/1`.
 - Altra strategies write to this path automatically. Use this pattern only for
   non-Altra feeds that want to produce push-worthy signals.
 
-### Pattern E: AlvaAsk + Owner Notification (notify/message)
+### Pattern E: AlvaAsk + Feed Notification (notify/message)
 
 **Preferred pattern for scheduled tasks.** Use `@alva/alvaask` instead of
 ADK for cronjob feeds — it's simpler (no sandbox/session management) and
 the `ask()` call handles tool use, web search, and ALFS access automatically.
 
-For feeds that use `@alva/alvaask` to call Alva's agent and push the result
-to the feed owner. Common use cases: scheduled market reports, periodic
-research summaries, heartbeat monitoring, and proactive alerts.
+For feeds that use `@alva/alvaask` to call Alva's agent and publish the result
+as a feed completion notification. Common use cases: scheduled market reports,
+periodic research summaries, heartbeat monitoring, and proactive alerts.
 
 Write the agent's response to the **`notify`** group with a **`message`**
-output. When the cronjob completes, the platform reads this path and pushes
-the content to the owner on all connected channels (Telegram, Discord, Web).
+output. When the cronjob completes, the platform reads this path and dispatches
+`feed_run_complete` to the feed owner via Web and any active IM channel, and
+to groups subscribed to this feed with
+`/alva subscribe feed <feed_id>`.
 
 ```javascript
 const { ask } = require("@alva/alvaask");
@@ -295,8 +297,10 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - `text` is the notification body (required for content push).
 - **`alva release feed` is required** — without it, push notifications
   will not be delivered.
-- Does **not** require a playbook or followers — works for any feed.
-- Combine with Pattern D if you want to push to both owner AND followers.
+- Does **not** require a playbook or followers for owner delivery — works for
+  any feed. Group delivery requires the group to subscribe to that feed.
+- Combine with Pattern D if you want both feed completion notifications and
+  playbook/follower signal notifications.
 
 ### Deduplication
 

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -5,8 +5,10 @@ surface is an **AI-generated push digest**, not a dashboard. User can provide
 either a rough topic or a full source plan; the agent researches the topic,
 drafts a `CONFIG`, selects the smallest useful set of Alva search/feed/data inputs,
 runs on cron, generates an opinionated grounded take via `@alva/alvaask`, and
-pushes it to Telegram (via `signal/targets` for followers, or
-`notify/message` for the owner). The HTML playbook is a **light feed-stream
+pushes it through Alva notifications (via `signal/targets` for
+playbook/follower signals, or `notify/message` for feed completion
+notifications to the owner and feed-subscribed groups). The HTML playbook is a
+**light feed-stream
 replay** of past pushes — not an analytical dashboard.
 
 > **Highest-priority standard — strictly follow. Template iterates; always
@@ -127,7 +129,7 @@ that materially affect the feed:
 | Topic boundary | What should this track, and what should it exclude? | Prevents broad keyword slop. |
 | Sources | Optional but useful: paste sources you already trust — RSS feeds, newsletters, podcasts, YouTube channels, websites, X handles, subreddits, upstream Alva feeds, or plain text source names. If skipped, the agent researches a source plan first. | Makes the digest match the user's actual information diet, and chooses `unified_search` vs `feed_widgets` and adapters. |
 | Cadence / trigger | How often should it summarize or check? For thresholds, what exact condition matters? | Sets cron and materiality. |
-| Audience | Followers or owner only? | Chooses `signal/targets` vs `notify/message`. |
+| Audience | Playbook signal or feed notification? | Chooses `signal/targets` for playbook/follower signals or `notify/message` for owner plus feed-subscribed groups. |
 | Angle | What kind of take should the update have? | Drives the generation prompt and voice. |
 | Worth-pushing bar | What counts as material enough to notify? | Reduces noisy pushes. |
 
@@ -198,8 +200,8 @@ Default assumptions for the skip path:
   `mode: "watch"` with a tighter cron. Do not ask the user to choose a mode.
 - `quiet_day_policy`: `"ping"` for paid/subscriber-facing briefs where silence
   is confusing; `"skip"` for noisy topics where no-news days should stay quiet.
-- `audience`: `"followers"` for released playbooks; `"owner"` for private
-  prototypes or platform environments where follower push is not available.
+- `audience`: `"followers"` for playbook/follower signals; `"owner"` for
+  feed completion notifications using `notify/message`.
 - `angle`: opinionated, but no buy/sell/hold calls, no price targets, no
   uncited numerical claims.
 
@@ -272,7 +274,7 @@ const CONFIG = {
     quiet_day_policy: "ping",        // "ping" (default) | "skip"
   },
 
-  audience: "followers",             // "followers" (signal/targets) | "owner" (notify/message)
+  audience: "followers",             // "followers" = signal/targets; "owner" = notify/message to owner + feed-subscribed groups
 
   push_policy: {
     materiality: `Push when there is a fresh supply-chain disruption,
@@ -481,7 +483,7 @@ Retro analysis of quiet periods needs a record. The HTML timeline can show
 skipped fires dimmed-and-collapsed for author-facing transparency. **Append
 always; let `delivery.pushed` drive rendering.**
 
-### `signal/targets` (followers) — Altra format
+### `signal/targets` (playbook/follower signals) — Altra format
 
 When `audience: "followers"`, also append one record to `signal/targets` per
 pushed fire. Format follows Altra's target schema (see `references/feed-sdk.md`
@@ -513,10 +515,12 @@ await ctx.self.ts("signal", "targets").append([{
 > switch `audience` to `"owner"` and write to `notify/message` (Pattern E)
 > — that path is never FeedAltra-gated.
 
-### `notify/message` (owner) — title + text
+### `notify/message` (feed completion notification) — title + text
 
 When `audience: "owner"`, write to `notify/message` instead. No FeedAltra
-requirement; plain `Feed` suffices.
+requirement; plain `Feed` suffices. Despite the historical `owner` label in
+this template, `notify/message` dispatches `feed_run_complete`: the feed owner
+receives it directly, and groups subscribed to the feed can receive it too.
 
 ```javascript
 const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
@@ -750,7 +754,7 @@ Use verbatim; only the slots vary. Run with `model: CONFIG.generation_model`
 
 ```text
 You are writing today's update for the "<<TOPIC_NAME>>" AI Digest playbook.
-Output feeds a Telegram push and an HTML timeline card.
+Output feeds a push notification and an HTML timeline card.
 
 TOPIC
   <<TOPIC_DESCRIPTION>>
@@ -879,14 +883,14 @@ empty fallback event and do not push partial prose.
 ### `composePushPayload(event, playbookUrl)`
 
 The push body is derived deterministically from the event record — one
-`ask()` per fire, one payload shape. Keep Telegram copy compact but not
+`ask()` per fire, one payload shape. Keep notification copy compact but not
 headline-only: treat it as the playbook page TLDR. Preserve the core point,
 key numbers, and why-it-matters sentence from the playbook body. Prefer natural
 prose for short/medium bodies, switch to concise bullet points only when the
 body is already list-shaped or long and data-dense. Bullet count is not fixed;
 fit as many meaningful short points as the remaining budget allows, then always
-reserve room for the playbook link. Do **not** list sources in the Telegram
-push; citations and full source rows live in the playbook. The hard budget is
+reserve room for the playbook link. Do **not** list sources in the push;
+citations and full source rows live in the playbook. The hard budget is
 500 chars because `/data/signal/targets` truncates at 500.
 
 ```javascript
@@ -1028,7 +1032,8 @@ function composePushPayload(event, playbookUrl) {
 
 For `audience: "followers"` the output is the `meta.reason` of a
 `signal/targets` record (§6). For `audience: "owner"` it's the `text` of a
-`notify/message` record with `title = "${CONFIG.topic.name} · <date EST>"`.
+`notify/message` record with `title = "${CONFIG.topic.name} · <date EST>"`;
+that feed event can also fan out to groups subscribed to the feed.
 
 ### When to skip pushing
 
@@ -1046,20 +1051,20 @@ for retro. Don't silently drop them.
 ### Deploy + release command
 
 ```bash
-# Create the cron job. Same command for followers and owner-only digests;
+# Create the cron job. Same command for playbook signals and feed notifications;
 # CONFIG.audience controls whether the feed writes signal/targets or notify/message.
 alva deploy create --name <playbook-name> \
   --path '~/feeds/<name>/v1/src/index.js' \
   --cron "<CONFIG.cadence.cron>" --push-notify
 
-# Release the feed. Required for follower pushes and normal published playback.
+# Release the feed. Required for push fanout content and normal published playback.
 alva release feed --name <playbook-name> --version 1.0.0 \
   --cronjob-id <ID_FROM_DEPLOY> \
   --description "<one-sentence playbook purpose>"
 ```
 
 See `references/feed-sdk.md` Patterns D and E for the full release flow;
-for followers, the release step is mandatory or pushes arrive empty.
+the release step is mandatory or pushes arrive empty.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that feed/playbook subscriptions are resource-level, while `signal/targets` and `notify/message` choose notification event semantics
- document that `notify/message` dispatches `feed_run_complete` to the owner and feed-subscribed groups
- update deploy docs and the AI Digest template to avoid the old owner-vs-followers framing

## Tests
- `git diff --check`
