### PR TITLE
docs(alva): document `alva feed delete`

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -912,6 +912,7 @@ Reference docs:
 - [Run](references/api/run.md) — `alva run`
 - [Deploy Cronjob](references/api/deploy-cronjob.md) — `alva deploy`
 - [Release](references/api/release.md) — `alva release`
+- [Feed](references/api/feed.md) — `alva feed`
 - [Remix](references/api/remix.md) — `alva remix`
 - [SDK](references/api/sdk.md) — `alva sdk`
 - [Playbook Comments](references/api/playbook-comment.md) — `alva comments`

--- a/skills/alva/references/api/feed.md
+++ b/skills/alva/references/api/feed.md
@@ -1,0 +1,45 @@
+# Feed
+
+Lifecycle management for already-released feeds. Use `alva release feed`
+to create them ([release.md](release.md)); use the commands here for the
+rest of the lifecycle. All commands are under `alva feed`.
+
+## Delete Feed
+
+```
+alva feed delete --id FEED_ID
+```
+
+Soft-delete a feed and all its active majors. Returns the deleted feed
+id on success.
+
+| Flag | Type | Required | Description |
+| --- | --- | --- | --- |
+| --id | int64 | yes | Numeric feed id (positive integer) |
+
+Cascade behavior:
+
+- All active `feed_majors` for the feed are soft-deleted in the same
+  database transaction as the feed row.
+- The producer cronjob attached to each major is removed best-effort
+  (Hatchet trigger removal is not transactional). If the cronjob removal
+  fails, the cronjob scavenger reconciles the leftover row on its next
+  sweep — no manual cleanup needed.
+
+Auth: the caller must own the feed (uid match), enforced by the
+backend. Calling on a feed you do not own returns
+`{"error":{"code":"PERMISSION_DENIED",...}}`.
+
+```
+alva feed delete --id 100
+→ {"id": "100"}
+```
+
+Error responses follow the shared envelope in
+[error-responses.md](error-responses.md). Common cases:
+
+| HTTP | code | When |
+| --- | --- | --- |
+| 400 | `INVALID_ARGUMENT` | `--id` missing, non-numeric, zero, or negative |
+| 403 | `PERMISSION_DENIED` | feed exists but is owned by another user |
+| 404 | `NOT_FOUND` | no feed with that id exists |


### PR DESCRIPTION
## Summary
- Add `references/api/feed.md` documenting the new `alva feed delete --id <id>` command: flags, cascade behavior on `feed_majors` + producer cronjobs, ownership check, and the standard error envelope.
- Wire the new doc into the SKILL.md reference index.

Depends on alva-gateway PR #368 and toolkit-ts PR #56 for the actual command to exist.

## Test plan
- [x] markdown renders cleanly
- [ ] e2e: agent can `alva feed delete --id <id>` end-to-end once both upstream PRs ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)