### PR TITLE
docs(alva): rename notification history docs

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -917,7 +917,7 @@ Reference docs:
 - [Playbook Comments](references/api/playbook-comment.md) — `alva comments`
 - [Screenshot](references/api/screenshot.md) — `alva screenshot`
 - [Trading](references/api/trading.md) — `alva trading`
-- [Notifications](references/api/notifications.md) — `alva notifications`
+- [Notification History](references/api/notification-history.md) — `alva notification-history`
 - [Push Subscriptions](references/api/push-subscriptions.md) — `alva push-subscriptions`
 - [Error Responses](references/api/error-responses.md)
 

--- a/skills/alva/references/api/deploy-cronjob.md
+++ b/skills/alva/references/api/deploy-cronjob.md
@@ -26,7 +26,7 @@ alva deploy create \
 | --path        | string | yes      | Path to entry script (home-relative or absolute)                              |
 | --cron        | string | yes      | Standard cron expression (min interval: 1 minute)                             |
 | --args        | JSON   | no       | JSON passed to `require("env").args` on each execution                        |
-| --push-notify | flag   | no       | Let this cronjob emit feed alert events after successful feed runs            |
+| --push-notify | flag   | no       | Let successful feed runs emit feed alert events                              |
 
 When `--push-notify` is set, every successful execution checks the feed's push
 sidecars: `signal/targets` and `notify/message` both dispatch
@@ -92,8 +92,8 @@ alva deploy update --id 42 --cron "0 */2 * * *"
 | ----------------- | ------ | -------------------------------- |
 | --cron            | string | Update schedule                  |
 | --args            | JSON   | Update arguments                 |
-| --push-notify     | flag   | Enable push notification         |
-| --no-push-notify  | flag   | Disable push notification        |
+| --push-notify     | flag   | Enable feed alert emission       |
+| --no-push-notify  | flag   | Disable feed alert emission      |
 
 ## Delete Cronjob
 

--- a/skills/alva/references/api/notification-history.md
+++ b/skills/alva/references/api/notification-history.md
@@ -1,16 +1,17 @@
-# Notifications
+# Notification History
 
-Read the caller's notification history scoped to a playbook or feed.
-Cursor pagination over `(created_at, id)`.
+Read the caller's notification delivery history scoped to a playbook or feed.
+This is an audit surface, not a subscription toggle. Cursor pagination is over
+`(created_at, id)`.
 
-## List Playbook Notifications
+## List Playbook History
 
 ```bash
-alva notifications list-playbook --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
+alva notification-history list-playbook --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
 ```
 
-Returns notifications sent to the caller for `(username, name)`. The
-playbook must be `public` or `paid`.
+Returns notification events for the caller and `(username, name)`. The playbook
+must be `public` or `paid`.
 
 | Flag       | Type   | Required | Description                                |
 | ---------- | ------ | -------- | ------------------------------------------ |
@@ -46,7 +47,7 @@ Each row:
 | feed_id     | string | Present when notification is feed-scoped             |
 
 ```bash
-alva notifications list-playbook --username alice --name btc-dashboard --first 5
+alva notification-history list-playbook --username alice --name btc-dashboard --first 5
 # → {
 #     "items": [{"id":"24463","event_type":"feed_alert_ready","status":"sent",
 #                "created_at":1777355703,"message":"...","feed_id":"8117", ...}, ...],
@@ -55,10 +56,10 @@ alva notifications list-playbook --username alice --name btc-dashboard --first 5
 #   }
 ```
 
-## List Feed Notifications
+## List Feed History
 
 ```bash
-alva notifications list-feed --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
+alva notification-history list-feed --username USER --name NAME [--channel C] [--status S] [--since SEC] [--first N] [--cursor TOKEN]
 ```
 
 Same shape as above, scoped to a feed. Authorization is alfs read on
@@ -66,7 +67,7 @@ Same shape as above, scoped to a feed. Authorization is alfs read on
 instead of `playbook_path`.
 
 ```bash
-alva notifications list-feed --username alice --name btc-ema --first 5 --status sent
+alva notification-history list-feed --username alice --name btc-ema --first 5 --status sent
 # → {"items": [...], "next_cursor": "...", "feed_path": "/alva/home/alice/feeds/btc-ema"}
 ```
 

--- a/skills/alva/references/api/push-subscriptions.md
+++ b/skills/alva/references/api/push-subscriptions.md
@@ -27,16 +27,14 @@ alva push-subscriptions unsubscribe-feed     --username USER --name NAME
 | --username | yes      | Target owner's username                  |
 | --name     | yes      | URL-safe playbook or feed name           |
 
-All idempotent. Unsubscribe is soft (row preserved, `subscribed: false`)
-so re-subscribe restores seniority. Subscribe response includes the
-canonical alfs path (`playbook_path` or `feed_path`).
+All commands are idempotent. Subscribe response includes the subscription row
+and canonical ALFS path (`playbook_path` or `feed_path`).
 
 ```bash
 alva push-subscriptions subscribe-feed --username alice --name btc-ema-cross
 # → {
 #     "subscription": {
 #       "target": {"type": "FEED", "id": "8117"},
-#       "subscribed": true,
 #       "created_at_ms": 1777355703123,
 #       "updated_at_ms": 1777355703123
 #     },
@@ -47,13 +45,15 @@ alva push-subscriptions subscribe-feed --username alice --name btc-ema-cross
 ## List
 
 ```bash
-alva push-subscriptions list [--include-history]
+alva push-subscriptions list [--first N] [--cursor TOKEN]
 ```
 
-`--include-history` also returns rows the caller previously
-unsubscribed (default: active rows only).
+Returns the caller's currently active personal feed push subscriptions. Use
+`--first` and `--cursor` for cursor pagination.
 
-Row shape: `{ target: {type, id}, subscribed, created_at_ms, updated_at_ms }`.
+Row shape includes `target`, `created_at_ms`, `updated_at_ms`, `cursor`, and
+feed metadata when available (`feed_name`, `feed_status`, `last_pushed_at_ms`,
+`used_by`, `used_by_total`).
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Rename Alva notification delivery history docs from `notifications.md` to `notification-history.md`.
- Update the Alva skill index to point at `alva notification-history`.
- Refresh push subscription docs to match the current REST shape: no `subscribed` field, list uses `--first` / `--cursor`, and list rows include feed metadata.
- Clarify that `--push-notify` enables feed alert emission, not subscription.

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related
- alva-ai/toolkit-ts#55

## Test Plan
- [x] `rg -n 'subscribed|include-history|include_history|compound-subscribe|alva notifications|notifications\\.md|delivered notification|sent to the caller|Enable push notification|Disable push notification' skills/alva/SKILL.md skills/alva/references/api || true`\n- [x] `git diff --check`