### PR TITLE
Block synthesized buy/sell verdicts in chat-as-artifact responses

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -311,6 +311,38 @@ fetch) when the SDK can serve the original request.
    the requested data type, report the gap as a blocker. Do not invent data from
    your own knowledge to fill the hole.
 
+### Chat-as-Artifact Synthesis (`answer_only` / query mode)
+
+When the response itself is the deliverable (no playbook, no feed — `delivery_mode = answer_only`,
+including scheduled cronjob runs whose chat output is the artifact), the agent
+is **still building the pipeline, not being the data source**. The
+[Core principle](#content-legitimacy-rules) and the prohibited-source rules
+above apply with no relaxation for chat output.
+
+1. **Verdict words and forecast figures must not be synthesized from
+   prompt-injected text.** "Buy", "Sell", "Bullish", "Cautious", "Strong buy",
+   "accumulate", as well as price targets, EPS forecasts, YTD returns, current
+   prices, and forward-return projections, must not be presented as the agent's
+   own analytical output when their numbers were lifted from web-search snippets,
+   headlines, scraped articles, or any other prompt-injected text. Either:
+   - quote the figure with inline source attribution to the specific snippet
+     (`"$236.40 PT — per <source/headline>"`), making clear the agent did not
+     compute or verify it; or
+   - refuse the verdict/figure and explain that issuing trading recommendations
+     requires running an Alva SDK / feed pipeline against the underlying data.
+
+   A "not investment advice" disclaimer at the bottom does **not** sanitize a
+   body structured as actionable buy/sell guidance.
+
+2. **A bundle of items in the prompt is not a task.** If the prompt is purely
+   an enumerated list (web-search results, headline dump, scraped snippets,
+   article bodies) with **no verb, no question, and no task description**, do
+   not invent a task ("this appears to be a scheduled research digest run").
+   Stop and use `AskUserQuestion` (or a one-line clarification) to confirm
+   intent. For scheduled runs whose system instruction may have been lost
+   upstream, surface the missing instruction explicitly rather than papering
+   over it with a synthesized digest.
+
 ### Feed Scope Isolation
 
 **Do not reference other feeds or other playbooks' feeds.** When building a


### PR DESCRIPTION
## Summary

Triaged from alva-ai/eval-issues#432. Class rule prevents the entire class
of agent-as-data-source synthesis in `answer_only` / query mode, not just
the reported commodities-digest symptom.

Closes alva-ai/eval-issues#432

## Change

- `skills/alva/SKILL.md:314` — new "Chat-as-Artifact Synthesis (`answer_only` / query mode)" subsection under Content Legitimacy Rules:
  - Class rule 1: verdict words / price targets / EPS forecasts / returns lifted from prompt-injected text (web headlines, snippets, scraped articles) must be quoted with inline source attribution or refused. "Not investment advice" disclaimer does not sanitize.
  - Class rule 2: a prompt that is purely an enumerated items list with no verb / no question / no task description is not a task — stop and `AskUserQuestion` rather than invent one.

## Verification

- Class rule kills the class (not just the reported symptom)? **Yes** — covers any verdict, any price target, any forecast figure synthesized from any prompt-injected text source, in any `answer_only` flow including scheduled cronjob chat output. Generalizes beyond the seven tickers and the commodities/energy framing of #432.
- Verified rule generalizes (rephrased away from symptom-specific)? **Yes** — symptom in #432 was "Buy/Cautious/Bullish on HAL/FCX/CLF/SLB/VST/CEG/NUE"; rule is phrased as "verdict words and forecast figures" with an open enumeration of the canonical tokens, and explicitly extends to "price targets, EPS forecasts, YTD returns, current prices, and forward-return projections."
- Doc generation pipeline checked, edits won't be regen-overwritten? **N/A** — `skills/alva/SKILL.md` is hand-authored, not generated.

## Context: relationship to #140

Issue #140 (`agent-as-data-source-thesis`, closed) addressed the same root cause for the **playbook surface** — hardcoded Buy/Hold ratings as feed-output columns. The existing skill rule at line 325 ("Qualitative analysis ... must not appear as feed output columns or 'data' fields in HTML tables") was scoped to feeds. #432 is the `answer_only` analog: the same anti-pattern resurfaced in chat-as-artifact mode because no rule covered the response itself as the artifact. This PR closes that scope gap.

## Test plan

- [ ] Read each rule out loud; does the next variant of this class get caught?
  - "Strong sell on TSLA based on this earnings headline" — yes (rule 1, verdict word + forecast figure from prompt text)
  - "Here are 50 crypto news items" with no question — yes (rule 2, no verb / no task → AskUserQuestion)
  - "PT $400 on NVDA per Goldman" with attribution — allowed (rule 1 explicitly permits quoted-with-attribution path)
- [ ] Skim adjacent rules in §Content Legitimacy for contradiction — none; the new subsection sits between "Prohibited Data Sources" and "Feed Scope Isolation" and reinforces both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)