### PR TITLE
[CI] Use self-hosted runners for Actions workflows

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
Updates `.github/workflows/*` to use `runs-on: self-hosted` instead of GitHub-hosted `ubuntu-*` / `Backend-ci` where those labels were set in this repository.

## Notes
- Reusable workflows under `alva-ai/cicd` / `ggsrc/public-ci` are unchanged by this PR.
- **jagent** / **sdkhub**: multi-OS matrix build checks were collapsed to a single self-hosted job (macOS matrix coverage removed).

## Checklist
- [ ] Confirm org self-hosted runners are online and labeled `self-hosted` (or adjust labels to match your runner registration).