### PR TITLE
docs(alva): require playbook-draft before every release

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -686,6 +686,8 @@ above so anonymous viewers can load feed output without authentication.
    playbook unexplained.
 3. **Create playbook draft**: `alva release playbook-draft` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
+   Run this before every `alva release playbook` to keep the draft
+   updated — including version bumps and re-releases.
    This request must include both the URL-safe `name` and the human-readable
    `display_name`. Use `[subject/theme] [analysis angle/strategy logic]`, put
    the subject/theme first, and keep it within 40 characters. Avoid personal
@@ -1655,9 +1657,10 @@ consistent read pattern (`@last`, `@range`, etc.).
   and safe to call anytime.
 - **Cronjob path must point to an existing script.** The deploy API validates
   the entry_path exists via filesystem stat before creating the cronjob.
-- **Always create a draft before releasing.** `alva release playbook`
-  requires the playbook to already exist (created via
-  `alva release playbook-draft`).
+- **Run `alva release playbook-draft` before every `alva release
+  playbook`.** This holds for every release — first publish, version
+  bumps, and README-only or content-only re-releases of an existing
+  playbook.
 - **Create new playbooks from scratch unless you are doing a version update.**
   Only version updates may refer to an existing playbook. For all other new
   playbooks, do not read existing ones.


### PR DESCRIPTION
## Problem

Eval [#1183](https://github.com/alva-ai/eval-issues/issues/1183) — regression of #117/#683/#1107/#1132. On a version-bump re-release of an already-published playbook, the agent skipped `alva release playbook-draft` and called `alva release playbook` directly (twice: v1.0.3, v1.0.4). The release succeeded, so there was no runtime signal training the agent to comply.

## Root cause

The skill's only rule on this said:

> `alva release playbook` requires the playbook to already exist (created via `alva release playbook-draft`).

This frames the draft as a **one-time creation step**. On a version update the playbook already exists, so the agent reasonably concludes the draft is unnecessary. The release flow ("Common steps") also listed the draft as step 3 of a creation flow with no statement that it applies to update / re-release flows.

## Backend contract (verified)

`PublishPlaybookByName` (`alva-backend/internal/services/playbook/playbook_publish.go:108`) only requires the playbook **row** to exist (`:176`) and reads `index.html` fresh from ALFS at publish time (`:145`, `:282`) — it does **not** require a draft version. So the backend will not reject a draft-skipping release.

This change is therefore an **intentional skill-side rule stricter than the backend**: always run draft → release so draft state (`playbook.json`, `display_name`, `trading_symbols`) stays consistent on every release, rather than relying on the backend to reject.

## Change

`skills/alva/SKILL.md`:
- Release flow step 3 — state the draft runs before every `alva release playbook`, including version bumps and re-releases.
- Pitfalls list — rewrite the rule as an action (`Run alva release playbook-draft before every alva release playbook`) instead of the misleading "requires the playbook to already exist" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)