### PR TITLE
docs(alva): document V8 isolate absent globals

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -420,6 +420,25 @@ the host machine's filesystem, environment variables, or processes. The runtime
 has access to ALFS, data skills via HTTP, runtime libraries, LLM access, and
 the Feed SDK.
 
+**Absent globals — do not use:**
+
+- `process.*` — no `process` object exists. For output use `console.log`
+  (not `process.stdout.write`); for env vars use
+  `secret.loadPlaintext('NAME')` (not `process.env`); to abort use
+  `throw new Error(...)` (not `process.exit`).
+- `setTimeout` / `setInterval` / `clearTimeout` — no timer globals.
+  Use a synchronous busy-wait helper or restructure to await-driven flow;
+  see `references/snippets/sleep.md` if it exists.
+- `URLSearchParams` — not in scope. Build query strings manually,
+  e.g. `Object.entries(p).map(([k,v]) => k+'='+encodeURIComponent(v)).join('&')`,
+  or use the helper your data skill exposes.
+- `fetch` (global) — must `require('net/http')` and use `http.fetch`.
+- Top-level `await` — wrap in `(async () => { ... })()`.
+
+If a script throws `ReferenceError: <X> is not defined`, the runtime
+does not expose `<X>` — do not retry the same call; rewrite to one of
+the patterns above.
+
 ### 3. Data Skills
 
 Financial data APIs across 16+ domains, served by the Arrays backend


### PR DESCRIPTION
## Summary

Triaged from alva-ai/eval-issues#357 (canonical, oldest open). Class rule prevents the entire "agent assumed Node/browser global exists in V8 isolate" class, not just the four reported symptoms.

Closes alva-ai/eval-issues#357
Closes alva-ai/eval-issues#515
Closes alva-ai/eval-issues#631
Closes alva-ai/eval-issues#678

## Change

- `skills/alva/SKILL.md` (JS Runtime section, after line 422) — added "Absent globals — do not use" subsection enumerating: `process.*`, `setTimeout`/`setInterval`/`clearTimeout`, `URLSearchParams`, `fetch` (global), top-level `await`. Each entry names the sandbox-native pattern to use instead. Closes with a meta-rule: `ReferenceError` on a global means the runtime doesn't expose it — do not retry, rewrite.

## Verification

- Class rule kills the class (not just the reported symptoms)? **yes** — phrased around "Absent globals" generically with a meta-rule on `ReferenceError`. The next variant (e.g. `crypto.subtle`, `WebSocket`, `Buffer`) gets caught by the meta-rule even if not enumerated.
- Verified rule generalizes (rephrased away from symptom-specific)? **yes** — the four bullet points are concrete examples; the meta-rule generalizes.
- Doc generation pipeline checked, edits won't be regen-overwritten? **yes** — `skills/alva/SKILL.md` is hand-authored in this repo, not generated.

## Test plan

- [ ] Read the rule out loud — does the next variant of this class (e.g. agent reaching for `Buffer.from` in V8) get caught by the meta-rule?
- [ ] Skim adjacent rules in §JS Runtime / §Data Skills for contradiction.
- [ ] Verify the snippet `Object.entries(p).map(...).join('&')` produces correct query strings (manual eval).

## Triage context

Triaged via the [`maintain` skill](https://github.com/alva-ai/mono-meta/pull/390) at `users/ming/skills/maintain/`. Cluster discovered via sibling-search on `ReferenceError` and `v8 isolate` keywords; canonical = #357 (oldest open, 2026-04-27). Skill's preflight verified the SKILL.md JS Runtime section enumerates forbidden Node modules but not absent globals — single-rule fix prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)