### PR TITLE
docs(alva): release playbook --readme-url must be absolute ALFS path

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -681,21 +681,22 @@ above so anonymous viewers can load feed output without authentication.
    The CLI handles authentication automatically. See
    [screenshot.md](references/api/screenshot.md) for full parameter details.
 
-`alva release playbook` **requires** `--readme-url`. The flow is: first
-write the README to ALFS at `~/playbooks/{name}/README.md`, then pass
-that **same path** as `--readme-url` (quote it in the shell to prevent
-local `~` expansion):
+`alva release playbook` **requires** `--readme-url`, and it must be the
+absolute ALFS path `/alva/home/<username>/playbooks/<name>/README.md`
+(the relative `<name>/README.md` shorthand is **no longer accepted**).
+Resolve `<username>` once via `alva whoami`. The flow is: first write
+the README to ALFS, then pass the absolute path as `--readme-url`:
 
 ```bash
 alva fs write --path '~/playbooks/{name}/README.md' --file ./README.md --mkdir-parents
-alva release playbook ... --readme-url '~/playbooks/{name}/README.md'
+alva release playbook ... --readme-url '/alva/home/<username>/playbooks/{name}/README.md'
 ```
 
 Omitting the flag fails CLI argument parsing; passing any value other
-than the canonical README path fails server validation with
+than the absolute README path fails server validation with
 `InvalidArgument`. See
