### PR TITLE
feat(alva): per-ticker coverage-gap policy for financial-metrics

### DIFF
--- a/docs/changelogs/2026-05-14-screener-coverage-gap.md
+++ b/docs/changelogs/2026-05-14-screener-coverage-gap.md
@@ -1,0 +1,273 @@
+# Per-ticker coverage-gap policy (universal) + screener-template rendering contract
+
+Issue: https://github.com/alva-ai/mono-meta/issues/419
+
+## 1. Background
+
+A user-built screener (`ai-buildout-5x`, session
+`https://alva.ai/chat?id=2054655887044825088`) over a curated 35-name AI-
+exposed universe silently degraded 12 tickers to 50%-weight scoring (AI +
+Valuation factors only, dropping Growth + Margin) because
+`/api/v1/stocks/financial-metrics` returned `INVALID_PARAMETER: stock symbol
+not found` for those names on every metric attempted (48 total errors:
+12 unique tickers × `REVENUE_GROWTH_YOY_TTM` · `REVENUE_GROWTH_QOQ` ·
+`GROSS_MARGIN_MRQ` · `FCF_MARGIN_MRQ`).
+
+The failing tickers are real, publicly-traded, mid/small-cap US companies
+with full SEC coverage: AAOI, AEHR, AI, AMBA, BBAI, INDI, NNE, POET,
+POWI, POWL, SOUN, TDC. The user explicitly asked for *small-cap upside*;
+the silent degrade biased the ranking toward mid-caps (CRDO at $35B mcap
+won partly because the small-cap competitors were scored at half weight),
+with no UI surface telling the user which names were partially scored.
+
+**Relevant systems** — single submodule. The problem is **not screener-
+specific**: any playbook calling `/api/v1/stocks/financial-metrics` (thesis,
+what-if, ai-digest, custom) hits the same per-ticker coverage gap. Policy
+belongs in `SKILL.md` so every agent reaches it; only the *rendering surface*
+("Data Coverage Gap" UI card, `coverage_gap` field shape) is screener-template-
+specific.
+
+- `code/public/skills/skills/alva/SKILL.md` — has a "SDK Coverage Gaps"
+  section (line 369) for whole-domain gaps and a fail-fast rule (line 1027),
+  but nothing prescriptive for per-ticker partial coverage inside an
+  otherwise working endpoint. **This is where the policy + recipe goes.**
+- `code/public/skills/skills/alva/templates/screener/template.md` — frozen
+  Feed Contract, operational invariants, and template guidance. **Only
+  gets the screener-specific rendering contract** (`summary.coverage_gap`
+  field, "Data Coverage Gap" card location, methodology-disclosure rule)
+  with a one-line pointer to the canonical policy in SKILL.md.
+- `code/public/skills/skills/alva/templates/screener/example/feeds/inflection-screener-feed.js`
+  — the working example screener feed users copy from per `template.md:9`
+  ("Start from `example/` — do not rebuild from scratch"); inline
+  demonstration of the SKILL.md recipe.
+- `code/public/skills/skills/alva/templates/screener/example/index.html`
+  — renders rankings, summary, methodology modal; new "Data Coverage Gap"
+  card on Overview tab.
+
+**Constraints (validated in Phase 1)**:
+
+- `Feed error handling is fail-fast` (SKILL.md:1027) — applies to whole-
+  endpoint failures, not per-ticker partial coverage.
+- The example feed already hard-drops tickers via `_drop` flags
+  (`_drop = "insufficient_gm"` etc.) but never enters a "fallback compute"
+  branch and never emits a coverage-gap surface.
+- The example's universe is sourced from `/stocks/screener/financial-
+  metrics`, which excludes uncovered tickers by construction. So the
+  example never exercises the per-ticker-gap path — copies that switch
+  to a curated ticker list (the natural thematic-basket shape) inherit
+  no guidance.
+- The previously-attempted fallback path `/api/v1/stocks/financials/
+  income-statement` is wrong (returns `ROUTE_NOT_FOUND`). The correct
+  paths are `/api/v1/stocks/company/income-statements` and `/api/v1/
+  stocks/company/cashflow-statements`. Confirmed via
+  `arrays-data-api-equity-fundamentals` doc skill.
+
+**Premises (all validated by user in Phase 5; P1 revised in Phase 9)**:
+
+- P1: The root cause is missing **universal** policy in SKILL.md, not just
+  missing screener-template guidance. Any playbook calling
+  `financial-metrics` hits this — thesis, what-if, ai-digest, custom —
+  not only screener-shaped ones. Policy lives in SKILL.md; template only
+  carries the screener-specific rendering contract.
+- P2: Doing nothing leaves every future curated-list playbook (any
+  shape, not only screener) exposed to the same silent degrade.
+- P3: The fix layers on existing patterns (`_drop`, fail-fast, frozen
+  Feed Contract, existing "SDK Coverage Gaps" section in SKILL.md) — no
+  new abstraction.
+- P4: Single-submodule scope (`code/public/skills`). No service-side
+  code, no proto, no DB.
+
+## 2. End-to-End Behavior
+
+**Primary behavior (applies to any playbook, not just screeners).**
+When a feed queries `/api/v1/stocks/financial-metrics` for a ticker and
+the endpoint returns `INVALID_PARAMETER: stock symbol not found`
+(HTTP 400), the feed:
+
+1. Attempts a fallback compute from `/api/v1/stocks/company/income-
+   statements` + `/api/v1/stocks/company/cashflow-statements` for the
+   four canonical ratios derivable from raw statements
+   (`REVENUE_GROWTH_YOY_TTM`, `REVENUE_GROWTH_QOQ`, `GROSS_MARGIN_MRQ`,
+   `FCF_MARGIN_MRQ`).
+2. If the fallback succeeds, the ticker enters the ranked table with
+   full-weight scoring. Source attribution flips from `metrics_api` to
+   `fallback_computed` in a per-row provenance field so methodology
+   text can disclose the mix.
+3. If the fallback fails (statements endpoints also return error / empty
+   data / insufficient rows for the formula), the ticker is **excluded
+   from the ranked list / output entirely** and surfaced via a per-
+   template `coverage_gap` channel — never scored at reduced weight.
+   The channel shape is template-specific (screener: a `coverage_gap`
+   array on the `summary` group; thesis / what-if would have their own
+   shapes), but the policy of "exclude and surface, never silent
+   reweight" is universal and lives in SKILL.md.
+4. For the screener template, the example HTML renders excluded
+   tickers in a compact "Data Coverage Gap" card on the Overview tab
+   listing each ticker, the missing metrics, and the specific endpoints
+   that failed.
+
+**Variants and edge cases**:
+
+- *Some metrics covered, others gapped* (most common): fallback compute
+  fills only the missing ones; covered metrics keep their
+  `financial-metrics` source. Provenance is per-metric, not per-row.
+- *True pre-revenue (e.g. NNE)*: fallback returns `revenue = 0`. Growth
+  ratios are undefined (divide-by-zero) — exclude the ticker from
+  growth-weighted ranking but emit into `coverage_gap` with
+  `reason = "pre_revenue"`, distinct from `reason = "no_coverage"`.
+  This is the disclosure the issue's methodology request asks for.
+- *Statements endpoints also fail* (true upstream gap): exclude, log
+  in `coverage_gap` with `reason = "no_coverage"`.
+- *Universe-API screeners* (like the existing inflection example): the
+  universe-fetch step already excludes uncovered tickers, so the
+  fallback branch never fires. The policy is a no-op for them. Adding
+  it costs nothing.
+
+**Failure modes**:
+
+- Fail-fast invariant preserved: whole-endpoint failures (auth, 5xx,
+  schema drift) still throw and surface the failed run in the sandbox.
+  The new fallback branch is scoped to a specific error signature
+  (`INVALID_PARAMETER` + `stock symbol not found`) — broader failures
+  bypass the fallback and throw as today.
+- `summary.coverage_gap` MUST be present (`[]` when no gaps) so the UI
+  card renders deterministically.
+
+## 3. Findings
+
+**Existing code patterns to reuse**:
+
+- `_drop` exclusion pattern in `inflection-screener-feed.js:122-143` —
+  the new "exclude and report" branch attaches to the same loop, just
+  routes through fallback-attempt first.
+- `buildSeriesMap` (line 66) — its sort-by-`observed_at` convention is
+  what we need to mirror when ordering statement rows for TTM /
+  YoY / QoQ math.
+- Frozen Feed Contract field naming convention (`template.md:168-177`)
+  — new `coverage_gap` field follows the same snake_case + flat-shape
+  rules. `summary.delta` (line 200-205) is the existing precedent for
+  "summary-level array of strings/objects describing churn".
+- SKILL.md "SDK Coverage Gaps" section (line 369-378) for cross-linking;
+  this change is the per-ticker analogue of the existing whole-domain-
+  gap guidance.
+
+**Constraints and dependencies discovered**:
+
+- Verified live via Alva sandbox (Phase 4): all 12 failing tickers
+  return 200 with 6-8 quarters of data on both `company/income-
+  statements` and `company/cashflow-statements`. Real revenues match
+  public IR data (AAOI $151M, TDC $444M, POWL $296M, AMBA $100M, etc.).
+  NNE and POET correctly return $0 / minimal revenue — the data itself
+  distinguishes "no-coverage" from "pre-revenue" without the agent
+  having to guess.
+- The four canonical ratios are all derivable from documented response
+  fields: `revenue`, `cost_of_revenue` (→ `GROSS_MARGIN_MRQ`),
+  `gross_profit_ratio`; `operating_cash_flow` − `capital_expenditure`
+  divided by `revenue` (→ `FCF_MARGIN_MRQ`); 4-quarter rolling
+  `revenue` (→ `REVENUE_GROWTH_YOY_TTM`); current vs. prior quarter
+  `revenue` (→ `REVENUE_GROWTH_QOQ`).
+
+**Chosen approach (Approach A from Phase 6, scope revised in Phase 9)** —
+Policy + recipe in SKILL.md (universal); screener template carries only
+the rendering contract.
+
+*Alternatives rejected*: **Approach B** (promote fallback into a reusable `@alva/finance` helper) — defers because it expands scope to a backend repo and requires test infra for the formulas; premature without a second caller. **Approach C** (validate universe up-front, exclude uncovered tickers before scoring) — rejects because it relabels the silent-bias problem rather than solving it: in the reported session the user *wanted* the small-cap names that fail, so excluding them at the universe step is the same bad outcome with a different label.
+
+*Scope revision in Phase 9*: the original Approach A put the policy +
+recipe in `template.md`. User pushed back: not every playbook starts
+from the screener template, but every playbook reads SKILL.md. Policy
+moved to SKILL.md; template.md narrows to the screener-specific
+rendering contract.
+
+Scope of revised Approach A:
+
+**`SKILL.md` — policy + recipe (the main change)**:
+
+- Add a new subsection **"Per-Ticker Coverage Gaps"** under the existing
+  "SDK Coverage Gaps" section (line 369), covering:
+  - Error signature: `financial-metrics` returns HTTP 400 with
+    `INVALID_PARAMETER: stock symbol not found`.
+  - Operational invariant: **fallback-or-exclude, never silent
+    reweighting.**
+  - Fallback endpoints: `/api/v1/stocks/company/income-statements`
+    and `/api/v1/stocks/company/cashflow-statements`.
+  - Formulas for the four canonical ratios (`GROSS_MARGIN_MRQ`,
+    `FCF_MARGIN_MRQ`, `REVENUE_GROWTH_YOY_TTM`, `REVENUE_GROWTH_QOQ`)
+    in terms of raw statement fields.
+  - Exclude-and-surface requirement: each playbook MUST expose a
+    `coverage_gap` channel; exact shape is template-specific (see
+    each template's Feed Contract).
+  - `reason` taxonomy: `"no_coverage"` (both endpoints fail) vs.
+    `"pre_revenue"` (statements return `revenue == 0`). Methodology
+    text MUST use these labels verbatim — no conflating with
+    "speculative" or similar agent-invented categories.
+
+**`templates/screener/template.md` — screener rendering contract only**:
+
+- Extend the Feed Contract `summary` shape with `coverage_gap:
+  [{id, missing_metrics, reason, fallback_attempted}]` (frozen field).
+- Add "Data Coverage Gap" card to the Overview tab structural notes
+  (placement, when to render, when to hide if empty).
+- One-line pointer at the top of the new subsection: *"Policy and
+  recipe live in SKILL.md `Per-Ticker Coverage Gaps`. This section
+  only specifies the screener-template rendering shape."*
+- Methodology Modal section: one-paragraph rule that narrative copy
+  must label `coverage_gap` rows with `reason` verbatim — same as
+  SKILL.md's taxonomy, restated here because the Methodology Modal is
+  the surface most likely to be customized per-screener.
+
+**`templates/screener/example/feeds/inflection-screener-feed.js`** —
+inline demonstration of the SKILL.md recipe (~30 LOC):
+
+- Catch `INVALID_PARAMETER` on per-ticker `financial-metrics` calls
+  → call `company/income-statements` + `company/cashflow-statements`
+  → compute the four ratios from raw fields.
+- Failed-fallback tickers: emit into `summary.coverage_gap` with
+  `reason` set, never reach the ranked list.
+- Existing `_drop` path preserved as the broader exclusion mechanism.
+
+**`templates/screener/example/index.html`** — "Data Coverage Gap" card
+(~40 LOC): compact card on Overview tab, reads from
+`summary.coverage_gap`, hides when array is empty, uses existing
+movers-card chassis.
+
+**Risks and unknowns**:
+
+- *Risk*: TTM rolling math from raw statement rows can drift from
+  vendor TTM if the vendor handles non-calendar fiscal quarters
+  differently. Acceptable for `coverage_gap` rows (which today have
+  no value at all) but the recipe must call out: "rows scored via
+  fallback may differ marginally from rows scored via `financial-
+  metrics` for vendor-side adjustments". Surface this in methodology.
+- *Unknown* (out of scope, per Phase 3): why Arrays
+  `financial-metrics` lacks ticker-level coverage for AAOI / AMBA /
+  POWI specifically (they have decades of public IR data). Mentioned
+  here for trail; lives with whoever owns Arrays equity coverage.
+- *Risk*: agents copying the example may keep the fallback code but
+  skip the `coverage_gap` emission. Mitigation: make
+  `summary.coverage_gap` a *required* field on the screener `summary`
+  group schema (renderers check its presence) so silent-skip surfaces
+  as a missing-field error rather than a clean-but-wrong run.
+- *Risk* (non-screener templates): thesis / what-if / ai-digest don't
+  yet have a `coverage_gap` rendering surface, so SKILL.md's "exclude
+  and surface" requirement is currently unenforced for them — agents
+  could exclude without surfacing. Accepted for this change: the bug
+  reported in #419 is screener-shaped; other templates can adopt the
+  pattern when they next take a maintenance pass. The universal policy
+  in SKILL.md still tells those agents *not* to silent-reweight, which
+  is the primary harm.
+
+**Scope shape**: single-service (`code/public/skills` submodule). Touches
+four files; no service-side code, no proto, no DB, no other submodules.
+
+**Reference files for implementation**:
+
+- SKILL.md prose pattern: existing "SDK Coverage Gaps" section
+  (line 369-378) — new "Per-Ticker Coverage Gaps" subsection slots in
+  right after it, same numbered-list + invariant tone.
+- Feed Contract pattern: `skills/alva/templates/screener/template.md:168-220`
+  (frozen-field tables + record-shape blocks) — add `coverage_gap` alongside
+  `delta` in the `summary` record shape.
+- Feed code pattern to mirror: `skills/alva/templates/screener/example/feeds/inflection-screener-feed.js` itself (modify in place); follow its existing `arraysGet` / `buildSeriesMap` / `_drop` conventions.
+- HTML card pattern: existing Movers cards block in `skills/alva/templates/screener/example/index.html` — same chassis (chart-card / flag-card style), smaller, no chart.
+- No test pattern exists in this submodule (skills repo has no test infra) — verification is by running the example feed end-to-end against the live Arrays endpoints, which Phase 4 has already done for the fallback branch.

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -364,6 +364,79 @@ data-driven metrics.
    blocker.** Do not silently substitute with estimated or fabricated values
    marked `live: false`.
 
+### Per-Ticker Coverage Gaps
+
+The whole-domain rule above covers "the SDK has no coverage at all." This
+section covers the more common case: **a working endpoint that lacks
+coverage for specific tickers in an otherwise valid universe.** This is
+the silent-bias mode that bit the `ai-buildout-5x` screener — 12 of 35
+curated small/mid-cap names returned `INVALID_PARAMETER` from
+`/api/v1/stocks/financial-metrics` and the playbook quietly scored them
+at half weight without telling the user.
+
+Error signature:
+
+```
+HTTP 400
+{"success":false,"data":null,"error":{
+  "code":"INVALID_PARAMETER",
+  "message":"stock symbol not found: <TICKER>"
+}}
+```
+
+**Operational invariant — fallback-or-exclude, never silent reweighting.**
+When this signature appears on a per-ticker call, the feed MUST:
+
+1. **Attempt fallback compute from raw statements.** The four ratios
+   most commonly requested via `financial-metrics` are derivable from
+   `/api/v1/stocks/company/income-statements` and
+   `/api/v1/stocks/company/cashflow-statements`:
+
+   | Metric | Formula from raw fields |
+   |---|---|
+   | `GROSS_MARGIN_MRQ` | `gross_profit_ratio` (most-recent quarter row) |
+   | `FCF_MARGIN_MRQ` | `(operating_cash_flow − capital_expenditure) / revenue` (MRQ) |
+   | `REVENUE_GROWTH_YOY_TTM` | `sum(revenue, last 4 quarters) / sum(revenue, prior 4 quarters) − 1` |
+   | `REVENUE_GROWTH_QOQ` | `revenue(current_quarter) / revenue(prior_quarter) − 1` |
+
+   Both endpoints are part of `arrays-data-api-equity-fundamentals`;
+   look up the full schema with `alva data-skills endpoint
+   arrays-data-api-equity-fundamentals company-income-statements`.
+   Do not guess paths — the older path `/api/v1/stocks/financials/
+   income-statement` is wrong and returns `ROUTE_NOT_FOUND`.
+
+2. **If fallback succeeds**, the ticker enters the output at full weight.
+   Track per-metric provenance so methodology copy can disclose the mix
+   (e.g. `source ∈ {"metrics_api", "fallback_computed"}`).
+
+3. **If fallback fails** (statements endpoints also return error / empty
+   data / insufficient rows for the formula), **exclude the ticker from
+   the ranked output entirely** and surface it in a `coverage_gap`
+   channel — never include it at reduced weight. The channel shape is
+   template-specific (the screener template defines a `summary.coverage_gap`
+   array; other templates can define their own surfaces — see each
+   template's Feed Contract). What is universal is the policy.
+
+**`reason` taxonomy** — exactly two values, both load-bearing:
+
+- `"no_coverage"` — both `financial-metrics` and the statements
+  fallback failed. True upstream data gap.
+- `"pre_revenue"` — statements returned data but `revenue == 0` for
+  all available quarters (e.g. NNE, early-stage POET). Growth ratios
+  are mathematically undefined; ranking on growth would be a category
+  error.
+
+Methodology / narrative copy MUST use these labels verbatim. **Never
+invent categories like "speculative tail" that conflate
+`no_coverage` with `pre_revenue`** — they are different failure modes
+(missing data vs. real $0 revenue) and lumping them misleads users
+who are making allocation decisions.
+
+This rule scopes the fail-fast invariant (line 1027): whole-endpoint
+failures (auth, 5xx, schema drift) still throw. Only the specific
+per-ticker `INVALID_PARAMETER: stock symbol not found` signature
+triggers the fallback branch.
+
 ### Release Gate: `--feeds` Is a Declaration, Not a Shortcut
 
 `alva release playbook --feeds '[]'` is **only** valid when the released HTML

--- a/skills/alva/templates/screener/example/feeds/inflection-screener-feed.js
+++ b/skills/alva/templates/screener/example/feeds/inflection-screener-feed.js
@@ -14,7 +14,7 @@
 // Universe: US mid caps via screener (MARKET_CAP $5B–$50B).
 // Hard filter: rev_growth > 0, ≥4 gm quarters, gm acceleration in ≥2 of last 4.
 
-const { Feed, feedPath, makeDoc, num, str } = require("@alva/feed");
+const { Feed, feedPath, makeDoc, num, str, arr } = require("@alva/feed");
 const http = require("net/http");
 const secret = require("secret-manager");
 const envMod = require("env");
@@ -32,6 +32,24 @@ async function arraysGet(path, params) {
   const r = await http.fetch(url, { headers: ARRAYS_HEADERS });
   if (r.status < 200 || r.status >= 300) throw new Error("HTTP " + r.status + " " + path);
   return JSON.parse(await r.text());
+}
+
+// Non-throwing variant for the specific per-ticker INVALID_PARAMETER signature.
+// Whole-endpoint failures (auth, 5xx, schema drift) still throw — preserves
+// fail-fast. See SKILL.md "Per-Ticker Coverage Gaps".
+async function arraysGetMaybe(path, params) {
+  const qs = Object.keys(params)
+    .filter((k) => params[k] !== undefined && params[k] !== null && params[k] !== "")
+    .map((k) => encodeURIComponent(k) + "=" + encodeURIComponent(params[k]))
+    .join("&");
+  const url = ARRAYS_BASE + path + (qs ? "?" + qs : "");
+  const r = await http.fetch(url, { headers: ARRAYS_HEADERS });
+  const body = JSON.parse(await r.text());
+  if (r.status === 400 && body && body.error && body.error.code === "INVALID_PARAMETER") {
+    return { ok: false, body };
+  }
+  if (r.status < 200 || r.status >= 300) throw new Error("HTTP " + r.status + " " + path);
+  return { ok: true, body };
 }
 
 const _args = envMod.args || {};
@@ -55,6 +73,7 @@ feed.def("screener", {
     str("topSector"), str("lastUpdated"),
     num("basketGmDeltaP75"), num("basketRevGrowthP25"),
     num("basketGmDeltaValidCount"), num("basketRevGrowthValidCount"),
+    arr("coverage_gap", [str("id"), str("missing_metrics"), str("reason"), str("fallback_attempted")]),
   ]),
   klines: makeDoc("Daily OHLCV", "60-day daily candlestick bars for top-40 tickers", [
     str("ticker"), num("open"), num("high"), num("low"), num("close"), num("volume"),
@@ -77,6 +96,30 @@ function buildSeriesMap(data) {
 }
 
 function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+
+// Fallback compute: when /financial-metrics has no coverage for a ticker, try
+// to derive the metric from raw quarterly income statements. Demonstrates the
+// pattern in SKILL.md "Per-Ticker Coverage Gaps". Returns one of:
+//   { ok: true,  series: [{observed_at, value}, ...] }    → injectable into gmMap
+//   { ok: false, reason: "no_coverage" | "pre_revenue", attempted: [...] }
+// Only handles GROSS_MARGIN_MRQ here; extend with other ratios per SKILL.md.
+async function fallbackGrossMargin(ticker, startSec, endSec) {
+  const attempted = ["/api/v1/stocks/company/income-statements"];
+  const r = await arraysGetMaybe("/api/v1/stocks/company/income-statements", {
+    symbol: ticker, start_time: startSec, end_time: endSec,
+    period_type: "quarter", time_type: "CALENDAR_END_DATE",
+  });
+  if (!r.ok) return { ok: false, reason: "no_coverage", attempted };
+  const rows = (r.body.data || []).slice().sort((a, b) => a.observed_at - b.observed_at);
+  if (rows.length < 4) return { ok: false, reason: "no_coverage", attempted };
+  const anyRevenue = rows.some(x => x.revenue && x.revenue > 0);
+  if (!anyRevenue) return { ok: false, reason: "pre_revenue", attempted };
+  const series = rows
+    .filter(x => x.gross_profit_ratio != null)
+    .map(x => ({ observed_at: x.observed_at, value: x.gross_profit_ratio }));
+  if (series.length < 4) return { ok: false, reason: "no_coverage", attempted };
+  return { ok: true, series };
+}
 
 (async () => {
   await feed.run(async (ctx) => {
@@ -114,6 +157,29 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
     const rvMap = buildSeriesMap(rvRes.data);
     const crMap = buildSeriesMap(crRes.data);
     console.log("gm=" + Object.keys(gmMap).length + " om=" + Object.keys(omMap).length + " rv=" + Object.keys(rvMap).length + " cr=" + Object.keys(crMap).length);
+
+    // ── Per-ticker coverage-gap fallback (see SKILL.md "Per-Ticker Coverage Gaps") ──
+    // For tickers in the universe but missing from gmMap, try income-statements.
+    // If that also fails, record in coverageGap with reason ∈ {no_coverage, pre_revenue}.
+    const coverageGap = [];
+    const fallbackTickers = Object.keys(universe).filter(t => !gmMap[t]);
+    if (fallbackTickers.length) {
+      const results = await Promise.all(fallbackTickers.map(async (t) => ({
+        t, r: await fallbackGrossMargin(t, twoYrAgoSec, nowSec),
+      })));
+      let rescued = 0;
+      for (const { t, r } of results) {
+        if (r.ok) { gmMap[t] = r.series; rescued++; continue; }
+        coverageGap.push({
+          id: t,
+          missing_metrics: "GROSS_MARGIN_MRQ",
+          reason: r.reason,
+          fallback_attempted: r.attempted.join(","),
+        });
+        // _drop is set below in the main loop via insufficient_gm — same effect.
+      }
+      console.log("fallback gm: rescued=" + rescued + " gap=" + coverageGap.length);
+    }
 
     // ── Compute factors per ticker ──
     for (const t of Object.keys(universe)) {
@@ -262,6 +328,7 @@ function clamp01(x) { return Math.max(0, Math.min(1, x)); }
       basketRevGrowthP25: pct(basketRevGrowthP25),
       basketGmDeltaValidCount: gmDeltasSorted.length,
       basketRevGrowthValidCount: revGrowthsSorted.length,
+      coverage_gap: coverageGap,
     }]);
 
     if (_overrideNow) {

--- a/skills/alva/templates/screener/example/index.html
+++ b/skills/alva/templates/screener/example/index.html
@@ -715,6 +715,37 @@
     color: var(--text-n5); line-height: 22px; letter-spacing: 0.14px;
   }
 
+  /* ── Data Coverage Gap card ── */
+  .coverage-gap-card {
+    background: var(--grey-g01); border-radius: var(--radius-ct-l);
+    padding: var(--spacing-m) var(--spacing-l);
+  }
+  .coverage-gap-header { margin-bottom: var(--spacing-s); }
+  .coverage-gap-title {
+    font-size: 14px; font-weight: 400; color: var(--text-n9);
+    letter-spacing: 0.14px; margin-bottom: 2px;
+  }
+  .coverage-gap-sub {
+    font-size: 11px; color: var(--text-n5); letter-spacing: 0.11px;
+  }
+  .coverage-gap-row {
+    display: grid; grid-template-columns: 70px 1fr auto;
+    align-items: center; gap: var(--spacing-s);
+    padding: 8px 0; border-bottom: 1px solid var(--line-l05);
+    font-size: 12px;
+  }
+  .coverage-gap-row:last-child { border-bottom: none; }
+  .coverage-gap-ticker { font-weight: 400; color: var(--main-m1); letter-spacing: 0.12px; }
+  .coverage-gap-detail { font-size: 11px; color: var(--text-n5); }
+  .coverage-gap-reason {
+    font-size: 11px; padding: 2px 8px; border-radius: var(--radius-ct-s);
+    background: var(--main-m4); color: var(--b-common-white);
+    letter-spacing: 0.11px; white-space: nowrap;
+  }
+  .coverage-gap-reason.pre-revenue {
+    background: var(--main-m5);
+  }
+
   /* ── Methodology (Alva typography) ── */
   .method-section { margin-bottom: var(--spacing-xl); }
   .method-section:last-child { margin-bottom: 0; }
@@ -1161,6 +1192,15 @@
       </div>
       <div class="widget-card">
         <div class="table-card" id="rankings-table"></div>
+      </div>
+      <div id="coverage-gap-section" class="widget-card" style="display:none;">
+        <div class="coverage-gap-card">
+          <div class="coverage-gap-header">
+            <div class="coverage-gap-title">Data Coverage Gap</div>
+            <div class="coverage-gap-sub">Tickers excluded from ranking — never silent half-weight. See methodology.</div>
+          </div>
+          <div class="coverage-gap-list" id="coverage-gap-list"></div>
+        </div>
       </div>
     </div>
     <div id="overview-error" class="error-state" style="display:none;"></div>
@@ -1980,6 +2020,35 @@
     });
   }
 
+  function renderCoverageGap(gaps) {
+    var section = document.getElementById('coverage-gap-section');
+    var list = document.getElementById('coverage-gap-list');
+    if (!section || !list) return;
+    if (!Array.isArray(gaps) || gaps.length === 0) {
+      section.style.display = 'none';
+      return;
+    }
+    var REASON_LABEL = { no_coverage: 'no coverage', pre_revenue: 'pre-revenue' };
+    var toList = function(v){
+      if (Array.isArray(v)) return v.join(', ');
+      if (typeof v === 'string') return v.split(',').map(function(x){return x.trim();}).filter(Boolean).join(', ');
+      return '';
+    };
+    list.innerHTML = gaps.map(function(g){
+      var reason = g.reason || 'no_coverage';
+      var reasonCls = reason === 'pre_revenue' ? 'coverage-gap-reason pre-revenue' : 'coverage-gap-reason';
+      var metrics = toList(g.missing_metrics);
+      var attempted = toList(g.fallback_attempted);
+      return '<div class="coverage-gap-row">' +
+        '<div class="coverage-gap-ticker">'+escHTML(g.id || '')+'</div>' +
+        '<div class="coverage-gap-detail">missing: '+escHTML(metrics)+
+          (attempted ? ' &middot; tried: '+escHTML(attempted) : '')+'</div>' +
+        '<div class="'+reasonCls+'">'+escHTML(REASON_LABEL[reason] || reason)+'</div>' +
+      '</div>';
+    }).join('');
+    section.style.display = 'block';
+  }
+
   function renderMoversCards(movers) {
     document.getElementById('entries-count').textContent = movers.entries.length;
     document.getElementById('dropouts-count').textContent = movers.dropouts.length;
@@ -2759,6 +2828,7 @@
           document.getElementById('overview-loading').style.display='none';
           document.getElementById('overview-content').style.display='block';
           renderOverview(curr.stocks, priorMap);
+          renderCoverageGap(curr.summary && curr.summary.coverage_gap);
         };
         TAB_RENDERERS.trends = function(){
           document.getElementById('trends-loading').style.display='none';

--- a/skills/alva/templates/screener/template.md
+++ b/skills/alva/templates/screener/template.md
@@ -61,6 +61,12 @@ example doesn't yet ship.
 - Forward-only history accumulation: never call point-in-time SDKs to
   fake-backfill past snapshots — those return *currently revised* data, not
   real historical state.
+- **Per-ticker coverage gaps must be handled via fallback-or-exclude, never
+  silent reweighting.** When `/api/v1/stocks/financial-metrics` returns
+  `INVALID_PARAMETER` for specific tickers, attempt fallback compute from
+  `company/income-statements` + `company/cashflow-statements`; if that
+  also fails, exclude the ticker and emit it into `summary.coverage_gap`.
+  Full policy + formulas in [SKILL.md `Per-Ticker Coverage Gaps`](../../SKILL.md).
 
 This template shares its shell (tab bar + README chip + methodology modal)
 with the thesis template; matching surfaces stay visually identical across
@@ -203,7 +209,19 @@ exit_reason  str|null
 date            int
 universe_size   int
 delta           {new_ids, dropped_ids}    vs prior snapshot; first run: both []
+coverage_gap    [{id, missing_metrics, reason, fallback_attempted}]
+                                          tickers excluded for data coverage; [] when none
 ```
