### PR TITLE
[codex] Align AI Digest push copy with feed body

### DIFF
--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -217,8 +217,10 @@ await feed.run(async (ctx) => {
 ```
 
 When this feed runs as a cronjob, the platform reads
-`/data/signal/targets` and dispatches the signal content (truncated to
-500 chars) as `playbook_data_ready` to eligible playbook notification targets.
+`/data/signal/targets` and dispatches the signal content as
+`playbook_data_ready` to eligible playbook notification targets. Telegram
+delivery chunks long messages at the platform's per-message limit; the feed SDK
+does not require a 500-character summary.
 
 **Key points:**
 
@@ -226,6 +228,9 @@ When this feed runs as a cronjob, the platform reads
   `targets` -- this is the path the notification system looks for.
 - Use `meta.reason` to provide a human-readable message -- this is what
   recipients see in their push notification.
+- Keep `meta.reason` close to the user-facing feed output when the feed is
+  notification-native. Use a push-safe projection only when a channel has a
+  real hard limit or cannot render the feed's richer format.
 - One record per run is typical; the platform reads `@last/1`.
 - Altra strategies write to this path automatically. Use this pattern only for
   non-Altra feeds that want to produce push-worthy signals.

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -88,9 +88,8 @@ Read in this order:
 
 ## 1. When to use this template
 
-Use AI Digest when the playbook's main job is to **push a concise,
-grounded update** about a topic, fixed stream, upstream feed, or deterministic
-threshold.
+Use AI Digest when the playbook's main job is to **push a grounded digest**
+about a topic, fixed stream, upstream feed, or deterministic threshold.
 
 Good fits:
 
@@ -288,7 +287,7 @@ const CONFIG = {
           Opinionated — tell the reader what to watch next, not just what
           happened. Every number must cite its source.`,
 
-  body_max_chars: 1200,              // rendered body budget; push_line capped separately at 160
+  body_max_chars: 1200,              // canonical digest body budget; push reuses this body
 
   // Full Alva model IDs — not short names, not dated Anthropic IDs.
   generation_model: "claude-sonnet-4-6",
@@ -453,9 +452,10 @@ remixers all agree on what an AI Digest event looks like.
 
 `digest/events` is the **source of truth** for the HTML timeline.
 `signal/targets` / `notify/message` are delivery sidecars — they hold the
-push payload the platform broadcasts, not the rendered body. One LLM
-generation per fire; the event record stores the canonical body, and the
-delivery sidecar gets a lean projection of it.
+push payload the platform broadcasts, derived from the same canonical event
+body. One LLM generation per fire; the event record stores the canonical body,
+and the delivery sidecar should stay as close to that body as the channel
+allows.
 
 All three are Feed SDK time-series
 (`ctx.self.ts("digest", "events").append(...)`). Do **not** use
@@ -468,7 +468,7 @@ All three are Feed SDK time-series
 | `date` | number (ms) | Cron-fire timestamp. Append it on every record; Feed SDK time-series may treat it as the built-in timestamp field rather than a declared schema field. |
 | `delivery` | `{pushed: bool, reason: string}` | `pushed=false` carries a short `reason` (`quiet_day_skipped`, `no_matches`, `all_deduped`, `not_material`, `rate_limited` — freeform, kept short) |
 | `materiality` | `{is_material: bool, reason: string}` | Deterministic pre-generation decision derived from `CONFIG.push_policy`, matches, and optional context facts |
-| `push_line` | string | ≤ 160 chars plain text. |
+| `push_line` | string | ≤ 160 chars plain text. This is only the headline, not the whole push body. |
 | `body` | string | Markdown with inline `[N]` reference markers. |
 | `citations` | `[{ref, claim, url, source, source_ref}]` | One entry per `[N]` marker. `source_ref` is a match URL, `match.meta.event_key`, or, when using enrichment, `context_facts[].ref_id`. |
 | `matches` | `[{source, url, title, ts, snippet, meta}]` | All matches considered this fire (post-relevance, post-dedupe) |
@@ -487,9 +487,10 @@ always; let `delivery.pushed` drive rendering.**
 
 When `audience: "followers"`, also append one record to `signal/targets` per
 pushed fire. Format follows Altra's target schema (see `references/feed-sdk.md`
-Pattern D); the platform reads `meta.reason` as the push body and truncates it
-to 500 chars. Always pass the released playbook URL so the compact push can
-reserve the final link line:
+Pattern D); the platform reads `meta.reason` as the push body. Telegram delivery
+chunks long messages at the platform message limit, so do not impose an
+artificial 500-character cap in the template. Always pass the released playbook
+URL so the push can include the canonical replay link:
 
 ```javascript
 const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
@@ -497,7 +498,7 @@ const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index
 await ctx.self.ts("signal", "targets").append([{
   date: now,
   instruction: { type: "allocate", weights: [] },   // no-op — this is notify-only
-  meta: { reason: composePushPayload(event, PLAYBOOK_URL) }, // ≤ 500 chars; see §9
+  meta: { reason: composePushPayload(event, PLAYBOOK_URL) }, // mirrors event.body; see §9
 }]);
 ```
 
