### PR TITLE
[codex] docs(alva): note push notify for Altra signals

### DIFF
--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -748,6 +748,11 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 └── perf/metrics            -- Performance report
 ```
 
+`signal/targets` makes the feed push-capable, but delivery still requires the
+cronjob to be created or updated with `--push-notify` and the feed release to be
+bound to that cronjob. See `references/deployment.md` for the deploy/release
+flow.
+
 ---
 
 ## Point-In-Time (PIT) Compliance


### PR DESCRIPTION
## Summary
- add a note in the Altra trading reference that `signal/targets` only makes a feed push-capable
- clarify that actual delivery still requires `--push-notify` on the cronjob and a feed release bound to that cronjob
- point readers to the deployment reference for the full deploy/release flow

## Validation
- `git diff --check`