+
+`coverage_gap` is **required** (`[]` when no gaps) — renderers check
+its presence to detect silent-skip. Policy and fallback recipe live in
+[SKILL.md `Per-Ticker Coverage Gaps`](../../SKILL.md); this template only
+specifies the field shape and rendering surface. `reason` is one of
+`"no_coverage"` or `"pre_revenue"` (taxonomy defined in SKILL.md);
+`missing_metrics` is the list of metric IDs that could not be sourced
+(e.g. `["REVENUE_GROWTH_YOY_TTM", "FCF_MARGIN_MRQ"]`);
+`fallback_attempted` records the endpoints tried
+(e.g. `["company/income-statements", "company/cashflow-statements"]`).
 
 `tldr` — one row per snapshot (only if you ship Daily Digest + push):
 
@@ -250,7 +268,8 @@ Per-tab structural notes — for the actual rendering, read the example.
 
 ### Tab 1 — Overview
 
-Top-down: optional Daily Digest card → Ranked Table with expandable rows.
+Top-down: optional Daily Digest card → Ranked Table with expandable rows
+→ **Data Coverage Gap card** (when `summary.coverage_gap.length > 0`).
 
 **Ranked table** uses the Table Card base from `design-widgets.md` verbatim.
 Order columns by importance left-to-right; if there's no Rank/Score, sort by
