### PR TITLE
docs(alva): update FeedAltra provider docs

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1390,10 +1390,8 @@ usually incomplete — see
 See [altra-trading.md](references/altra-trading.md) for full details.
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
+const { FeedAltraModule, createArraysOhlcvProvider } = require("@alva/feed");
 const { FeedAltra, e, Amount } = FeedAltraModule;
-const { AltraModule } = require("@alva/graph");
-const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1378,8 +1378,8 @@ involves uploading, naming, rotating, listing, or using third-party secrets.
 data alignment, and portfolio simulation automatically. Do not manually loop
 over SDK data (e.g. `getCryptoKline`) to evaluate trading conditions — this
 leads to incorrect timestamps and look-ahead bias. Use Altra for all
-strategies regardless of complexity; it supports any interval (`"1min"` to
-`"1w"`) and any combination of OHLCV + external data via `registerRawData`.
+strategies regardless of complexity; supported OHLCV intervals depend on the
+provider and market, and external data can be added via `registerRawData`.
 
 **After a successful backtest, you should package the results in a form the user
 can use.** That may be a playbook, a dashboard, or a concise analytical summary,
@@ -1409,8 +1409,8 @@ const altra = new FeedAltra(
 );
 
 const dg = altra.getDataGraph();
-dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // any interval: "1min" to "1w"
-dg.registerFeature({ name: "rsi" /* ... */ });
+dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d"); // supported interval strings include "1min", "15min", "1d"
+dg.registerFeature(createRsiFeature()); // feature descriptors include description, inputConfig, fields, and fn
 
 altra.setStrategy(strategyFn, {
   trigger: { type: "events", expr: e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d") },
@@ -1584,8 +1584,9 @@ consistent read pattern (`@last`, `@range`, etc.).
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.
   Always `await` it: `const result = await altra.run(endDate);`
 - **Altra lookback: feature vs strategy.** Feature lookback controls how many
-  bars the feature computation sees. Strategy lookback controls how many feature
-  outputs the strategy function sees. They are independent.
+  historical records feature computation receives. Strategy lookback controls
+  the OHLCV, raw, and feature records delivered to the strategy, and can extend
+  upstream raw/feature computation ranges so requested records are available.
 - **Quote `~` paths to prevent shell expansion.** The shell expands bare `~` to
   your local home (e.g. `/Users/alice/`), not the ALFS home
   (`'/alva/home/alice/'`). Always quote paths: `--path '~/feeds/...'`.

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -267,7 +267,7 @@ const {
 
 ## OHLCV Provider
 
-All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
+Use an OHLCV provider such as `createArraysOhlcvProvider()`. Never fabricate
 price data. The provider is exported from `@alva/feed`.
 
 ```javascript
@@ -316,7 +316,7 @@ const altra = new FeedAltra(
 | `startDate`                    | Backtest start timestamp (ms UTC). Use the exact date, never adjust for warmup. |
 | `portfolioOptions.initialCash` | Starting cash (default: 100,000)                                                |
 | `portfolioOptions.currency`    | Quote currency (default: "USD")                                                 |
-| `simOptions.simTick`           | Simulation resolution. Must be `"1min"`.                                        |
+| `simOptions.simTick`           | Simulation resolution. Prefer valid tick strings like `"1min"`, `"15min"`, or `"1d"`; numeric ms values must map to a valid tick string. |
 | `simOptions.feeRate`           | Fee per trade as fraction (e.g. 0.001 = 0.1%)                                   |
 | `simOptions.slippage`          | Slippage as fraction                                                            |
 | `perfOptions.timezone`         | `"UTC"` for crypto/mix, `"America/New_York"` for us_stock                       |
@@ -425,7 +425,7 @@ dataGraph.registerFeature({
 dataGraph.registerFeature({
   name: "price_ma_ratio",
   inputConfig: {
-    ohlcvs: [{ id: { pair: SYMBOL, interval: "1d" }, lookback: 0 }],
+    ohlcvs: [{ id: { pair: SYMBOL, interval: "1d" } }],
     features: [{ id: "sma_20" }],
   },
   fields: [num("ratio")],
@@ -569,7 +569,8 @@ e.any(e.ohlcv("BINANCE_SPOT_BTC_USDT", "1h"), e.raw("funding")); // OR
 }
 ```
 
-**LookbackOptions**: `{ count: number }` or `{ duration: number }` (in ms).
+**LookbackOptions**: `{ count?: number, duration?: number }`; set one or both.
+`duration` is in ms.
 
 ### Strategy Function
 
@@ -610,12 +611,15 @@ if (bars.length === 0) return { target: null, state }; // warmup
 
 ### Understanding Lookback
 
-**Feature lookback** and **strategy lookback** are independent:
+**Feature lookback** and **strategy lookback** are set in different scopes:
 
 | Type              | Where Set                | Controls                                                    |
 | ----------------- | ------------------------ | ----------------------------------------------------------- |
-| Feature lookback  | Feature's `inputConfig`  | How many bars the feature function receives for computation |
-| Strategy lookback | Strategy's `inputConfig` | How many feature outputs the strategy function sees         |
+| Feature lookback  | Feature's `inputConfig`  | How many OHLCV, raw, or feature dependency records the feature receives |
+| Strategy lookback | Strategy's `inputConfig` | How many OHLCV, raw, or feature records the strategy sees              |
+
+Strategy lookback can also extend upstream raw/feature computation ranges so the
+requested records are available to the strategy.
 
 **Quick reference**:
 
@@ -624,7 +628,8 @@ if (bars.length === 0) return { target: null, state }; // warmup
 - MACD(12,26,9): Feature lookback `{ count: 25 }`
 - Crossover detection: Strategy lookback `{ count: 1 }` (see 2 values: current +
   previous)
-- Current value only: Omit lookback (default 0 = see 1 value)
+- Current activation data only: Omit lookback (record count depends on trigger
+  and data frequency)
 
 **Never adjust `startDate` for warmup**: Use `lookback` in feature/strategy
 `inputConfig` instead.
@@ -662,12 +667,11 @@ trades.
 | `0.5`  | 50% of equity in this asset |
 | `1.0`  | 100% long (fully invested)  |
 | `-1.0` | 100% short                  |
-| `2.0`  | 200% long (2x leverage)     |
+| `2.0`  | 200% long target, subject to margin limits |
 
-- Missing symbols are left unchanged (not sold)
+- Existing positions omitted from `weights` are targeted to `0` and closed
 - If weights sum to < 1.0, remainder stays as cash
-- Long positions with same weight are idempotent (no trade)
-- Short positions compound (NOT idempotent)
+- Repeating the same target weights rebalances to those weights
 
 ### Order-Based Execution
 
@@ -693,26 +697,13 @@ const { Amount } = FeedAltraModule;
 
 Amount.base(0.5); // 0.5 units of base asset (e.g. 0.5 BTC)
 Amount.quote(100); // $100 worth
-Amount.ofCash(0.5); // 50% of available cash (buy/short only)
-Amount.ofPosition(0.5); // 50% of current position (sell only)
+Amount.ofCash(0.5); // 50% of available cash (buy orders only)
+Amount.ofPosition(0.5); // 50% of current position size
+Amount.ofEquity(0.05); // 5% of portfolio equity
 ```
 
-### Composite Targets
-
-Combine orders and weights in one target. Orders execute first, then weights
-apply to the updated portfolio.
-
-```javascript
-{
-  date: tick,
-  instruction: {
-    type: "allocate",
-    weights: [{ symbol: SYMBOL, weight: 0.8 }],
-    orders: [{ symbol: SYMBOL, side: "buy", amount: Amount.quote(100) }],
-  },
-  meta: { reason: "Rebalance to 80% + DCA $100" },
-}
-```
+Use either an `allocate` instruction or an `orders` instruction in a target;
+they are not combined in one instruction.
 
 ---
 
@@ -889,7 +880,7 @@ Use `@test/suite` for unit testing strategy components.
 
 ```javascript
 const { describe, it, expect, runTests } = require("@test/suite:v1.0.0");
-const { SYMBOL, INTERVAL, TICK } = require("./constants.js");
+const { SYMBOL, STRATEGY_INTERVAL, TICK } = require("./constants.js");
 const { discountFeatureFn } = require("./features.js");
 
 function createMockBars(count, basePrice, startTime) {
@@ -908,7 +899,7 @@ describe("Feature: discount_30d", () => {
   it("returns empty when insufficient bars", () => {
     const mockData = {
       ohlcvs: {
-        [SYMBOL]: { [INTERVAL]: createMockBars(29, 100000, 1733011200000) },
+        [SYMBOL]: { [STRATEGY_INTERVAL]: createMockBars(29, 100000, 1733011200000) },
       },
     };
     const result = discountFeatureFn(mockData, {
@@ -926,7 +917,7 @@ runTests({ verbose: true });
 
 ```javascript
 const { describe, it, expect, runTests } = require("@test/suite:v1.0.0");
-const { SYMBOL, INTERVAL, TICK } = require("./constants.js");
+const { SYMBOL, STRATEGY_INTERVAL, TICK } = require("./constants.js");
 const { strategyFn, initialState } = require("./strategy.js");
 
 function createMockCtx(overrides) {
@@ -935,7 +926,7 @@ function createMockCtx(overrides) {
     data: {
       ohlcvs: {
         [SYMBOL]: {
-          [INTERVAL]: [
+          [STRATEGY_INTERVAL]: [
             { date: 1733011200000, endTime: 1733097600000, close: 90000 },
           ],
         },

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -177,10 +177,8 @@ module.exports = { strategyFn, initialState };
 ### main.js
 
 ```javascript
-const { FeedAltraModule } = require("@alva/feed");
+const { FeedAltraModule, createArraysOhlcvProvider } = require("@alva/feed");
 const { FeedAltra, e } = FeedAltraModule;
-const { AltraModule } = require("@alva/graph");
-const { createArraysOhlcvProvider } = AltraModule;
 const secret = require("secret-manager");
 
 const { SYMBOL, STRATEGY_INTERVAL } = require("./constants.js");
@@ -227,8 +225,8 @@ altra.setStrategy(strategyFn, {
 ## Imports
 
 Altra is accessed through the `FeedAltraModule` export from `@alva/feed`.
-Field type helpers (`num`, `str`, etc.) are at the `@alva/feed` top level, and
-`createArraysOhlcvProvider` lives on `@alva/graph`'s `AltraModule`:
+Field type helpers (`num`, `str`, etc.) and `createArraysOhlcvProvider` are at
+the `@alva/feed` top level:
 
 ```javascript
 const {
@@ -240,6 +238,7 @@ const {
   arr,
   fld,
   makeDoc,
+  createArraysOhlcvProvider,
 } = require("@alva/feed");
 const {
   FeedAltra,
@@ -250,8 +249,6 @@ const {
   order,
   orders,
 } = FeedAltraModule;
-const { AltraModule } = require("@alva/graph");
-const { createArraysOhlcvProvider } = AltraModule;
 ```
 
 | Export                                    | Source                     | Description                                      |
@@ -264,18 +261,17 @@ const { createArraysOhlcvProvider } = AltraModule;
 | `order` / `orders`                        | `FeedAltraModule`          | Helper to create order targets                   |
 | `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level)   | Field type helpers (same as Feed SDK)            |
 | `makeDoc`                                 | `@alva/feed` (top level)   | Type document helper                             |
-| `createArraysOhlcvProvider`               | `@alva/graph` `AltraModule` | Builds the OHLCV provider used by Altra          |
+| `createArraysOhlcvProvider`               | `@alva/feed` (top level)    | Builds the OHLCV provider used by Altra          |
 
 ---
 
 ## OHLCV Provider
 
 All OHLCV data must come through `createArraysOhlcvProvider()`. Never fabricate
-price data. The provider is exported from `@alva/graph` (not `@alva/feed`).
+price data. The provider is exported from `@alva/feed`.
 
 ```javascript
-const { AltraModule } = require("@alva/graph");
-const { createArraysOhlcvProvider } = AltraModule;
+const { createArraysOhlcvProvider } = require("@alva/feed");
 const secret = require("secret-manager");
 
 const ARRAYS_JWT = secret.loadPlaintext("ARRAYS_JWT");
@@ -318,8 +314,8 @@ const altra = new FeedAltra(
 | ------------------------------ | ------------------------------------------------------------------------------- |
 | `path`                         | ALFS feed path (e.g. `'~/feeds/my-strategy/v1'`). All output data stored here.   |
 | `startDate`                    | Backtest start timestamp (ms UTC). Use the exact date, never adjust for warmup. |
-| `portfolioOptions.initialCash` | Starting cash (default: 1,000,000)                                              |
-| `portfolioOptions.currency`    | Quote currency (default: "USDT")                                                |
+| `portfolioOptions.initialCash` | Starting cash (default: 100,000)                                                |
+| `portfolioOptions.currency`    | Quote currency (default: "USD")                                                 |
 | `simOptions.simTick`           | Simulation resolution. Must be `"1min"`.                                        |
 | `simOptions.feeRate`           | Fee per trade as fraction (e.g. 0.001 = 0.1%)                                   |
 | `simOptions.slippage`          | Slippage as fraction                                                            |

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -663,13 +663,13 @@ trades.
 
 | Weight | Meaning                     |
 | ------ | --------------------------- |
-| `0`    | Sell entire position (exit) |
+| `0`    | Close entire position (exit) |
 | `0.5`  | 50% of equity in this asset |
 | `1.0`  | 100% long (fully invested)  |
 | `-1.0` | 100% short                  |
 | `2.0`  | 200% long target, subject to margin limits |
 
-- Existing positions omitted from `weights` are targeted to `0` and closed
+- Existing positions omitted from `weights` are also targeted to `0` and closed
 - If weights sum to < 1.0, remainder stays as cash
 - Repeating the same target weights rebalances to those weights
 
@@ -702,8 +702,9 @@ Amount.ofPosition(0.5); // 50% of current position size
 Amount.ofEquity(0.05); // 5% of portfolio equity
 ```
 
-Use either an `allocate` instruction or an `orders` instruction in a target;
-they are not combined in one instruction.
+Use either an `allocate` instruction or an `orders` instruction in a target.
+Do not put `orders` inside an `allocate` instruction; current execution only
+uses the `weights` for `allocate` targets.
 
 ---
 


### PR DESCRIPTION
## Summary
- update Altra docs to import createArraysOhlcvProvider from @alva/feed
- clarify @alva/graph provider path is legacy compatibility
- align documented FeedAltra portfolio defaults with current backtest-js behavior

## Verification
- git diff --check -- skills/alva/SKILL.md skills/alva/references/altra-trading.md