### PR TITLE
docs(alva): require explicit push subscriptions

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -591,17 +591,18 @@ strategies alike. If the feed produces `signal/targets`, it MUST use
 `FeedAltra`.
 
 **Push notification streams:** Subscriptions target feed/playbook resources,
-not output paths. The output path only chooses the notification event:
+not output paths. The output path only chooses the feed-alert source:
 
-| Output stream | Event | Use for | Recipients |
+| Output stream | Feed-alert source | Use for | Delivery eligibility |
 | --- | --- | --- | --- |
-| `signal/targets` | `playbook_data_ready` | Playbook/follower signals | Playbook followers and groups subscribed to the playbook |
-| `notify/message` | `feed_run_complete` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts | Feed owner and groups subscribed to the feed |
+| `signal/targets` | `signal/targets` | Playbook signals, trading targets, actionable alerts | Users or groups explicitly subscribed to the feed or to a playbook that references the feed |
+| `notify/message` | `notify/message` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts | Users or groups explicitly subscribed to the feed or to a playbook that references the feed |
 
 Rules:
 
-- Do not require `signal/targets` for feed group delivery. A group subscribed
-  to a feed can receive `feed_run_complete` from `notify/message`.
+- Both streams dispatch the canonical `feed_alert_ready` event. Do not use the
+  legacy names `playbook_data_ready` or `feed_run_complete` in new docs or
+  agent instructions.
 - A push-capable feed needs `--push-notify` and a feed release bound to the
   cronjob:
 
@@ -611,6 +612,14 @@ alva deploy create --name <feed> --path '~/feeds/<feed>/v1/src/index.js' \
 alva release feed --name <feed> --version 1.0.0 \
   --cronjob-id <ID_FROM_DEPLOY> --description "<one-sentence purpose>"
 ```
+
+- `--push-notify` only marks the feed publisher as capable of emitting alerts.
+  It does **not** subscribe any user or group, and it does not bypass
+  notification preferences.
+- Real delivery always requires an explicit subscription:
+  `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`,
+  `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`,
+  or a group `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
 
 Keep schema examples in [feed-sdk.md](references/feed-sdk.md) Patterns D/E.
 See **Step 9** below for the post-release subscription flow.
@@ -839,8 +848,10 @@ Present a concrete recommendation, not a generic "want push?":
 - **User requests push for a different feed** → honor their choice.
 
 If the feed already has the right push sidecar for the intended event
-(`signal/targets` for playbook signals, `notify/message` for feed completion)
-and `push_notify: true`, skip — it's already configured.
+(`signal/targets` for signal-style alerts, `notify/message` for feed
+completion / AlvaAsk reports) and `push_notify: true`, the publisher side is
+already configured. Still verify or create the user's/group's explicit
+subscription before claiming notifications are set up.
 
 #### Configure and verify
 
@@ -852,13 +863,18 @@ verification.
    `signal/targets` for playbook signals (Pattern D), or `notify/message` for
    feed completion / AlvaAsk reports (Pattern E).
 2. **Enable the flag on the cronjob:** `alva deploy update --id <ID> --push-notify`.