@@ -753,8 +754,9 @@ Use verbatim; only the slots vary. Run with `model: CONFIG.generation_model`
 (full Alva ID, e.g. `"claude-sonnet-4-6"`).
 
 ```text
-You are writing today's update for the "<<TOPIC_NAME>>" AI Digest playbook.
-Output feeds a push notification and an HTML timeline card.
+You are writing today's canonical update for the "<<TOPIC_NAME>>" AI Digest
+playbook. The same body powers the Playbook timeline card and the Telegram/Web
+push.
 
 TOPIC
   <<TOPIC_DESCRIPTION>>
@@ -771,6 +773,7 @@ RULES
   when explaining why it matters; do not invent calculation steps.
 - No buy/sell/hold recommendations; no price targets. Observation + framing.
 - push_line ≤ 160 chars, plain text (no markdown), leads with the observation.
+  It is the headline only; do not compress the whole digest into this field.
 - body ≤ <<BODY_MAX_CHARS>> chars, markdown allowed.
 - If MATERIALITY.is_material is false: write one short "nothing material"
   acknowledgement; only cite facts you actually mention.
@@ -883,152 +886,153 @@ empty fallback event and do not push partial prose.
 ### `composePushPayload(event, playbookUrl)`
 
 The push body is derived deterministically from the event record — one
-`ask()` per fire, one payload shape. Keep notification copy compact but not
-headline-only: treat it as the playbook page TLDR. Preserve the core point,
-key numbers, and why-it-matters sentence from the playbook body. Prefer natural
-prose for short/medium bodies, switch to concise bullet points only when the
-body is already list-shaped or long and data-dense. Bullet count is not fixed;
-fit as many meaningful short points as the remaining budget allows, then always
-reserve room for the playbook link. Do **not** list sources in the push;
-citations and full source rows live in the playbook. The hard budget is
-500 chars because `/data/signal/targets` truncates at 500.
+`ask()` per fire, one payload shape. **Default to consistency over compression:**
+the Telegram/Web copy should read like the Playbook feed card, not like a
+separate micro-summary. Keep the same sentence order, key numbers, and
+why-it-matters framing from `event.body`; append the Playbook link as the final
+line.
+
+Do **not** add a 500-character budget here. Current Telegram delivery chunks
+long messages at the platform's per-message limit, and Web uses the same audit
+body. The playbook URL is required; if it is missing, throw instead of sending
+a push with no product re-entry point.
+
+Do **not** list source rows in the Telegram push; citations and full source
+rows live in the Playbook. It is fine to strip inline `[N]` citation markers
+from the push copy while keeping the same claims.
+
+Use a push-safe projection only when the canonical body is genuinely hostile to
+IM/Web notification surfaces: very long output, tables, code fences, embedded
+HTML, images, modals/details, or source-panel material. This projection is not a
+tiny teaser. It should keep the core claims, important numbers, causality, and
+what-to-watch-next intact, using as many sentences or bullets as needed within a
+generous notification budget.
 
 ```javascript
 function composePushPayload(event, playbookUrl) {
-  const MAX_PUSH_CHARS = 500;
-  const HEADLINE_CHARS = 140;
-  const TLDR_BUDGET_CHARS = 330;
-  const SHORT_BODY_CHARS = 180;
-  const NATURAL_POINT_CHARS = 150;
-  const BULLET_THRESHOLD_CHARS = 330;
-  const MAX_BULLETS = 5;
-  const MIN_BULLET_LINE_CHARS = 48;
-  const BULLET_CHARS = 105;
-  const linkLine = `Full update → ${playbookUrl}`;
+  if (!playbookUrl) throw new Error("composePushPayload requires playbookUrl");
+  const full = composeFullPushPayload(event, playbookUrl);
+  return needsPushSafeProjection(event, full)
+    ? composePushSafeProjection(event, playbookUrl)
+    : full;
+}
 
