### PR TITLE
docs(alva): require --readme-url on alva release playbook

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -626,10 +626,19 @@ outputs read at runtime (no inline literals for data).
    The CLI handles authentication automatically. See
    [screenshot.md](references/api/screenshot.md) for full parameter details.
 
-When calling `alva release playbook`, always pass
-`--readme-url '{name}/README.md'` (the relative form). The server validates
-this against the README path you wrote in step 2 and rejects any other
-value with `InvalidArgument`. See
+`alva release playbook` **requires** `--readme-url`. The flow is: first
+write the README to ALFS at `~/playbooks/{name}/README.md`, then pass
+that **same path** as `--readme-url` (quote it in the shell to prevent
+local `~` expansion):
+
+```bash
+alva fs write --path '~/playbooks/{name}/README.md' --file ./README.md --mkdir-parents
+alva release playbook ... --readme-url '~/playbooks/{name}/README.md'
+```
+
+Omitting the flag fails CLI argument parsing; passing any value other
+than the canonical README path fails server validation with
+`InvalidArgument`. See
 [release.md](references/api/release.md#playbook-readme) for the absolute
 form, full validation rules, and the canonical content shape.
 
@@ -689,8 +698,8 @@ Before calling `alva release playbook`, verify all of the following:
    [Playbook README in release.md](references/api/release.md#playbook-readme)).
    Its source / cadence claims match the actual feed scripts and deployed
    cronjobs. The `--readme-url` flag must be passed on `alva release playbook`
-   and must match this exact path (relative form `{name}/README.md` is
-   preferred).
+   and must match this exact path — preferred form is the relative ALFS
+   shorthand `~/playbooks/{name}/README.md` (quote it in the shell).
 
 ### 8. Remix (Create from Existing Playbook)
 
@@ -1032,7 +1041,8 @@ verify these prerequisites:
 4. **README check** (playbook only) — confirm `~/playbooks/{name}/README.md`
    exists in ALFS and follows the
    [Playbook README content shape](references/api/release.md#playbook-readme).
-   The publish call must pass `--readme-url '{name}/README.md'`.
+   The publish call must pass `--readme-url '~/playbooks/{name}/README.md'`
+   (quoted to prevent local `~` expansion).
 
 If the build was interrupted and resumed, re-run this checklist from the top.
 Do not assume prior steps completed successfully.
@@ -1402,8 +1412,12 @@ alva release feed --name btc-ema --version 1.0.0 --cronjob-id 42 \
 alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashboard" --description "BTC market dashboard" --feeds '[{"feed_id":100}]' --trading-symbols '["BTC"]'
 # → {"playbook_id":99,"playbook_version_id":200}
 
-# 3. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically)
-alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id":100}]' --changelog "Initial release"
+# 3. Write playbook README to ALFS (required before release).
+alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
+
+# 4. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically).
+#    --readme-url is required and must match the README path written above.
+alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id":100}]' --changelog "Initial release" --readme-url '~/playbooks/btc-dashboard/README.md'
 # → {"playbook_id":99,"version":"v1.0.0","published_url":"https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html"}
 
 # After release, output the canonical share link to the user:

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -76,7 +76,7 @@ alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashb
 ## Release Playbook
 
 ```
-alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text" --readme-url "NAME/README.md"
+alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text" --readme-url '~/playbooks/NAME/README.md'
 ```
 
 Release an existing playbook for public hosting. Reads the playbook HTML from
@@ -84,8 +84,9 @@ Release an existing playbook for public hosting. Reads the playbook HTML from
 
 Changelog lives on the release, not the draft — set it when publishing.
 
-`--readme-url` is required: it declares the ALFS location of the playbook's
-README and the server validates the value against a fixed convention (see
+`--readme-url` is a **required CLI flag**: the command fails argument
+parsing if it is missing. It declares the ALFS location of the playbook's
+README, and the server validates the value against a fixed convention (see
 [Playbook README](#playbook-readme) below). Write the README to that path
 **before** calling this command.
 
@@ -108,8 +109,8 @@ Feed reference fields:
 # 1. Write README to ALFS first (see Playbook README below for content shape).
 alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
 
-# 2. Then release, declaring the README location.
-alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release" --readme-url "btc-dashboard/README.md"
+# 2. Then release, passing the same ALFS path you wrote to as --readme-url.
+alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release" --readme-url '~/playbooks/btc-dashboard/README.md'
 → {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html", "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
 
@@ -126,13 +127,20 @@ copy.
 
 ### Path and `--readme-url` forms
 
-The owner writes the README to ALFS before publish; the server does not
-write the file. The server only accepts two forms for `--readme-url`:
+The flow is: **first** write the README to ALFS, **then** pass that same
+ALFS path verbatim as `--readme-url`. The server does not write the file —
+it only validates that the value matches the canonical README location.
 
-1. **Relative** (preferred): `<name>/README.md` — e.g. `btc-dashboard/README.md`.
+The server accepts two forms for `--readme-url`:
+
+1. **Relative** (preferred): `~/playbooks/<name>/README.md` — e.g.
+   `~/playbooks/btc-dashboard/README.md`. This matches the same `~/playbooks/...`
+   shorthand used by `alva fs write`, so the publish call mirrors the path
+   you wrote to. Quote it in the shell (`'~/playbooks/<name>/README.md'`)
+   to prevent local `~` expansion.
 2. **Absolute**: `/alva/home/<username>/playbooks/<name>/README.md` — e.g.
    `/alva/home/alice/playbooks/btc-dashboard/README.md`. Use this only
-   when hard-coding the username is unavoidable.
+   when hard-coding the username is unavoidable (e.g. cross-user references).
 
 Both forms point to the same ALFS path. Any other value is rejected with
 `InvalidArgument`.

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -148,7 +148,7 @@ and only then upload them. Do not write fresh files from scratch.
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
 8. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
-9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url "{new-name}/README.md"`
+9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '~/playbooks/{new-name}/README.md'` (same ALFS path you wrote to in step 7; quote it to prevent local `~` expansion)
 
 **Important**: The new playbook must use a unique name in your user space. The
 feed scripts must use **your own** ALFS paths (not the original owner's) for


### PR DESCRIPTION
## Summary
- Track toolkit-ts PR #47, which makes `--readme-url` a required CLI flag on `alva release playbook`.
- Standardize the preferred value on the relative `~/playbooks/{name}/README.md` shorthand (matching the path passed to `alva fs write`); the absolute `/alva/home/<username>/...` form stays available for cross-user references.
- Add the README write step to the deployment quick-reference example so the canonical flow is end-to-end visible.

## Test plan
- [ ] Confirm the documented `alva release playbook ... --readme-url '~/playbooks/{name}/README.md'` invocation succeeds against toolkit-ts ≥ PR #47.
- [ ] Confirm omitting `--readme-url` now fails CLI argument parsing.
- [ ] Spot-check `references/api/release.md`, `references/remix-workflow.md`, and the deployment example in `SKILL.md` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)