### PR TITLE
Add Domain Scope precondition to Request Routing

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -183,6 +183,14 @@ that the user should verify with current sources.
 | **Data Query** | Fetch the requested data accurately and return it directly unless the user asks for a richer artifact |
 | **Remix** | Reuse the source artifact, apply the requested changes, and return an updated result that matches the requested customization |
 
+### Domain Scope (precondition for every route)
+
+Alva is a financial data platform. Every route above presumes the request is **finance/data-shaped** — i.e. it benefits from market data, scheduled refresh, analytics, trading, or a data-backed shareable artifact. Before entering any route, confirm the request fits that shape.
+
+If the request has **no financial/data component and no scheduled refresh need** (e.g. games, generic web pages, brand sites, marketing copy, productivity tools, art/entertainment artifacts), do not silently proceed into the build pipeline. Surface the mismatch in one short message: name what Alva is built for, ask whether the user wants to (a) reframe the request with a finance/data angle, (b) proceed anyway as a static artifact while accepting the platform mismatch, or (c) take the work elsewhere. Only continue after the user picks (a) or (b).
+
+This is a class rule, not a keyword filter — judge by whether the eventual artifact would consume Alva's data/scheduling primitives meaningfully, not by surface vocabulary. An empty `--feeds '[]'` release for a static, non-data artifact is a signal you should have asked this question upstream.
+
 ### Choose Template (mandatory when `/use-template:<name>` is present)
 
 If the user's message contains a `/use-template:<name>` directive (e.g. `/use-template:thesis`, `/use-template:screener`), this step is **mandatory** and must run before Guided Planning and before any build work.


### PR DESCRIPTION
## Summary

Triaged from alva-ai/eval-issues#248 (regression of #187). Class rule
prevents the entire class, not just the reported symptom.

Closes alva-ai/eval-issues#248

## Change

- `skills/alva/SKILL.md:186` — class rule: "before any route fires, confirm the request is finance/data-shaped; if not, surface the platform mismatch and let the user pick reframe / proceed-as-static / take elsewhere."

## Verification

- Class rule kills the class (not just the reported symptom)? **Yes** — phrased around "no financial/data component and no scheduled refresh need", which catches games, brand sites, productivity tools, etc., not just bomberman/billiards.
- Verified rule generalizes (rephrased away from symptom-specific)? **Yes** — explicitly noted as a class rule, not a keyword filter; cites the empty `--feeds '[]'` shape as an upstream signal rather than the trigger.
- Doc generation pipeline checked, edits won't be regen-overwritten? **Yes** — `skills/alva/SKILL.md` is hand-authored.

## Why now (regression context)

#187 was closed 2026-04-14 as "too narrow for a doc rule" per the
prefer-principles-over-gates feedback. Since then the same shape has
appeared with a brand site (Nexiva, on the #187 thread) and now a
Bomberman game (#248). Three independent users on three artifact types
clears the recurrence bar; the rule is now principle-shaped (no
enumeration of game/site categories) rather than a narrow gate.

## Test plan

- [ ] Read the rule out loud; the next variant (e.g. "build me a todo app", "make me a portfolio site") gets caught by the same gate.
- [ ] Skim adjacent rules in Request Routing for contradiction — Guided Planning still runs after this gate when the user picks (a) or (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)