-  const stripMarkdown = (s) => String(s || "")
+function composeFullPushPayload(event, playbookUrl) {
+  const linkLine = playbookUrl ? `Full update -> ${playbookUrl}` : "";
+  const cleanForPush = (s) => String(s || "")
+    .replace(/\[[0-9]+\]/g, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/;/g, ",") // generic signal renderer treats semicolons as bullet separators
+    .replace(/\s+([.,!?;:。！？])/g, "$1")
+    .trim();
+
+  const headline = cleanForPush(event.push_line);
+  const body = cleanForPush(event.body);
+  const parts = [];
+
+  if (headline && !body.toLowerCase().startsWith(headline.toLowerCase())) {
+    parts.push(headline);
+  }
+  if (body) parts.push(body);
+  parts.push(linkLine);
+
+  return parts.filter(Boolean).join("\n\n");
+}
+
+function needsPushSafeProjection(event, fullPayload) {
+  const body = String(event.body || "");
+  const lineCount = body.split("\n").filter(line => line.trim()).length;
+  const complex = [
+    /```/,
+    /^\s*\|.+\|\s*$/m,
+    /!\[[^\]]*\]\(/,
+    /<\s*(details|summary|table|thead|tbody|tr|td|th|iframe|canvas|svg|img|script|style|div)\b/i,
+    /(^|\n)#+\s*(sources?|citations?|methodology)\b/i,
+  ].some(re => re.test(body));
+
+  return fullPayload.length > 3200 || lineCount > 28 || complex;
+}
+
+function composePushSafeProjection(event, playbookUrl) {
+  const linkLine = `Full update -> ${playbookUrl}`;
+  const headline = cleanText(event.push_line);
+  const body = stripPushHostileBlocks(event.body);
+  const points = extractMeaningfulPoints(body);
+  const summary = fitMeaningfulPoints(points, 2400 - linkLine.length - headline.length);
+
+  return [
+    headline,
+    summary,
+    linkLine,
+  ].filter(Boolean).join("\n\n");
+}
+
+function stripPushHostileBlocks(body) {
+  return String(body || "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<details[\s\S]*?<\/details>/gi, "")
+    .replace(/<table[\s\S]*?<\/table>/gi, "")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
+    .replace(/^\s*\|.+\|\s*$/gm, "")
+    .replace(/\[[0-9]+\]/g, "")
+    .replace(/;/g, ",")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function cleanText(s) {
+  return String(s || "")
     .replace(/\[[0-9]+\]/g, "")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .replace(/[`*_>#]/g, "")
+    .replace(/;/g, ",")
     .replace(/\s+/g, " ")
     .replace(/\s+([.,!?;:。！？])/g, "$1")
     .trim();
-  const tidyTruncation = (s) => String(s || "")
-    .replace(/\s+\b(?:but|and|or|because|while|with|without|that|which|as|to|of|by|for|the|is|are)\s*…$/i, "…")
-    .replace(/[,;:]\s*…$/, "…");
-  const trimPoint = (s, limit) => {
-    const clean = stripMarkdown(s);
-    return clean.length > limit
-      ? tidyTruncation(clean.slice(0, limit).replace(/\s+\S*$/, "") + "…")
-      : clean;
-  };
-  const trimBlock = (s, limit) => {
-    const clean = String(s || "").trim();
-    return clean.length > limit
-      ? tidyTruncation(clean.slice(0, limit).replace(/\s+\S*$/, "") + "…")
-      : clean;
-  };
-  const fitSummary = (summary, limit) => {
-    const clean = String(summary || "").trim();
-    if (!clean || clean.length <= limit) return clean;
-    if (!clean.includes("\n• ")) return trimBlock(clean, limit);
+}
 
-    const fitted = [];
-    let used = 0;
-    for (const line of clean.split("\n")) {
-      const separator = fitted.length ? 1 : 0;
-      const available = limit - used - separator;
-      if (available <= 0) break;
-      if (line.length <= available) {
-        fitted.push(line);
-        used += separator + line.length;
-      } else if (fitted.length < 2 && available >= 48) {
-        fitted.push(trimBlock(line, available));
-        break;
-      } else {
-        break;
-      }
-    }
-    return fitted.join("\n");
-  };
-  const sentencePoints = (body) => stripMarkdown(body)
-    .split(/(?<=[.!?。！？])\s*/)
+function extractMeaningfulPoints(body) {
+  const lines = String(body || "").split("\n").map(line => line.trim()).filter(Boolean);
+  const bullets = lines
+    .filter(line => /^[-*•]\s+/.test(line))
+    .map(line => cleanText(line.replace(/^[-*•]\s+/, "")));
+  if (bullets.length >= 2) return bullets;
+
+  return cleanText(body)
+    .split(/(?<=[.!?。！？])\s+/)
     .map(s => s.trim())
     .filter(Boolean);
-  const bulletPoints = (body) => String(body || "")
-    .split("\n")
-    .map(s => s.trim())
-    .filter(s => /^[-*•]\s+/.test(s))
-    .map(s => s.replace(/^[-*•]\s+/, ""));
-  const hasData = (s) => /[$€¥%]|\d|bps?\b|x\b|million|billion|trillion/i.test(s);
-  const hasImpact = (s) =>
-    /\b(guidance|margin|revenue|capex|inventory|orders?|shipments?|lead time|pricing|demand|supply|backlog|export|risk|watch|implies|means|matters|beat|miss|raise|cut)\b/i.test(s);
-  const selectKeyPoints = (points, maxPoints = MAX_BULLETS) => {
-    const cleaned = points.map(stripMarkdown).filter(Boolean);
-    if (cleaned.length <= maxPoints) return cleaned;
-    const selected = new Set([0]);
-    const ranked = cleaned.slice(1).map((text, offset) => {
-      const index = offset + 1;
-      const score = (hasData(text) ? 3 : 0) + (hasImpact(text) ? 2 : 0) + (text.length <= 220 ? 1 : 0);
-      return { index, score };
-    }).sort((a, b) => b.score - a.score || a.index - b.index);
-    for (const item of ranked) {
-      if (selected.size >= maxPoints) break;
-      selected.add(item.index);
-    }
-    return [...selected].sort((a, b) => a - b).map(index => cleaned[index]);
-  };
-  const bulletSummary = (points, budget) => {
-    const selected = selectKeyPoints(points, MAX_BULLETS);
-    const lines = [];
-    let used = 0;
-    for (const point of selected) {
-      const separator = lines.length ? 1 : 0;
-      const available = budget - used - separator;
-      if (available < MIN_BULLET_LINE_CHARS) break;
-      const lineLimit = Math.min(BULLET_CHARS, available - 2);
-      const line = `• ${trimPoint(point, lineLimit)}`;
-      if (line.length > available) break;
-      lines.push(line);
-      used += separator + line.length;
-    }
-    return lines.length >= 2 ? lines.join("\n") : trimPoint(selected[0] || "", budget);
-  };
+}
 
-  function summarizeTldr(body, budget) {
-    const compact = stripMarkdown(body);
-    if (!compact) return "";
-    const bullets = bulletPoints(body);
-    const points = bullets.length >= 2 ? bullets : sentencePoints(body);
-    const shouldUseBullets = bullets.length >= 2
-      || (compact.length >= BULLET_THRESHOLD_CHARS && points.length >= 4 && points.filter(hasData).length >= 2);
-    if (!shouldUseBullets && (compact.length < SHORT_BODY_CHARS || points.length < 2)) {
-      return trimPoint(compact, TLDR_BUDGET_CHARS);
+function fitMeaningfulPoints(points, budget) {
+  const meaningful = points.filter(Boolean);
+  if (!meaningful.length || budget <= 0) return "";
+
+  const selected = [];
+  let used = 0;
+  for (const point of meaningful) {
+    const next = selected.length ? `\n- ${point}` : point;
+    if (used + next.length > budget) {
+      if (selected.length >= 2) break;
+      selected.push(point.slice(0, Math.max(0, budget - used)).replace(/\s+\S*$/, "").trim() + "...");
+      break;
     }
-    if (!shouldUseBullets) {
-      return selectKeyPoints(points, 2)
-        .map(p => trimPoint(p, NATURAL_POINT_CHARS))
-        .join(" ");
-    }
-    return bulletSummary(points, budget);
+    selected.push(point);
+    used += next.length;
   }
 
-  const headline = trimPoint(event.push_line, HEADLINE_CHARS);
-  const reserved = [headline, linkLine].filter(Boolean).join("\n").length + 2;
-  const summaryBudget = Math.max(0, Math.min(TLDR_BUDGET_CHARS, MAX_PUSH_CHARS - reserved));
-  const summary = fitSummary(summarizeTldr(event.body, summaryBudget), summaryBudget);
-  const prefix = [
-    headline,
-    summary,
-  ].filter(Boolean).join("\n");
-  const prefixBudget = Math.max(0, MAX_PUSH_CHARS - linkLine.length - 1);
-
-  return [
-    prefix.slice(0, prefixBudget).trim(),
-    linkLine,
-  ].filter(Boolean).join("\n");
+  if (selected.length === 1) return selected[0];
+  return selected.map(p => `- ${p}`).join("\n");
 }
 ```
+
+Follower push rendering currently wraps `meta.reason` with the playbook name and
+may convert Markdown to Telegram HTML downstream. That wrapper is acceptable;
+the digest content itself should remain the same canonical body. Avoid
+semicolon-delimited mini-summaries in `meta.reason`, because the generic signal
+renderer treats semicolons as bullet separators for trading-style reasons.
 
 For `audience: "followers"` the output is the `meta.reason` of a
 `signal/targets` record (§6). For `audience: "owner"` it's the `text` of a
@@ -1163,6 +1167,11 @@ claim sub-minute delivery guarantees.
   path, not only the final value.
 - **Honor `max_pushes_per_day` before generation.** Rate limiting is part of the
   user promise, not a UI preference.
+- **Keep push copy and feed output aligned.** The Telegram/Web notification body
+  should derive from the canonical `digest/events.body`; do not create a
+  separate short teaser unless a real channel limit requires it.
+- **Every pushed notification must include the released Playbook URL.** Throw
+  before writing `signal/targets` / `notify/message` if the URL is missing.
 
 ---
 
@@ -1290,15 +1299,19 @@ feed.def("signal", { targets: makeDoc("Push Signal", "",      [/* see §6 */]) }
       && (parsed.dedupe_keys || []).every(d => seen[d.key]);
     if (!materiality.is_material) Object.assign(parsed, quietDayPayload(materiality.reason));
 
-    // always write event; push only when material
+    // Build push payload before writing records so a missing PLAYBOOK_URL fails
+    // without leaving delivery.pushed=true in digest/events.
     const record = { date: runAt, /* …push_line, body, citations, matches: fresh, dedupe_keys… */
       materiality,
       delivery: { pushed: !allOldDup && materiality.is_material, reason: allOldDup ? "all_deduped" : materiality.reason } };
+    const pushPayload = record.delivery.pushed ? composePushPayload(record, PLAYBOOK_URL) : "";
+
+    // always write event; push only when material
     await ctx.self.ts("digest", "events").append([record]);
     if (record.delivery.pushed) {
       await ctx.self.ts("signal", "targets").append([{ date: runAt,
         instruction: { type: "allocate", weights: [] },
-        meta: { reason: composePushPayload(record, PLAYBOOK_URL) } }]);
+        meta: { reason: pushPayload } }]);
     }
 
     // persist dedupe + throttle


### PR DESCRIPTION
## Summary
- Update the AI Digest template so Telegram/Web push copy defaults to the canonical `digest/events.body` instead of a short separate TLDR.
- Require a released Playbook URL in push payloads and append it as the notification tail.
- Replace the old 500-character feed SDK guidance with channel-limit-aware push-safe projection language.

## Why
AI Digest notifications should stay aligned with the Playbook feed output. The previous template over-indexed on compact Telegram copy and documented a 500-character cap that does not match current Telegram chunking behavior.

## Validation
- `git -C code/public/skills diff --check -- skills/alva/templates/ai-digest/template.md skills/alva/references/feed-sdk.md`
- Extracted the `composePushPayload` block and smoke-tested preserved body text, required Playbook URL, and table-triggered push-safe projection with Node.