-3. **Verify a real run produced push content:** trigger a run (or wait for
+3. **Subscribe the delivery target:** for personal push use
+   `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`
+   or `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`;
+   for group push, run `/alva subscribe feed <id>` or
+   `/alva subscribe playbook <id>` in that group.
+4. **Verify a real run produced push content:** trigger a run (or wait for
    the next cron fire) and read `@last/1` of the configured sidecar. Confirm
    the record is fresh and the message body is non-empty.
-4. **Confirm to the user** with the specifics: which feed, what the next
-   push will say, when it will fire.
+5. **Confirm to the user** with the specifics: which feed/playbook is
+   subscribed, what the next push will say, and when it will fire.
 
-If Step 3 returns no record or an empty body, **do not claim push is set
+If Step 4 returns no record or an empty body, **do not claim push is set
 up** — diagnose (missing output write, wrong path, run failure) and fix
 before reporting success.
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -750,8 +750,9 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 
 `signal/targets` makes the feed push-capable, but delivery still requires the
 cronjob to be created or updated with `--push-notify` and the feed release to be
-bound to that cronjob. See `references/deployment.md` for the deploy/release
-flow.
+bound to that cronjob. Actual delivery also requires an explicit personal or
+group subscription to the feed or to a playbook that references it. See
+`references/deployment.md` for the deploy/release flow.
 
 ---
 

--- a/skills/alva/references/api/deploy-cronjob.md
+++ b/skills/alva/references/api/deploy-cronjob.md
@@ -26,12 +26,13 @@ alva deploy create \
 | --path        | string | yes      | Path to entry script (home-relative or absolute)                              |
 | --cron        | string | yes      | Standard cron expression (min interval: 1 minute)                             |
 | --args        | JSON   | no       | JSON passed to `require("env").args` on each execution                        |
-| --push-notify | flag   | no       | Enable push fanout after successful feed runs                                 |
+| --push-notify | flag   | no       | Let this cronjob emit feed alert events after successful feed runs            |
 
 When `--push-notify` is set, every successful execution checks the feed's push
-sidecars: `signal/targets` dispatches `playbook_data_ready`, while
-`notify/message` dispatches `feed_run_complete` to the owner and groups
-subscribed to that feed.
+sidecars: `signal/targets` and `notify/message` both dispatch
+`feed_alert_ready` with different feed-alert sources. Delivery still requires
+an explicit personal or group subscription to the feed or to a playbook that
+references the feed; `--push-notify` does not subscribe any user or group.
 
 Response:
 

--- a/skills/alva/references/api/notifications.md
+++ b/skills/alva/references/api/notifications.md
@@ -35,7 +35,7 @@ Each row:
 | Field       | Type   | Description                                          |
 | ----------- | ------ | ---------------------------------------------------- |
 | id          | string | Notification ID                                      |
-| event_type  | string | E.g. `playbook_data_ready`, `feed_run_complete`      |
+| event_type  | string | E.g. `feed_alert_ready`, `order_filled`              |
 | user_id     | string | Recipient user ID                                    |
 | channel     | string | Delivery channel                                     |
 | status      | string | `sent` / `failed` / `filtered`                       |
@@ -48,7 +48,7 @@ Each row:
 ```bash
 alva notifications list-playbook --username alice --name btc-dashboard --first 5
 # → {
-#     "items": [{"id":"24463","event_type":"feed_run_complete","status":"sent",
+#     "items": [{"id":"24463","event_type":"feed_alert_ready","status":"sent",
 #                "created_at":1777355703,"message":"...","feed_id":"8117", ...}, ...],
 #     "next_cursor": "MTc3NzM1NTU4MjIzOTc5NzoyNDQ1OA==",
 #     "playbook_path": "/alva/home/alice/playbooks/btc-dashboard"

--- a/skills/alva/references/api/push-subscriptions.md
+++ b/skills/alva/references/api/push-subscriptions.md
@@ -1,15 +1,15 @@
 # Push Subscriptions
 
-Personal opt-in for DM/web push. Independent of social follow:
-subscribe ≠ follow, unsubscribe ≠ unfollow. Following a playbook
-elsewhere compound-subscribes (and revives a previously-unsubscribed
-row).
+Personal opt-in for DM/web push. Notification preferences are the source of
+truth for delivery. Independent of social follow: subscribe ≠ follow,
+unsubscribe ≠ unfollow. Following a playbook does not create or revive a push
+subscription.
 
 Two target types:
 
-- **PLAYBOOK** — fires for any feed of that playbook.
+- **PLAYBOOK** — fires for alerts from feeds referenced by that playbook.
 - **FEED** — fires for that one feed; if it's used by multiple
-  playbooks (remix), one push per playbook context.
+  playbooks (remix), the caller still receives one push per feed alert.
 
 Auth: caller must be able to read the target (gated upstream).
 
@@ -63,4 +63,5 @@ Row shape: `{ target: {type, id}, subscribed, created_at_ms, updated_at_ms }`.
   requires `active_channel` to be `telegram` or `discord` with the matching
   `telegram_username` or `discord_username` set.
 - Producer side (making a feed *capable* of pushing) is separate — see
-  Section 9 of SKILL.md and `--push-notify` on `alva deploy`.
+  Section 9 of SKILL.md and `--push-notify` on `alva deploy`. Enabling
+  `--push-notify` does not subscribe any user or group.

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -39,12 +39,14 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 | --cron          | string | yes      | Standard cron expression                               |
 | --name          | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
 | --args          | JSON   | no       | JSON passed to `require("env").args` on each execution |
-| --push-notify   | flag   | no       | Enable push fanout after successful feed runs          |
+| --push-notify   | flag   | no       | Let this cronjob emit feed alert events after successful feed runs |
 
-When `--push-notify` is set, every successful cronjob execution triggers a
-notification fanout. `signal/targets` dispatches `playbook_data_ready`;
-`notify/message` dispatches `feed_run_complete` to the owner and any groups
-subscribed to that feed.
+When `--push-notify` is set, every successful cronjob execution checks the
+feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
+canonical `feed_alert_ready` event with different feed-alert sources. Delivery
+still requires an explicit personal or group subscription to the feed or to a
+playbook that references the feed; `--push-notify` does not subscribe the
+owner, any user, or any group.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -164,11 +164,12 @@ Read `@last/N` (where N >= batch size) to get the most recent batch.
 
 ### Pattern D: Signal / Playbook Push Notification
 
-For feeds that produce actionable signals worth pushing to playbook followers
-or groups subscribed to a playbook. Write signal records to the **`signal`**
-group with a **`targets`** output -- the resulting path
-`~/feeds/{name}/v{major}/data/signal/targets` is the convention the platform
-reads when dispatching the `playbook_data_ready` notification event.
+For feeds that produce actionable signals worth pushing to users or groups
+that explicitly subscribed to the feed, or to a playbook that references the
+feed. Write signal records to the **`signal`** group with a **`targets`**
+output -- the resulting path
+`~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
+when dispatching the canonical `feed_alert_ready` notification event.
 
 The target format follows the same structure used by Altra trading strategies:
 
@@ -216,16 +217,22 @@ await feed.run(async (ctx) => {
 });
 ```
 
-When this feed runs as a cronjob, the platform reads
-`/data/signal/targets` and dispatches the signal content as
-`playbook_data_ready` to eligible playbook notification targets. Telegram
-delivery chunks long messages at the platform's per-message limit; the feed SDK
-does not require a 500-character summary.
+When this feed runs as a cronjob with `--push-notify`, the platform reads
+`/data/signal/targets` and dispatches the signal content as `feed_alert_ready`
+to eligible feed/playbook notification subscriptions. Telegram delivery chunks
+long messages at the platform's per-message limit; the feed SDK does not
+require a 500-character summary.
 
 **Key points:**
 
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
+- `--push-notify` and `alva release feed --cronjob-id ...` only make the feed
+  publisher capable of emitting alerts. They do **not** subscribe any user or
+  group.
+- Real delivery requires an explicit subscription: personal
+  `alva push-subscriptions subscribe-feed` / `subscribe-playbook`, or group
+  `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
 - Use `meta.reason` to provide the push-notification body -- this is what
   recipients see when the signal is delivered.
 - `meta.reason` is **Markdown**. Write it as the push body itself, using
@@ -251,10 +258,9 @@ as a feed completion notification. Common use cases: scheduled market reports,
 periodic research summaries, heartbeat monitoring, and proactive alerts.
 
 Write the agent's response to the **`notify`** group with a **`message`**
-output. When the cronjob completes, the platform reads this path and dispatches
-`feed_run_complete` to the feed owner via Web and any active IM channel, and
-to groups subscribed to this feed with
-`/alva subscribe feed <feed_id>`.
+output. When the cronjob completes with `--push-notify`, the platform reads
+this path and dispatches `feed_alert_ready` to users or groups that explicitly
+subscribed to the feed, or to a playbook that references the feed.
 
 ```javascript
 const { ask } = require("@alva/alvaask");
@@ -307,10 +313,14 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - `text` is the notification body (required for content push).
 - **`alva release feed` is required** — without it, push notifications
   will not be delivered.
-- Does **not** require a playbook or followers for owner delivery — works for
-  any feed. Group delivery requires the group to subscribe to that feed.
+- `--push-notify` only enables publisher-side fanout. It does **not** create
+  personal or group subscriptions.
+- Real delivery requires an explicit subscription: personal
+  `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`
+  or `subscribe-playbook`, or group `/alva subscribe feed <feed_id>` /
+  `/alva subscribe playbook <playbook_id>`.
 - Combine with Pattern D if you want both feed completion notifications and
-  playbook/follower signal notifications.
+  signal-style notifications.
 
 ### Deduplication
 

--- a/skills/alva/references/language.md
+++ b/skills/alva/references/language.md
@@ -16,7 +16,7 @@ pipeline job, worker.
 
 **Playbook**
 A hosted investing app on Alva that shows analysis, dashboards, screeners, or
-trading signals to the user and their followers.
+trading signals to the user and explicitly subscribed viewers.
 _Avoid_: app, report (unless the playbook is literally a report).
 
 **Alert / Notification**

--- a/skills/alva/templates/ai-digest/example/index.html
+++ b/skills/alva/templates/ai-digest/example/index.html
@@ -463,7 +463,7 @@
     { "type": "podcast", "query": "semiconductor supply chain", "lookback_hours": 168 }
   ],
   "cadence": { "mode": "digest", "cron": "0 12 * * *", "quiet_day_policy": "ping" },
-  "audience": "followers",
+  "audience": "playbook",
   "angle": "Focus on macro supply-chain disruption and capacity signals. Opinionated — tell the reader what to watch next, not just what happened. Every factual claim must cite its source. No buy/sell/price targets.",
   "output_style": { "length": "medium", "tone": "opinionated", "must_cite": true, "model": "claude-sonnet-4-6" },
   "relevance_filter": { "mode": "hybrid", "semantic_model": "claude-haiku-4-5", "batch_size": 15 },

--- a/skills/alva/templates/ai-digest/template.md
+++ b/skills/alva/templates/ai-digest/template.md
@@ -6,8 +6,8 @@ either a rough topic or a full source plan; the agent researches the topic,
 drafts a `CONFIG`, selects the smallest useful set of Alva search/feed/data inputs,
 runs on cron, generates an opinionated grounded take via `@alva/alvaask`, and
 pushes it through Alva notifications (via `signal/targets` for
-playbook/follower signals, or `notify/message` for feed completion
-notifications to the owner and feed-subscribed groups). The HTML playbook is a
+playbook-scoped subscribers, or `notify/message` for feed-style subscribers).
+The HTML playbook is a
 **light feed-stream
 replay** of past pushes — not an analytical dashboard.
 
@@ -128,7 +128,7 @@ that materially affect the feed:
 | Topic boundary | What should this track, and what should it exclude? | Prevents broad keyword slop. |
 | Sources | Optional but useful: paste sources you already trust — RSS feeds, newsletters, podcasts, YouTube channels, websites, X handles, subreddits, upstream Alva feeds, or plain text source names. If skipped, the agent researches a source plan first. | Makes the digest match the user's actual information diet, and chooses `unified_search` vs `feed_widgets` and adapters. |
 | Cadence / trigger | How often should it summarize or check? For thresholds, what exact condition matters? | Sets cron and materiality. |
-| Audience | Playbook signal or feed notification? | Chooses `signal/targets` for playbook/follower signals or `notify/message` for owner plus feed-subscribed groups. |
+| Audience | Playbook-scoped or feed-scoped notification? | Chooses `signal/targets` for signal-style alerts or `notify/message` for feed-style digests. Either path still requires an explicit push subscription. |
 | Angle | What kind of take should the update have? | Drives the generation prompt and voice. |
 | Worth-pushing bar | What counts as material enough to notify? | Reduces noisy pushes. |
 
@@ -199,8 +199,9 @@ Default assumptions for the skip path:
   `mode: "watch"` with a tighter cron. Do not ask the user to choose a mode.
 - `quiet_day_policy`: `"ping"` for paid/subscriber-facing briefs where silence
   is confusing; `"skip"` for noisy topics where no-news days should stay quiet.
-- `audience`: `"followers"` for playbook/follower signals; `"owner"` for
-  feed completion notifications using `notify/message`.
+- `audience`: `"playbook"` for playbook-scoped signal alerts; `"feed"` for
+  feed-scoped completion/digest alerts using `notify/message`. Both require
+  explicit personal or group subscription after deploy.
 - `angle`: opinionated, but no buy/sell/hold calls, no price targets, no
   uncited numerical claims.
 
@@ -273,7 +274,7 @@ const CONFIG = {
     quiet_day_policy: "ping",        // "ping" (default) | "skip"
   },
 
-  audience: "followers",             // "followers" = signal/targets; "owner" = notify/message to owner + feed-subscribed groups
+  audience: "playbook",              // "playbook" = signal/targets; "feed" = notify/message; both require explicit subscriptions
 
   push_policy: {
     materiality: `Push when there is a fresh supply-chain disruption,
@@ -445,9 +446,9 @@ remixers all agree on what an AI Digest event looks like.
   digest/
     events/    ← append-only, one record per cron fire (pushed OR skipped)
   signal/
-    targets/   ← written WHEN pushed AND audience="followers" (Pattern D)
+    targets/   ← written WHEN pushed AND audience="playbook" (Pattern D)
   notify/
-    message/   ← written WHEN pushed AND audience="owner"    (Pattern E)
+    message/   ← written WHEN pushed AND audience="feed"     (Pattern E)
 ```
 
 `digest/events` is the **source of truth** for the HTML timeline.
@@ -483,9 +484,9 @@ Retro analysis of quiet periods needs a record. The HTML timeline can show
 skipped fires dimmed-and-collapsed for author-facing transparency. **Append
 always; let `delivery.pushed` drive rendering.**
 
-### `signal/targets` (playbook/follower signals) — Altra format
+### `signal/targets` (playbook-scoped signals) — Altra format
 
-When `audience: "followers"`, also append one record to `signal/targets` per
+When `audience: "playbook"`, also append one record to `signal/targets` per
 pushed fire. Format follows Altra's target schema (see `references/feed-sdk.md`
 Pattern D); the platform reads `meta.reason` as the push body. Telegram delivery
 chunks long messages at the platform message limit, so do not impose an
@@ -513,15 +514,16 @@ await ctx.self.ts("signal", "targets").append([{
 > `signal/targets` works end-to-end with `--push-notify` — we verified in
 > v1 testing. **Use plain `Feed` for AI Digest playbooks.** If your
 > environment later enforces the FeedAltra rule at the platform layer,
-> switch `audience` to `"owner"` and write to `notify/message` (Pattern E)
+> switch `audience` to `"feed"` and write to `notify/message` (Pattern E)
 > — that path is never FeedAltra-gated.
 
 ### `notify/message` (feed completion notification) — title + text
 
-When `audience: "owner"`, write to `notify/message` instead. No FeedAltra
-requirement; plain `Feed` suffices. Despite the historical `owner` label in
-this template, `notify/message` dispatches `feed_run_complete`: the feed owner
-receives it directly, and groups subscribed to the feed can receive it too.
+When `audience: "feed"`, write to `notify/message` instead. No FeedAltra
+requirement; plain `Feed` suffices. `notify/message` dispatches the canonical
+`feed_alert_ready` event, but it does not auto-deliver to the feed owner. The
+owner, any other user, or any group must explicitly subscribe to the feed or to
+a playbook that references the feed.
 
 ```javascript
 const PLAYBOOK_URL = "https://<user>.playbook.alva.ai/<playbook>/<version>/index.html";
@@ -1030,16 +1032,16 @@ function fitMeaningfulPoints(points, budget) {
 }
 ```
 
-Follower push rendering currently wraps `meta.reason` with the playbook name and
+Signal push rendering currently wraps `meta.reason` with the playbook name and
 may convert Markdown to Telegram HTML downstream. That wrapper is acceptable;
 the digest content itself should remain the same canonical body. Avoid
 semicolon-delimited mini-summaries in `meta.reason`, because the generic signal
 renderer treats semicolons as bullet separators for trading-style reasons.
 
-For `audience: "followers"` the output is the `meta.reason` of a
-`signal/targets` record (§6). For `audience: "owner"` it's the `text` of a
-`notify/message` record with `title = "${CONFIG.topic.name} · <date EST>"`;
-that feed event can also fan out to groups subscribed to the feed.
+For `audience: "playbook"` the output is the `meta.reason` of a
+`signal/targets` record (§6). For `audience: "feed"` it's the `text` of a
+`notify/message` record with `title = "${CONFIG.topic.name} · <date EST>"`.
+Both paths require an explicit subscription before delivery.
 
 ### When to skip pushing
 
@@ -1070,7 +1072,19 @@ alva release feed --name <playbook-name> --version 1.0.0 \
 ```
 
 See `references/feed-sdk.md` Patterns D and E for the full release flow;
-the release step is mandatory or pushes arrive empty.
+the release step is mandatory or pushes arrive empty. Then subscribe the
+delivery target explicitly:
+
+```bash
+# Personal feed-scoped delivery.
+alva push-subscriptions subscribe-feed --username <user> --name <feed-name>
+
+# Personal playbook-scoped delivery.
+alva push-subscriptions subscribe-playbook --username <user> --name <playbook-name>
+```
+
+For group delivery, run `/alva subscribe feed <feed_id>` or
+`/alva subscribe playbook <playbook_id>` in the target group.
 
 ---
 

--- a/skills/alva/templates/thesis/example/feeds/ai-bottleneck-narrative.js
+++ b/skills/alva/templates/thesis/example/feeds/ai-bottleneck-narrative.js
@@ -32,7 +32,7 @@ feed.def("narrative", {
 });
 
 feed.def("signal", {
-  targets: makeDoc("Hero Push", "Daily hero digest for playbook followers", [
+  targets: makeDoc("Hero Push", "Daily hero digest for subscribed playbook viewers", [
     obj("instruction", [
       str("type"),
       arr("weights", [ str("symbol"), num("weight") ]),
@@ -376,7 +376,7 @@ function clampEnum(val, enumMap, fallback){
     function highCount(arr){ return (arr||[]).filter((r)=> r.priority === 'High').length; }
     // Per template v1.6.2: push fires on strict INCREASE of risks.length or
     // High-priority count. Decreases do not trigger a push (the thesis
-    // improving shouldn't spam followers).
+    // improving shouldn't spam subscribers).
     const catalystFlipped = prior && catalystSig(catalysts) !== catalystSig(priorCatalysts);
     const riskCountChanged = prior && risks.length > priorRisks.length;
     const highChanged = prior && highCount(risks) > highCount(priorRisks);


### PR DESCRIPTION
## Summary
- update Alva push docs so --push-notify is publisher capability only
- document feed_alert_ready as the canonical event for signal/targets and notify/message
- make ai-digest templates use explicit playbook/feed subscription terminology

## Tests
- docs only; not run