### PR TITLE
docs(alva): document --tags on release playbook-draft

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1565,7 +1565,10 @@ alva release feed --name btc-ema --version 1.0.0 --cronjob-id 42 \
 
 # 2. Create playbook draft (creates DB record + ALFS draft files automatically)
 #    Include trading_symbols when the playbook involves specific assets.
-alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashboard" --description "BTC market dashboard" --feeds '[{"feed_id":100}]' --trading-symbols '["BTC"]'
+#    Include --tags with discovery tags (max 10, each up to 32 chars) so the
+#    playbook surfaces under those tags on /explore. Re-running this command
+#    with --tags replaces the playbook's tag set.
+alva release playbook-draft --name btc-dashboard --display-name "BTC Trend Dashboard" --description "BTC market dashboard" --feeds '[{"feed_id":100}]' --trading-symbols '["BTC"]' --tags '["btc","macro"]'
 # → {"playbook_id":99,"playbook_version_id":200}
 
 # 3. Write playbook README to ALFS (required before release).


### PR DESCRIPTION
## Summary
- Documents the new `--tags` flag in the `alva release playbook-draft` walkthrough in `SKILL.md`, including an updated example and a note that re-running with `--tags` replaces the tag set.

## Breaking Changes
None — documentation only.

## Database Migrations
None.

## Merge Order
None — docs only; safe to merge anytime, ideally alongside the CLI change.

## Related
- alva-ai/alva-backend#1074 — backend `tags` parameter
- alva-ai/toolkit-ts#58 — `--tags` CLI flag
- alva-ai/alva-local-dev#185 — e2e test

## Test Plan
- [x] Documentation only — no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)