### PR TITLE
docs(alva): fix KPI value letter-spacing and line-height

### DIFF
--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -60,8 +60,8 @@
   font-size: 16px;
   font-weight: 400;
   color: var(--text-n9);
-  letter-spacing: 0.14px;
-  line-height: 22px;
+  letter-spacing: 0.16px;
+  line-height: 26px;
 }
 
 .widget-timestamp {


### PR DESCRIPTION
## Summary
- Update `.widget-value` letter-spacing from `0.14px` to `0.16px` to match the 1%-of-font-size rule for 16px text
- Update line-height from `22px` to `26px` for KPI values

## Test plan
- [ ] Visually verify KPI cards in dashboard widgets render with correct typography

🤖 Generated with [Claude Code](https://claude.com/claude-code)