### PR TITLE
docs(SKILL): /use-template:→/use-skill: via alva skills CLI; rename data-skills; v1.8.0

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.7.0
+  version: v1.8.0
 ---
 
 # Alva
@@ -456,14 +456,14 @@ the patterns above.
 
 Financial data APIs across 16+ domains, served by the Arrays backend
 (`$ARRAYS_ENDPOINT`, defaults to `https://data-tools.prd.space.id`). To find
-the right API for a task, use the `alva skills` CLI (public, no auth):
+the right API for a task, use the `alva data-skills` CLI (public, no auth):
 
-1. **Discover available data skills**: `alva skills list` — returns all data
+1. **Discover available data skills**: `alva data-skills list` — returns all data
    skills with their names and descriptions. Use this to find the skill that
    matches your data need.
-2. **Fetch the skill summary**: `alva skills summary --name <skill>` — returns
+2. **Fetch the skill summary**: `alva data-skills summary <skill>` — returns
    the endpoints table for that domain.
-3. **Fetch endpoint detail**: `alva skills endpoint --name <skill> --file <file>`
+3. **Fetch endpoint detail**: `alva data-skills endpoint <skill> <file>`
    — use the **File** value from the summary endpoints table (e.g. `rates`,
    `macro-index-historical`, `earnings-calendar`) to get full parameters,
    response fields, and examples. The `File` column is the endpoint slug;
@@ -479,7 +479,7 @@ the right API for a task, use the `alva skills` CLI (public, no auth):
 Data skills span spot and derivatives markets across stocks, ETFs, options,
 and crypto; equity fundamentals, estimates, events, and ownership flows;
 on-chain metrics and exchange flows; macro and economic indicators; news;
-and prediction markets. Run `alva skills list` for the live catalog.
+and prediction markets. Run `alva data-skills list` for the live catalog.
 
 **Data skill doc lookup is mandatory.** Always fetch the endpoint detail before
 writing code that calls it. Do not guess paths, parameter names, or response
@@ -487,13 +487,13 @@ shapes from memory. The doc lookup ensures you use the correct endpoint and
 handle the actual response format.
 
 **Enforcement**: Before any Arrays data HTTP call or `alva run` that hits one,
-you MUST have completed `alva skills endpoint --name <skill> --file <file>` for
+you MUST have completed `alva data-skills endpoint <skill> <file>` for
 that endpoint in this session (passing the **File** column value, not the Path). If the call fails with an unexpected shape,
 re-fetch the endpoint detail rather than guessing.
 
 **Failure and fallback guardrail**: If an Arrays endpoint returns 403, 404, or
 an unexpected empty/irrelevant result, do not immediately tell the user to