-[release.md](references/api/release.md#playbook-readme) for the absolute
-form, full validation rules, and the canonical content shape.
+[release.md](references/api/release.md#playbook-readme) for full
+validation rules and the canonical content shape.
 
 #### Pro users (`subscription_tier = "pro"`)
 
@@ -753,8 +754,9 @@ Before calling `alva release playbook`, verify all of the following:
    [Playbook README in release.md](references/api/release.md#playbook-readme)).
    Its source / cadence claims match the actual feed scripts and deployed
    cronjobs. The `--readme-url` flag must be passed on `alva release playbook`
-   and must match this exact path — preferred form is the relative ALFS
-   shorthand `~/playbooks/{name}/README.md` (quote it in the shell).
+   as the absolute ALFS path
+   `/alva/home/<username>/playbooks/{name}/README.md` (resolve `<username>`
+   via `alva whoami`); the relative shorthand is no longer accepted.
 
 ### 8. Remix (Create from Existing Playbook)
 
@@ -1096,8 +1098,9 @@ verify these prerequisites:
 4. **README check** (playbook only) — confirm `~/playbooks/{name}/README.md`
    exists in ALFS and follows the
    [Playbook README content shape](references/api/release.md#playbook-readme).
-   The publish call must pass `--readme-url '~/playbooks/{name}/README.md'`
-   (quoted to prevent local `~` expansion).
+   The publish call must pass `--readme-url` as the absolute ALFS path
+   `/alva/home/<username>/playbooks/{name}/README.md` (resolve `<username>`
+   via `alva whoami`); the relative shorthand is no longer accepted.
 
 If the build was interrupted and resumed, re-run this checklist from the top.
 Do not assume prior steps completed successfully.
@@ -1471,8 +1474,9 @@ alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashb
 alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
 
 # 4. Release playbook (reads HTML from ALFS, uploads to CDN, writes release files automatically).
-#    --readme-url is required and must match the README path written above.
-alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id":100}]' --changelog "Initial release" --readme-url '~/playbooks/btc-dashboard/README.md'
+#    --readme-url is required and must be the absolute ALFS path to the README
+#    written above (the relative shorthand is no longer accepted).
+alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id":100}]' --changelog "Initial release" --readme-url '/alva/home/alice/playbooks/btc-dashboard/README.md'
 # → {"playbook_id":99,"version":"v1.0.0","published_url":"https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html"}
 
 # After release, output the canonical share link to the user:

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -76,7 +76,7 @@ alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashb
 ## Release Playbook
 
 ```
-alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text" --readme-url '~/playbooks/NAME/README.md'
+alva release playbook --name NAME --version VERSION --feeds '[{"feed_id":100}]' --changelog "text" --readme-url '/alva/home/<username>/playbooks/NAME/README.md'
 ```
 
 Release an existing playbook for public hosting. Reads the playbook HTML from
@@ -96,7 +96,7 @@ README, and the server validates the value against a fixed convention (see
 | --version    | string | yes      | SemVer (e.g. `v1.0.0`)                                                                     |
 | --feeds      | array  | yes      | Feed references `[{feed_id, feed_major?}]`                                                 |
 | --changelog  | string | yes      | Release changelog                                                                          |
-| --readme-url | string | yes      | Owner-attested README location. See [Playbook README](#playbook-readme) for accepted forms. |
+| --readme-url | string | yes      | Owner-attested README location. Must be the absolute ALFS path — see [Playbook README](#playbook-readme). |
 
 Feed reference fields:
 
@@ -109,8 +109,9 @@ Feed reference fields:
 # 1. Write README to ALFS first (see Playbook README below for content shape).
 alva fs write --path '~/playbooks/btc-dashboard/README.md' --file ./README.md --mkdir-parents
 
-# 2. Then release, passing the same ALFS path you wrote to as --readme-url.
-alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release" --readme-url '~/playbooks/btc-dashboard/README.md'
+# 2. Then release, passing the absolute ALFS path as --readme-url.
+#    Resolve <username> via `alva whoami` (here: alice).
+alva release playbook --name btc-dashboard --version v1.0.0 --feeds '[{"feed_id": 100, "feed_major": 1}]' --changelog "Initial release" --readme-url '/alva/home/alice/playbooks/btc-dashboard/README.md'
 → {"playbook_id": 99, "version": "v1.0.0", "published_url": "https://alice.playbook.alva.ai/btc-dashboard/v1.0.0/index.html", "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"}
 ```
 
@@ -125,25 +126,23 @@ HTML's "How does this work?" / methodology modal renders the same content,
 so there is one source of truth — the README — not a separate per-template
 copy.
 
-### Path and `--readme-url` forms
+### Path and `--readme-url` form
 
-The flow is: **first** write the README to ALFS, **then** pass that same
-ALFS path verbatim as `--readme-url`. The server does not write the file —
-it only validates that the value matches the canonical README location.
+The flow is: **first** write the README to ALFS at
+`~/playbooks/<name>/README.md`, **then** pass the **absolute** ALFS path
+as `--readme-url`. The server does not write the file — it only
+validates that the value matches the canonical README location.
 
-The server accepts two forms for `--readme-url`:
+`--readme-url` accepts exactly one form:
 
-1. **Relative** (preferred): `~/playbooks/<name>/README.md` — e.g.
-   `~/playbooks/btc-dashboard/README.md`. This matches the same `~/playbooks/...`
-   shorthand used by `alva fs write`, so the publish call mirrors the path
-   you wrote to. Quote it in the shell (`'~/playbooks/<name>/README.md'`)
-   to prevent local `~` expansion.
-2. **Absolute**: `/alva/home/<username>/playbooks/<name>/README.md` — e.g.
-   `/alva/home/alice/playbooks/btc-dashboard/README.md`. Use this only
-   when hard-coding the username is unavoidable (e.g. cross-user references).
+- `/alva/home/<username>/playbooks/<name>/README.md` — e.g.
+  `/alva/home/alice/playbooks/btc-dashboard/README.md`. Resolve
+  `<username>` once via `alva whoami` and pass the path verbatim
+  (no `~` expansion, no relative shorthand).
 
-Both forms point to the same ALFS path. Any other value is rejected with
-`InvalidArgument`.
+The previously-accepted relative form `<name>/README.md` (and any
+`~/...` shorthand) is **no longer accepted**. Any other value is
+rejected with `InvalidArgument`.
 
 ### Content shape
 

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -148,7 +148,7 @@ and only then upload them. Do not write fresh files from scratch.
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
 8. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
-9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '~/playbooks/{new-name}/README.md'` (same ALFS path you wrote to in step 7; quote it to prevent local `~` expansion)
+9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'` (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative shorthand is no longer accepted)
 
 **Important**: The new playbook must use a unique name in your user space. The
 feed scripts must use **your own** ALFS paths (not the original owner's) for


### PR DESCRIPTION
## Summary
- Update SKILL.md release flow (step 7), pre-release validation checklist (item 4 and item 7), and the worked example to use `/alva/home/<username>/playbooks/<name>/README.md` for `--readme-url`.
- Update `references/api/release.md`: release-playbook example, flag table, and the "Path and --readme-url forms" section now describe a single accepted form (the absolute ALFS path) and call out that the relative shorthand and `~/...` form are rejected.
- Update `references/remix-workflow.md` step 9 to the absolute form.

## Breaking Changes
None at the docs level. The breaking change lives in alva-backend; these docs are catching up so agents stop hitting `InvalidArgument`.

## Database Migrations
None.

## Merge Order
None — docs follow the server contract; safe to merge whenever the alva-backend PR is merged. Merging this before the backend PR would briefly tell agents to use a form the production server still treats as equally valid alongside the (about-to-be-removed) relative form, which is harmless.

## Related
- alva-ai/alva-backend#1018 — server-side validator tightening (the source of truth)
- alva-ai/toolkit-ts#52 — CLI help / examples / tests updated to the absolute form

## Test Plan
- [x] `grep -rn -- "--readme-url" skills/alva/` shows only absolute paths
- [ ] Agent dry-run: follow the SKILL.md release flow end-to-end and confirm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)