@@ -286,6 +305,16 @@ K-line interval should be ≤ update cadence with enough bars to see the
 pattern the screener cares about (rule of thumb: quarterly fundamentals →
 daily bars / 60–90d window; daily / weekly → daily bars / 30–90d; intraday
 momentum → hourly or 15min / 5–10d; long-cycle macro → weekly bars / 1–2y).
+
+**Data Coverage Gap card** — when `summary.coverage_gap.length > 0`,
+render a compact card below the ranked table listing each excluded
+ticker with its `reason` (verbatim — `"no_coverage"` or `"pre_revenue"`,
+no synonyms), its `missing_metrics`, and the `fallback_attempted`
+endpoints. Hide the card entirely when the array is empty (no
+"All tickers covered ✓" placeholder — that's noise). The card uses the
+same chassis as the Movers cards; no chart. Its purpose is to make the
+silent-bias mode visible: a user looking at a ranked list of 23 names
+sees that 12 more were considered but excluded, and why.
 
 ### Tab 2 — Movers & Trends
 
@@ -408,6 +437,18 @@ explains; do not maintain a separate per-template content list here.
 **Performance** — lazy-render the modal body the first time it opens, not
 on page load; methodology is rarely the first thing a user wants. The
 example does this.
+
+**Coverage-gap disclosure rule** — when methodology copy or Daily Digest
+narrative references rows that were partially or fully excluded for
+data reasons, it MUST label them with the `reason` value from
+`summary.coverage_gap` verbatim (`"no_coverage"` or `"pre_revenue"`).
+**Never invent categories like "speculative tail" that mix excluded-for-
+data names with genuinely-speculative ones** — those are different
+failure modes (missing data vs. real $0 revenue vs. real-but-risky
+business model) and lumping them misleads users making allocation
+decisions. The taxonomy itself is owned by
+[SKILL.md `Per-Ticker Coverage Gaps`](../../SKILL.md); this rule is the
+template-side enforcement on user-facing prose.
 
 ---
 


### PR DESCRIPTION
## Summary

- When `/api/v1/stocks/financial-metrics` returns `INVALID_PARAMETER: stock symbol not found` for specific tickers, playbooks were silently scoring them at reduced weight with no UI surface — biasing screener rankings toward names with full coverage (alva-ai/mono-meta#419, reported on the `ai-buildout-5x` screener: 12 of 35 curated small/mid-caps half-weighted).
- Adds a universal **"Per-Ticker Coverage Gaps"** policy to `SKILL.md`: on that error signature, fallback-compute the missing ratios from `company/income-statements` + `company/cashflow-statements`; if that also fails, **exclude** the ticker and surface it via a `coverage_gap` channel — never silent reweight. Policy lives in SKILL.md so it reaches every playbook shape (thesis, what-if, ai-digest, custom), not just screeners.
- `reason` taxonomy (`no_coverage` vs `pre_revenue`) keeps missing-data names distinct from genuinely pre-revenue ones — addresses the issue's methodology-disclosure request.
- Screener template carries only the rendering contract (`summary.coverage_gap` field, "Data Coverage Gap" card placement, methodology-disclosure rule). The example feed (`inflection-screener-feed.js`) and `index.html` demonstrate the pattern end to end.

## Verification

- Fallback endpoints verified live against the Arrays API for all 12 failing tickers: `financial-metrics` returns HTTP 400 `INVALID_PARAMETER`, while `company/income-statements` + `company/cashflow-statements` return 200 with 6-8 quarters of real data.
- The new `fallbackGrossMargin` helper smoke-tested live: AAOI/TDC/AAPL return correct gross-margin series; non-existent ticker correctly returns `{ok: false, reason: "no_coverage"}`.
- `node --check` passes on the modified feed.
- The skills repo has no test/lint CI for these paths (CI only publishes `design-tokens.css`).

## Breaking Changes

None. `summary.coverage_gap` is a new field (`[]` when no gaps). Existing screeners regenerate cleanly; the fallback branch is a no-op for universe-API screeners whose universe excludes uncovered tickers by construction.

## Database Migrations

None.

## Merge Order

None.

## Related

alva-ai/mono-meta#419

## Test Plan

- [ ] Build a screener over a curated small-cap ticker list including names absent from `financial-metrics`; confirm the feed emits `summary.coverage_gap` and excludes those tickers from the ranked list.
- [ ] Confirm the "Data Coverage Gap" card renders on the Overview tab when `coverage_gap` is non-empty and is hidden when empty.
- [ ] Confirm a ticker with $0 revenue across all quarters is tagged `reason: "pre_revenue"`, and one with no statement data at all is tagged `"no_coverage"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)