### PR TITLE
docs(alva): always pass `--compress` in the screenshot step

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -700,17 +700,21 @@ above so anonymous viewers can load feed output without authentication.
    are silently skipped.
 4. **Screenshot**: Take a screenshot to verify the released playbook renders
    correctly from the deployed published URL (for example,
-   `https://<username>.playbook.alva.ai/<playbook_name>/v1.0.0/index.html`):
+   `https://<username>.playbook.alva.ai/<playbook_name>/v1.0.0/index.html`).
+   Always pass `--compress` (with `--compress-quality` / `--compress-max-width`
+   to shrink further) — PNG output is otherwise easily large enough to exceed
+   the 5 MB session upload cap:
 
    ```bash
-   alva screenshot --url <published_url> --out /tmp/screenshot.png
+   alva screenshot --url <published_url> --out /tmp/screenshot.png \
+     --compress --compress-quality 70 --compress-max-width 1280
    ```
 
    The CLI handles authentication automatically. Run `alva screenshot --help`
-   for `--selector`, `--xpath`, and compression flags. Before reading the
-   output, validate it is actually a PNG — a failed capture may save a JSON
-   error blob under the `.png` name, and reading that into the session
-   corrupts conversation history:
+   for `--selector` and `--xpath`. Before reading the output, validate it is
+   actually a PNG — a failed capture may save a JSON error blob under the
+   `.png` name, and reading that into the session corrupts conversation
+   history:
 
    ```bash
    head -c4 /tmp/screenshot.png | grep -q PNG || echo "SCREENSHOT_FAILED"


### PR DESCRIPTION
## Problem

[alva-ai/mono-meta#428](https://github.com/alva-ai/mono-meta/issues/428): the release-verification screenshot example captured a raw PNG, which easily exceeds the 5 MB session upload cap on full-page or high-DPI captures. The skill mentioned compression only obliquely (*"run `alva screenshot --help` ... for compression flags"*), so the agent didn't reach for it until after the capture had already failed to read.

## Change

In the release-verification screenshot step of `skills/alva/SKILL.md`:

- The example command now always passes `--compress` (with `--compress-quality` / `--compress-max-width`).
- A short note flags the size concern so the agent keeps those flags on.

Docs-only change. The CLI `--help` already documents the flags. Companion sandbox-image fix (pre-installing PIL) is out of scope — this is fix #2 of the two the issue proposes.

Refs alva-ai/mono-meta#428

🤖 Generated with [Claude Code](https://claude.com/claude-code)