-upgrade or use BYOD. First re-check `alva skills summary --name <skill>` for the
+upgrade or use BYOD. First re-check `alva data-skills summary <skill>` for the
 same data domain and look for a semantically equivalent endpoint. For
 congressional trading questions about a specific politician, prefer endpoint
 details that support politician name and date filters (for example

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.9.0
+  version: v1.8.0
 ---
 
 # Alva
@@ -187,17 +187,21 @@ that the user should verify with current sources.
 
 If the user's message contains a `/use-template:<name>` directive (e.g. `/use-template:thesis`, `/use-template:screener`), this step is **mandatory** and must run before Guided Planning and before any build work.
 
-Templates live in the **playbook-skills catalog** on the gateway (see Step 8 in Capabilities for the full CLI). System templates are seeded under the `alva` namespace. Resolve `/use-template:<name>` to `alva/<name>` and fetch via CLI:
+Templates live in the **playbook-skills catalog** on the gateway (see Step 8 in Capabilities for the full CLI). `<name>` is just the skill name half — catalog ids are `<username>/<name>`, and templates can be published by any user, not only under the `alva` namespace. Do not assume `alva/<name>` exists; resolve via listing.
 
-1. **Locate**: `alva skills get alva/<name>` confirms the template exists and returns its file listing. If 404, run `alva skills list --username alva` to surface available system templates and ask the user which one to use.
-2. **Read the blueprint**: `alva skills file alva/<name> template.md` returns the authoritative blueprint. Do not proceed from memory of a prior session — fetch it fresh.
-3. **Pull other files on demand**: when building, fetch additional files progressively as needed (e.g. `alva skills file alva/<name> src/index.js` only if you intend to mirror the strategy logic). Do not bulk-download.
-4. Treat the blueprint as authoritative for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
-5. State the template choice and any intentional deviations in your Guided Planning plan. The `/use-template:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-template:` + concrete topic the same as "just do it": a single short plan, then build.
+1. **Discover**: run `alva skills list` (optionally `--tag <topic>` if the user mentioned one) and scan entries whose `name` field equals `<name>`.
+   - **Exactly one match** (e.g. `alva/thesis` is the only `thesis`) → use that `<username>/<name>` id.
+   - **Multiple matches** (e.g. `alva/thesis` and `alice/thesis`) → show the user the candidates with their descriptions and tags, and ask which to use.
+   - **No match** → present the available list (filtered by `--tag` if helpful) and ask the user to pick one or refine the name. Do NOT silently default to anything.
+2. **Inspect**: `alva skills get <username>/<name>` returns the file listing with sizes. Confirm a blueprint file is present — convention is `template.md`. If absent, look for `README.md` or ask the user which file is the blueprint.
+3. **Read the blueprint**: `alva skills file <username>/<name> template.md` (or the file from step 2). Do not proceed from memory of a prior session — fetch it fresh.
+4. **Pull other files on demand**: when building, fetch additional files progressively as needed (e.g. `alva skills file <username>/<name> src/index.js` only if you intend to mirror the strategy logic). Do not bulk-download.
+5. Treat the blueprint as authoritative for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
+6. State the template choice and any intentional deviations in your Guided Planning plan. The `/use-template:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-template:` + concrete topic the same as "just do it": a single short plan, then build.
 
 **Content arrangement.** A template's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
 
-**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` template is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
+**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `ai-digest` template (system-seeded as `alva/ai-digest`) is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
 
 No `/use-template:` directive → skip this step and proceed to Guided Planning normally.
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -187,7 +187,7 @@ that the user should verify with current sources.
 
 If the user's message contains a `/use-skill:<username>/<name>` directive (e.g. `/use-skill:alva/thesis`, `/use-skill:alice/btc-momentum`), this step is **mandatory** and must run before Guided Planning and before any build work.
 
-The directive gives the full catalog id (`<username>/<name>`). Skills live in the playbook-skills catalog on the gateway (see Step 8 in Capabilities for the full CLI). They can be published by any user — do not assume the `alva/` namespace.
+The directive gives the full catalog id (`<username>/<name>`). Skills live in the playbook-skills catalog on the gateway and are fetched via the `alva skills` CLI (use `alva skills --help` for the full surface). They can be published by any user — do not assume the `alva/` namespace.
 
 1. **Inspect**: `alva skills get <username>/<name>` returns the file listing with sizes. Confirm a blueprint file is present — convention is `template.md`. If absent, look for `README.md` or ask the user which file is the blueprint.
    - **On 404 / not found** (typo, deleted, or moved): run `alva skills list` and look for close matches **leniently** — case-insensitive, substring on both halves of the id, ignore separator differences. If exactly one obvious candidate, proceed with it and tell the user you corrected the id (e.g. "interpreting `/use-skill:Alva/AI-Digest` as `alva/ai-digest`"). If multiple plausible candidates, show them and ask. If nothing close, show the filtered list (use `--tag` if the user hinted at a topic) and ask the user to pick.
@@ -198,7 +198,7 @@ The directive gives the full catalog id (`<username>/<name>`). Skills live in th
 
 **Content arrangement.** A skill's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
 
-**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` skill is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the skill is one good option, not a requirement.
+**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` skill is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 9 — the skill is one good option, not a requirement.
 
 No `/use-skill:` directive → skip this step and proceed to Guided Planning normally.
 
@@ -610,7 +610,7 @@ alva release feed --name <feed> --version 1.0.0 \
 ```
 
 Keep schema examples in [feed-sdk.md](references/feed-sdk.md) Patterns D/E.
-See **Step 10** below for the post-release subscription flow.
+See **Step 9** below for the post-release subscription flow.
 
 ### 6. Build the Playbook Web App
 
@@ -737,54 +737,7 @@ Before calling `alva release playbook`, verify all of the following:
    and must match this exact path — preferred form is the relative ALFS
    shorthand `~/playbooks/{name}/README.md` (quote it in the shell).
 
-### 8. Playbook Skills (Catalog)
-
-Playbook **skills** are the catalog of reusable playbook starting points
-stored on alva-backend and surfaced through the gateway. System templates
-(e.g. `alva/ai-digest`, `alva/screener`, `alva/thesis`, `alva/what-if`)
-are seeded under the `alva` namespace; community contributors publish
-under their own. The `/use-skill:<username>/<name>` user directive (see [Choose
-Skill](#choose-skill-mandatory-when-use-skillusernamename-is-present)
-in Request Routing) is one consumer of this catalog — agents can also
-use it for free-form browsing, remix source discovery (Step 9), or
-pulling inspiration before building.
-
-Namespaced as `<username>/<name>`. All `alva skills *` commands require
-`alva auth login` first (routes are user-auth-gated).
-
-**Commands**:
-
-1. **List the catalog**: `alva skills list` — name, description, tags,
-   last-updated timestamp for every skill. Filters: `--tag <tag>`,
-   `--username <user>`.
-2. **Browse tags**: `alva skills tags` — distinct tag set across the catalog.
-3. **Inspect a skill**: `alva skills get <username>/<name>` — metadata
-   plus the file listing with sizes (no content).
-4. **Fetch a single file**: `alva skills file <username>/<name> <path>` —
-   one file's content.
-
-**Progressive loading.** `get` returns the file tree but no content;
-`file` fetches one file at a time. Pull what you need, when you need it
-(e.g. `template.md` first to read the blueprint; `src/index.js` only if
-you decide to mirror the strategy logic). The bulk-files endpoint exists
-on the gateway but is intentionally not exposed at the CLI to keep
-context budgets tight.
-
-All commands default to a pretty-printed view; add `--json` for the raw
-envelope. `alva skills file` writes raw content to stdout — redirect
-with `>` to save a copy.
-
-**Examples**:
-
-```bash
-alva skills list --tag research              # research-focused skills
-alva skills list --username alva             # all system skills
-alva skills get alva/screener                # see file tree before deciding
-alva skills file alva/screener template.md   # read the description first
-alva skills file alice/btc-momentum src/index.js > /tmp/src.js
-```
-
-### 9. Remix (Create from Existing Playbook)
+### 8. Remix (Create from Existing Playbook)
 
 Users can remix any published playbook to create a customized version. The Remix
 prompt uses the format `@{owner}/{name}` to identify the source playbook — e.g.
@@ -793,15 +746,11 @@ scripts (strategy logic) and HTML (dashboard UI), customizes them per the user's
 request, and deploys a new playbook under their own namespace. If the user does
 not specify what to change, the agent should ask before proceeding.
 
-If the user has not picked a source playbook yet, use Step 8's `alva skills`
-commands to browse the catalog (filter by tag / username) and surface
-candidates before remixing.
-
 See [remix-workflow.md](references/remix-workflow.md) for the full step-by-step
 guide. `alva remix` commands are exclusively for lineage registration — to
 read any playbook's files, use `alva fs read`.
 
-### 10. Post-release push notification flow
+### 9. Post-release push notification flow
 
 After a playbook is **released or kept as draft** (Step 7 complete), proactively
 evaluate whether any deployed feeds produce push-worthy content. Do not wait for

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -183,27 +183,24 @@ that the user should verify with current sources.
 | **Data Query** | Fetch the requested data accurately and return it directly unless the user asks for a richer artifact |
 | **Remix** | Reuse the source artifact, apply the requested changes, and return an updated result that matches the requested customization |
 
-### Choose Template (mandatory when `/use-template:<name>` is present)
+### Choose Skill (mandatory when `/use-skill:<username>/<name>` is present)
 
-If the user's message contains a `/use-template:<name>` directive (e.g. `/use-template:thesis`, `/use-template:screener`), this step is **mandatory** and must run before Guided Planning and before any build work.
+If the user's message contains a `/use-skill:<username>/<name>` directive (e.g. `/use-skill:alva/thesis`, `/use-skill:alice/btc-momentum`), this step is **mandatory** and must run before Guided Planning and before any build work.
 
-Templates live in the **playbook-skills catalog** on the gateway (see Step 8 in Capabilities for the full CLI). `<name>` is just the skill name half — catalog ids are `<username>/<name>`, and templates can be published by any user, not only under the `alva` namespace. Do not assume `alva/<name>` exists; resolve via listing.
+The directive gives the full catalog id (`<username>/<name>`). Skills live in the playbook-skills catalog on the gateway (see Step 8 in Capabilities for the full CLI). They can be published by any user — do not assume the `alva/` namespace.
 
-1. **Discover**: run `alva skills list` (optionally `--tag <topic>` if the user mentioned one) and scan entries whose `name` field equals `<name>`.
-   - **Exactly one match** (e.g. `alva/thesis` is the only `thesis`) → use that `<username>/<name>` id.
-   - **Multiple matches** (e.g. `alva/thesis` and `alice/thesis`) → show the user the candidates with their descriptions and tags, and ask which to use.
-   - **No match** → present the available list (filtered by `--tag` if helpful) and ask the user to pick one or refine the name. Do NOT silently default to anything.
-2. **Inspect**: `alva skills get <username>/<name>` returns the file listing with sizes. Confirm a blueprint file is present — convention is `template.md`. If absent, look for `README.md` or ask the user which file is the blueprint.
-3. **Read the blueprint**: `alva skills file <username>/<name> template.md` (or the file from step 2). Do not proceed from memory of a prior session — fetch it fresh.
-4. **Pull other files on demand**: when building, fetch additional files progressively as needed (e.g. `alva skills file <username>/<name> src/index.js` only if you intend to mirror the strategy logic). Do not bulk-download.
-5. Treat the blueprint as authoritative for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
-6. State the template choice and any intentional deviations in your Guided Planning plan. The `/use-template:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-template:` + concrete topic the same as "just do it": a single short plan, then build.
+1. **Inspect**: `alva skills get <username>/<name>` returns the file listing with sizes. Confirm a blueprint file is present — convention is `template.md`. If absent, look for `README.md` or ask the user which file is the blueprint.
+   - **On 404 / not found** (typo, deleted, or moved): run `alva skills list` and look for close matches **leniently** — case-insensitive, substring on both halves of the id, ignore separator differences. If exactly one obvious candidate, proceed with it and tell the user you corrected the id (e.g. "interpreting `/use-skill:Alva/AI-Digest` as `alva/ai-digest`"). If multiple plausible candidates, show them and ask. If nothing close, show the filtered list (use `--tag` if the user hinted at a topic) and ask the user to pick.
+2. **Read the blueprint**: `alva skills file <username>/<name> template.md` (or the file from step 1). Do not proceed from memory of a prior session — fetch it fresh.
+3. **Pull other files on demand**: when building, fetch additional files progressively as needed (e.g. `alva skills file <username>/<name> src/index.js` only if you intend to mirror the strategy logic). Do not bulk-download.
+4. Treat the blueprint as authoritative for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
+5. State the skill choice and any intentional deviations in your Guided Planning plan. The `/use-skill:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-skill:` + concrete topic the same as "just do it": a single short plan, then build.
 
-**Content arrangement.** A template's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
+**Content arrangement.** A skill's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
 
-**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `ai-digest` template (system-seeded as `alva/ai-digest`) is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
+**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` skill is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the skill is one good option, not a requirement.
 
-No `/use-template:` directive → skip this step and proceed to Guided Planning normally.
+No `/use-skill:` directive → skip this step and proceed to Guided Planning normally.
 
 ### Guided Planning
 
@@ -228,11 +225,11 @@ afterward.
    there are real strategic alternatives. Lead with your recommendation. Skip
    when the template or request already pins the approach.
 3. **Confirm the plan** — When step 1 was skipped (request already clear, or
-   `/use-template:` directive specifies the shape), present a single 5-8 line
+   `/use-skill:` directive specifies the shape), present a single 5-8 line
    plan listing the specific feeds and widgets, then build after approval.
-   State the template (if any) and the key defaults you are using.
+   State the skill (if any) and the key defaults you are using.
 
-If the user says "just do it" at any point — or used `/use-template:<name>`
+If the user says "just do it" at any point — or used `/use-skill:<username>/<name>`
 together with a concrete topic — skip clarifying questions for the rest of the
 session and present a single short plan, then build.
 
@@ -746,8 +743,8 @@ Playbook **skills** are the catalog of reusable playbook starting points
 stored on alva-backend and surfaced through the gateway. System templates
 (e.g. `alva/ai-digest`, `alva/screener`, `alva/thesis`, `alva/what-if`)
 are seeded under the `alva` namespace; community contributors publish
-under their own. The `/use-template:<name>` user directive (see [Choose
-Template](#choose-template-mandatory-when-use-templatename-is-present)
+under their own. The `/use-skill:<username>/<name>` user directive (see [Choose
+Skill](#choose-skill-mandatory-when-use-skillusernamename-is-present)
 in Request Routing) is one consumer of this catalog — agents can also
 use it for free-form browsing, remix source discovery (Step 9), or
 pulling inspiration before building.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.8.0
+  version: v1.9.0
 ---
 
 # Alva
@@ -194,7 +194,7 @@ If the user's message contains a `/use-template:<name>` directive (e.g. `/use-te
 
 **Content arrangement.** A template's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
 
-**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the [ai-digest template](templates/ai-digest/template.md) is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 9 — the template is one good option, not a requirement.
+**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the [ai-digest template](templates/ai-digest/template.md) is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
 
 No `/use-template:` directive → skip this step and proceed to Guided Planning normally.
 
@@ -606,7 +606,7 @@ alva release feed --name <feed> --version 1.0.0 \
 ```
 
 Keep schema examples in [feed-sdk.md](references/feed-sdk.md) Patterns D/E.
-See **Step 9** below for the post-release subscription flow.
+See **Step 10** below for the post-release subscription flow.
 
 ### 6. Build the Playbook Web App
 
@@ -733,7 +733,57 @@ Before calling `alva release playbook`, verify all of the following:
    and must match this exact path — preferred form is the relative ALFS
    shorthand `~/playbooks/{name}/README.md` (quote it in the shell).
 
-### 8. Remix (Create from Existing Playbook)
+### 8. Browse Playbook Skills (Catalog Discovery)
+
+Playbook **skills** are reusable starting points for new playbooks — system-seeded
+ones (e.g. `alva/ai-digest`, `alva/screener`) plus community-contributed ones.
+They live in the alva-backend catalog and surface through the gateway. Use them
+to discover inspiration before building or as remix sources for Step 9.
+
+Namespaced as `<username>/<name>` (e.g. `alva/ai-digest`, `alice/btc-momentum`).
+System skills use username `alva`.
+
+**Discovery commands** (require `alva auth login` first — these routes are
+user-auth-gated):
+
+1. **List the catalog**: `alva skills list` — name, description, tags, and
+   last-updated timestamp for every skill. Optional filters: `--tag <tag>`,
+   `--username <user>`.
+2. **Browse tags**: `alva skills tags` — distinct tag set across all skills.
+3. **Inspect a skill**: `alva skills get <username>/<name>` — metadata plus
+   the file listing with sizes (no content). Use this to see the shape of a
+   skill before pulling files.
+4. **Fetch a single file**: `alva skills file <username>/<name> <path>` —
+   one file's content. **Progressive loading**: pull one file at a time as
+   you need it (e.g. `template.md` first to read the description;
+   `src/index.js` only if you decide to remix). The bulk-files endpoint
+   exists on the gateway but is intentionally not exposed at the CLI to
+   keep loading progressive.
+
+All `alva skills *` commands default to a pretty-printed view; add `--json`
+for the raw envelope. `alva skills file` writes raw content to stdout, so
+redirect to a file: `alva skills file alice/btc-momentum src/index.js > out.js`.
+
+**When to use vs `/use-template:<name>`:**
+
+- `/use-template:<name>` reads from the **local bundled** templates shipped
+  with this skill (`skills/alva/templates/`). Fast, offline, fixed set:
+  `ai-digest`, `screener`, `thesis`, `what-if`.
+- `alva skills *` queries the **live catalog**. Wider, growing set, each call
+  hits the network. Use for: community discovery, finding remix sources,
+  browsing by tag, fetching the latest version of a system template.
+
+**Examples:**
+
+```bash
+alva skills list --tag research              # research-focused skills
+alva skills list --username alva             # all system skills
+alva skills get alva/screener                # see file tree before deciding
+alva skills file alva/screener template.md   # read the description first
+alva skills file alice/btc-momentum src/index.js > /tmp/src.js
+```
+
+### 9. Remix (Create from Existing Playbook)
 
 Users can remix any published playbook to create a customized version. The Remix
 prompt uses the format `@{owner}/{name}` to identify the source playbook — e.g.
@@ -742,11 +792,15 @@ scripts (strategy logic) and HTML (dashboard UI), customizes them per the user's
 request, and deploys a new playbook under their own namespace. If the user does
 not specify what to change, the agent should ask before proceeding.
 
+If the user has not picked a source playbook yet, use Step 8's `alva skills`
+commands to browse the catalog (filter by tag / username) and surface
+candidates before remixing.
+
 See [remix-workflow.md](references/remix-workflow.md) for the full step-by-step
 guide. `alva remix` commands are exclusively for lineage registration — to
 read any playbook's files, use `alva fs read`.
 
-### 9. Post-release push notification flow
+### 10. Post-release push notification flow
 
 After a playbook is **released or kept as draft** (Step 7 complete), proactively
 evaluate whether any deployed feeds produce push-worthy content. Do not wait for

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -187,14 +187,17 @@ that the user should verify with current sources.
 
 If the user's message contains a `/use-template:<name>` directive (e.g. `/use-template:thesis`, `/use-template:screener`), this step is **mandatory** and must run before Guided Planning and before any build work.
 
-1. Resolve `<name>` to `skills/alva/templates/<name>/template.md` (relative to this skill).
-2. **Read that template file** via the filesystem — do not proceed from memory of a prior session. If the file does not exist, list the directories under `templates/` and ask the user which to use.
-3. Treat the template as the authoritative blueprint for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
-4. State the template choice and any intentional deviations in your Guided Planning plan. The `/use-template:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-template:` + concrete topic the same as "just do it": a single short plan, then build.
+Templates live in the **playbook-skills catalog** on the gateway (see Step 8 in Capabilities for the full CLI). System templates are seeded under the `alva` namespace. Resolve `/use-template:<name>` to `alva/<name>` and fetch via CLI:
+
+1. **Locate**: `alva skills get alva/<name>` confirms the template exists and returns its file listing. If 404, run `alva skills list --username alva` to surface available system templates and ask the user which one to use.
+2. **Read the blueprint**: `alva skills file alva/<name> template.md` returns the authoritative blueprint. Do not proceed from memory of a prior session — fetch it fresh.
+3. **Pull other files on demand**: when building, fetch additional files progressively as needed (e.g. `alva skills file alva/<name> src/index.js` only if you intend to mirror the strategy logic). Do not bulk-download.
+4. Treat the blueprint as authoritative for layout, sections, widgets, data contracts, and cadence. Deviate only where the user explicitly overrides it.
+5. State the template choice and any intentional deviations in your Guided Planning plan. The `/use-template:` directive is a **strong build directive** — combined with a concrete topic, present the plan **once** and build; do not also stack clarifying multi-choice questions on top. Treat `/use-template:` + concrete topic the same as "just do it": a single short plan, then build.
 
 **Content arrangement.** A template's default sections are a floor, not a ceiling. Lead with whatever carries the user's core question, proactively add sections the request demands, and cut or fold near-empty sections into neighbors rather than padding them.
 
-**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the [ai-digest template](templates/ai-digest/template.md) is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
+**Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` template is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 10 — the template is one good option, not a requirement.
 
 No `/use-template:` directive → skip this step and proceed to Guided Planning normally.
 
@@ -733,47 +736,44 @@ Before calling `alva release playbook`, verify all of the following:
    and must match this exact path — preferred form is the relative ALFS
    shorthand `~/playbooks/{name}/README.md` (quote it in the shell).
 
-### 8. Browse Playbook Skills (Catalog Discovery)
+### 8. Playbook Skills (Catalog)
 
-Playbook **skills** are reusable starting points for new playbooks — system-seeded
-ones (e.g. `alva/ai-digest`, `alva/screener`) plus community-contributed ones.
-They live in the alva-backend catalog and surface through the gateway. Use them
-to discover inspiration before building or as remix sources for Step 9.
+Playbook **skills** are the catalog of reusable playbook starting points
+stored on alva-backend and surfaced through the gateway. System templates
+(e.g. `alva/ai-digest`, `alva/screener`, `alva/thesis`, `alva/what-if`)
+are seeded under the `alva` namespace; community contributors publish
+under their own. The `/use-template:<name>` user directive (see [Choose
+Template](#choose-template-mandatory-when-use-templatename-is-present)
+in Request Routing) is one consumer of this catalog — agents can also
+use it for free-form browsing, remix source discovery (Step 9), or
+pulling inspiration before building.
 
-Namespaced as `<username>/<name>` (e.g. `alva/ai-digest`, `alice/btc-momentum`).
-System skills use username `alva`.
+Namespaced as `<username>/<name>`. All `alva skills *` commands require
+`alva auth login` first (routes are user-auth-gated).
 
-**Discovery commands** (require `alva auth login` first — these routes are
-user-auth-gated):
+**Commands**:
 
-1. **List the catalog**: `alva skills list` — name, description, tags, and
-   last-updated timestamp for every skill. Optional filters: `--tag <tag>`,
+1. **List the catalog**: `alva skills list` — name, description, tags,
+   last-updated timestamp for every skill. Filters: `--tag <tag>`,
    `--username <user>`.
-2. **Browse tags**: `alva skills tags` — distinct tag set across all skills.
-3. **Inspect a skill**: `alva skills get <username>/<name>` — metadata plus
-   the file listing with sizes (no content). Use this to see the shape of a
-   skill before pulling files.
+2. **Browse tags**: `alva skills tags` — distinct tag set across the catalog.
+3. **Inspect a skill**: `alva skills get <username>/<name>` — metadata
+   plus the file listing with sizes (no content).
 4. **Fetch a single file**: `alva skills file <username>/<name> <path>` —
-   one file's content. **Progressive loading**: pull one file at a time as
-   you need it (e.g. `template.md` first to read the description;
-   `src/index.js` only if you decide to remix). The bulk-files endpoint
-   exists on the gateway but is intentionally not exposed at the CLI to
-   keep loading progressive.
+   one file's content.
 
-All `alva skills *` commands default to a pretty-printed view; add `--json`
-for the raw envelope. `alva skills file` writes raw content to stdout, so
-redirect to a file: `alva skills file alice/btc-momentum src/index.js > out.js`.
+**Progressive loading.** `get` returns the file tree but no content;
+`file` fetches one file at a time. Pull what you need, when you need it
+(e.g. `template.md` first to read the blueprint; `src/index.js` only if
+you decide to mirror the strategy logic). The bulk-files endpoint exists
+on the gateway but is intentionally not exposed at the CLI to keep
+context budgets tight.
 
-**When to use vs `/use-template:<name>`:**
+All commands default to a pretty-printed view; add `--json` for the raw
+envelope. `alva skills file` writes raw content to stdout — redirect
+with `>` to save a copy.
 
-- `/use-template:<name>` reads from the **local bundled** templates shipped
-  with this skill (`skills/alva/templates/`). Fast, offline, fixed set:
-  `ai-digest`, `screener`, `thesis`, `what-if`.
-- `alva skills *` queries the **live catalog**. Wider, growing set, each call
-  hits the network. Use for: community discovery, finding remix sources,
-  browsing by tag, fetching the latest version of a system template.
-
-**Examples:**
+**Examples**:
 
 ```bash
 alva skills list --tag research              # research-focused skills


### PR DESCRIPTION
## Summary

Three logical changes to `skills/alva/SKILL.md`:

1. **Rename `alva skills` → `alva data-skills`** (data-SDK CLI) on 7 lines. Converts `--name <skill>` / `--file <file>` to positional args.
2. **`/use-template:` → `/use-skill:`** user directive rename with three behavior changes:
   - **Full id required.** Directive carries the complete `<username>/<name>` (e.g. `/use-skill:alva/thesis`, `/use-skill:alice/btc-momentum`) — not just the name half. Templates can be published by any user, not only the `alva/` namespace.
   - **Lenient matching on 404.** If the exact id doesn't exist, the agent runs `alva skills list` and looks for close matches case-insensitively / substring / separator-agnostic. One obvious candidate → proceed and tell the user the correction. Multiple → ask. None → show filtered catalog.
   - **Rewire** from filesystem (`skills/alva/templates/<name>/template.md`) to gateway (`alva skills get` + `alva skills file`). Blueprint convention `template.md`; falls back to `README.md` or asks if absent. Other files pulled progressively.
3. **Rename section heading** from "Choose Template" → "Choose Skill"; update all internal references including the anchor link from Capabilities back to this section.

No new "Catalog" section in Capabilities — the Choose Skill flow exercises every `alva skills` command inline, and `alva skills --help` covers the rest. Existing capability sections renumbered to fill the gap left by removing the old Template-specific Step 8.

Frontmatter `metadata.version: v1.7.0` → `v1.8.0`.

## Breaking Changes

**For agents/users:** the user-facing directive changes from `/use-template:<name>` → `/use-skill:<username>/<name>`. Cached pre-v1.8.0 SKILL.md will still respond to the old directive (reading from filesystem); `version_check.sh` surfaces the upgrade on next session.

## Database Migrations

None.

## Follow-up cleanup

Local `skills/alva/templates/<name>/` files are kept in this PR — to be removed in a follow-up once cached agents have rolled forward and catalog parity is confirmed.

## Merge Order

⚠️ **Merge LAST.** Both upstreams already merged ✅:
- alva-ai/alva-gateway#351 ✅
- alva-ai/toolkit-ts#51 ✅

Still pending: **`@alva-ai/toolkit@0.6.0` published to npm** — otherwise the `alva skills` commands now required by `/use-skill:` won't exist in the agent's installed CLI.

## Related

- alva-ai/alva-gateway#351 (gateway endpoint)
- alva-ai/toolkit-ts#51 (CLI rename + new playbook-skills surface)

## Test Plan

- [x] `grep -c "alva skills"` (data-skills context) = 0; `grep -c "alva data-skills"` = 7
- [x] `grep "use-template" SKILL.md` = 0
- [x] `/use-skill:` directive documented as full `<username>/<name>` form
- [x] Lenient-matching fallback path written (404 → list → case-insensitive substring → proceed/ask)
- [x] No "Playbook Skills (Catalog)" capability section; commands documented inline in Choose Skill
- [x] Capability section numbering: ALFS → JS Runtime → Data Skills → Altra → Deploy → Build → Release → Remix → Push (1–9, no gap)
- [x] `version: v1.8.0` in frontmatter
- [ ] After merge + npm publish: agent handling `/use-skill:alva/thesis` runs `alva skills get` + `file` end-to-end
- [ ] Smoke lenient matching: `/use-skill:Alva/AI-Digest` is corrected to `alva/ai-digest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)