### PR TITLE
docs(alva): describe free-tier one-playbook cap

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.8.1
+  version: v1.8.2
 ---
 
 # Alva
@@ -711,17 +711,39 @@ validation rules and the canonical content shape.
 
 #### Free users (`subscription_tier = "free"`)
 
+**One-playbook cap.** Free accounts may hold **at most one published
+playbook**. The cap is enforced server-side at release time — a second
+`alva release playbook` call will fail until the existing playbook is
+deleted by the user.
+
 1. **Publish directly**: Call `alva release playbook` — free playbooks
    are always public. Output the public URL:
    `https://alva.ai/u/<username>/playbooks/<playbook_name>`
-2. **Upsell only on friction**: Do **not** proactively suggest upgrading.
+2. **If the user already has a published playbook and wants to publish
+   a new one**, stop before calling `alva release playbook`. Tell the
+   user the existing playbook must be deleted first, and ask which path
+   they want:
+   - **Delete the old playbook** — direct the user to remove their
+     existing playbook from the Alva dashboard, then resume. Do not
+     attempt to "rename around" the cap, reuse the old playbook's
+     name without an explicit deletion, or assume any in-app replace
+     flow will migrate `display_name`, feeds, or cronjobs cleanly —
+     it currently does not, and the old public URL can end up showing
+     the new playbook's HTML with stale metadata.
+   - **Keep both** — only possible on Pro. Offer the upgrade path at
+     <https://alva.ai/pricing>.
+
+   After the user confirms the deletion, re-run the full release
+   pipeline (draft → README → release) for the new playbook from
+   scratch under a fresh `name`.
+3. **Upsell only on friction**: Do **not** proactively suggest upgrading.
    But when the user's experience is degraded because of free-tier
-   limitations — wanting private playbooks, hitting the cronjob cap,
-   resource limits, or any other pro-gated feature — acknowledge the
-   limitation and offer the upgrade path:
+   limitations — wanting private playbooks, hitting the one-playbook cap,
+   hitting the cronjob cap, resource limits, or any other pro-gated
+   feature — acknowledge the limitation and offer the upgrade path:
    "This feature is available on the Pro plan. You can upgrade at
    <https://alva.ai/pricing> to [specific benefit, e.g. keep playbooks
-   private / deploy more cronjobs / ...]."
+   private / publish multiple playbooks / deploy more cronjobs / ...]."
 
 Use the playbook `name` and the username from `alva whoami` to construct the
 canonical share URL. Use `published_url` from the release response for

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -739,11 +739,11 @@ deleted by the user.
 3. **Upsell only on friction**: Do **not** proactively suggest upgrading.
    But when the user's experience is degraded because of free-tier
    limitations — wanting private playbooks, hitting the one-playbook cap,
-   hitting the cronjob cap, resource limits, or any other pro-gated
-   feature — acknowledge the limitation and offer the upgrade path:
+   resource limits, or any other pro-gated feature — acknowledge the
+   limitation and offer the upgrade path:
    "This feature is available on the Pro plan. You can upgrade at
    <https://alva.ai/pricing> to [specific benefit, e.g. keep playbooks
-   private / publish multiple playbooks / deploy more cronjobs / ...]."
+   private / publish multiple playbooks / ...]."
 
 Use the playbook `name` and the username from `alva whoami` to construct the
 canonical share URL. Use `published_url` from the release response for


### PR DESCRIPTION
## Summary

- Document the free-tier one-playbook cap in `SKILL.md`: free accounts may hold at most one published playbook; the cap is enforced server-side at release time.
- Tell the agent to stop before re-issuing `alva release playbook` when the user already has a published playbook, and to walk the user through deleting it from the dashboard (or upgrading to Pro) instead of relying on any in-app replace flow.
- Note the replace-flow caveat: it currently does not migrate `display_name` / `draft.feeds` / cronjobs cleanly, so the old public URL can end up serving the new playbook's HTML with stale metadata (observed on `luna7peng/eth-btc-pairs`).
- Bump skill version v1.8.1 → v1.8.2.

## Test plan

- [ ] Skim the rendered `Free users` section in `SKILL.md` and confirm the cap, deletion-required-first wording, and the unchanged upsell guidance all read cleanly together.
- [ ] Confirm no other section references "Free users" / "one playbook" in a now-conflicting way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)