### PR TITLE
docs(alva): add equity-research template family

### DIFF
--- a/skills/alva/templates/catalyst-weekly/template.md
+++ b/skills/alva/templates/catalyst-weekly/template.md
@@ -1,0 +1,127 @@
+# Catalyst Weekly Preview Template
+
+A forward calendar of upcoming catalysts across a coverage universe — earnings,
+corporate events, and macro releases — with a week-ahead preview that flags
+what matters and why. Mirrors the financial-services equity-research
+`catalyst-calendar` workflow (its Step-4 Weekly Preview); data re-sourced to
+Alva data skills.
+
+**Scope** — one coverage universe, a rolling forward horizon (default 2 weeks).
+Single-name pre-earnings depth is the `earnings-preview` template; the daily
+overnight note is `morning-note`.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`,
+`Authorization: Bearer <ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` first.
+
+| Catalyst type | Alva endpoint |
+|---|---|
+| Earnings dates + time | `stocks/earnings-calendar` |
+| Dividends, splits | `stocks/dividends`, `stocks/splits` |
+| IPOs | `stocks/ipo-calendar`, `stocks/ipo-confirmed-calendar` |
+| M&A milestones | `stocks/mergers-acquisitions` |
+| Earnings consensus (for the preview) | `stocks/estimates-guidance` |
+| Macro releases | `macro/economic-indicators`, `macro/treasury-rates` |
+
+**Coverage gaps — significant for this template.** Alva has no structured
+calendar for investor days / capital-markets days, product launches, FDA or
+other regulatory decisions, conferences and trade shows, debt maturities, or
+lockup expirations. The calendar reliably covers **earnings, dividends, splits,
+IPOs, M&A, and macro economic releases**. Do not invent the missing event
+types — state the covered scope in the README. A specific known event (e.g. an
+FDA PDUFA date) can be added via BYOD only if the user supplies a source.
+
+## Feeds
+
+Two feeds (equity-research family pattern); the narrative feed runs after the
+quant feed.
+
+**Quant feed `<coverage>-catalyst-weekly`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `calendar/events` | tabular | all upcoming catalysts over the horizon |
+| `calendar/earnings` | tabular | upcoming earnings with consensus EPS/revenue attached |
+| `calendar/macro` | tabular | upcoming macro releases |
+
+**Narrative feed `<coverage>-catalyst-weekly-narrative`** (ADK): the weekly
+preview — per key event, why it matters; a next-week heads-up; position
+implications; an impact rating. Labelled AI analysis.
+
+## Methodology
+
+The original catalyst-calendar workflow (Step-4 Weekly Preview), preserved.
+
+**Gather by type.** The original's four buckets — earnings & financial events,
+corporate events, industry events, macro events. Alva covers the earnings/
+financial and macro buckets structurally; the corporate/industry buckets are
+the coverage gap above.
+
+**The weekly preview — the core artifact.** "This week's key events",
+date-ordered, each carrying: the company; for an earnings event, the consensus
+and the key metric to watch; for a macro release, the expectation. Then a
+"next week" heads-up and "position implications".
+
+**Impact rating.** Each event tagged High / Medium / Low — an ADK judgment,
+labelled AI analysis. Binary events (an earnings print, an M&A close) outrank
+routine ones (a small dividend).
+
+**Earnings dates shift.** Treat dates as provisional — the quant feed re-pulls
+daily so a moved date self-corrects; `earnings-calendar` `status` flags
+confirmed vs estimated dates. Surface unconfirmed dates as such.
+
+**Recurring catalysts auto-populate.** Monthly/quarterly events — dividends,
+macro releases — come from the feeds each run; no manual entry.
+
+## Data contract (frozen field names)
+
+```
+calendar/events   { date, eventDate, type, symbol, name, label }
+calendar/earnings { date, eventDate, symbol, name, when, epsConsensus,
+                    revConsensus }
+calendar/macro    { date, eventDate, indicator, label }
+narrative/records { date, recordDate, generatedAt, thisWeek, nextWeek,
+                    positionImplications, impactRatings, source }
+```
+
+`type` ∈ `{earnings, dividend, split, ipo, ma, macro}`. `when` ∈
+`{amc, bmo}`. `thisWeek`, `nextWeek`, `positionImplications`, `impactRatings`
+are JSON-encoded arrays. `source` = `"adk"` for the narrative row.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **This-week hero** — count of events ahead + the single headline event.
+2. **This Week's Key Events** — date-ordered list; earnings rows carry the
+   consensus.
+3. **Calendar view** — full table over the horizon: date / event / company /
+   type / impact.
+4. **Next Week Preview** — a heads-up on the following week.
+5. **Position Implications** — ADK, labelled AI analysis.
+6. **References** — data sources, the covered event scope, and refresh cadence.
+
+## Template-specific rules
+
+- One coverage universe; default horizon 2 weeks, configurable.
+- Event dates, types, and consensus values are feed data; impact ratings and
+  the why-it-matters / position-implications copy are ADK, labelled AI analysis.
+- State the covered event types and the gaps in the README — never imply
+  conferences, product launches, or FDA dates are tracked.
+- Cadence: quant feed daily (dates shift); narrative feed weekly (e.g. Monday
+  pre-open) for the preview.
+
+## Build
+
+1. Confirm the coverage universe, the horizon, and whether macro events are
+   included.
+2. Shape-check the calendar endpoints with a small `alva run` snippet.
+3. Write + test + grant + deploy + release the quant feed, then the narrative
+   feed (deployed after the quant feed).
+4. Build the playbook HTML; write `README.md`; draft; screenshot-verify;
+   release.

--- a/skills/alva/templates/earnings-preview/template.md
+++ b/skills/alva/templates/earnings-preview/template.md
@@ -1,0 +1,162 @@
+# Earnings Preview Template
+
+Single-company pre-earnings briefing: when the company reports, what the street
+expects, its beat/miss record, where estimates are drifting, and what to watch
+on the print.
+
+**Scope** — one company, one upcoming report. Multi-name week-ahead coverage is
+the `catalyst-weekly` template; do not blend.
+
+Generic rules are **not repeated here** — design system
+([design-system.md](../../references/design-system.md),
+[design-widgets.md](../../references/design-widgets.md)), content legitimacy,
+README-as-attached-file, title/naming, and the single-page results-first shell
+all come from the Alva skill and the equity-research family shell. This doc is
+only the earnings-preview-specific substance: data wiring, feed design, and the
+analytical methodology.
+
+## Data
+
+All endpoints are Arrays data skills (`https://data-tools.prd.space.id`,
+`Authorization: Bearer <ARRAYS_JWT>`). Run the `list`→`summary`→`endpoint`
+discovery pipeline before coding.
+
+| Need | Endpoint + params | Fields used |
+|---|---|---|
+| Next report date/time | `earnings-calendar` · `symbol`, `start_time`, `end_time` | `date`, `time`, `status`, `eps_estimated`, `revenue_estimated`, `fiscal_date_ending` |
+| Upcoming-quarter consensus | `estimates-guidance` · `type=estimate`, `period_type=quarterly`, `metrics=EPS,SALES` | `fiscal_period`, `fiscal_year`, `estimate_date`, `mean`, `high`, `low`, `standard_deviation`, `estimate_count`, `up`, `down` |
+| Company guidance | `estimates-guidance` · `type=guidance` | `guidance_low/mid/high`, `mean_before`, `mean_surprise_amt_ratio` |
+| Deep beat/miss history | `company/income-statements` · `period_type=quarter`, `time_type=CALENDAR_END_DATE` | `calendar_end_date`, `fiscal_year`, `period`, `eps`, `revenue`, `gross_profit_ratio` |
+| Analyst price target | `company/price-target-consensus` · `symbol` | `target_high/low/consensus/median` |
+| Company identity | `company/detail` · `symbol` | `name`, `sector`, `industry` |
+
+**Gotchas — live-verified, the docs are wrong on these:**
+
+- `estimates-guidance` returns `fiscal_period` as integer `1`–`4` (not `"Q1"`)
+  and `periodicity` as `"QTR"`. Normalize yourself.
+- `earnings-calendar` returns `eps`/`revenue`/`*_estimated` as **strings**;
+  `revenue_estimated` carries float noise (`"…0.00000512"`). Parse and round.
+- `earnings-calendar` upcoming rows have no `eps`/`revenue`; it only keeps ~5
+  recent reported quarters — use `income-statements` for deeper history.
+- `estimates-guidance` returns **many rows per fiscal period**, one per
+  `estimate_date` — see consensus selection below.
+
+## Feeds
+
+Two feeds (equity-research family pattern): a **quant feed** for deterministic
+data and a **narrative feed** (ADK) for reasoning. The narrative feed is
+deployed to run *after* the quant feed so it can read the quant snapshot.
+
+**Quant feed `<slug>-earnings-preview`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `schedule/next` | snapshot | report `date`, `time`, fiscal period, `daysUntil` |
+| `consensus/upcoming` | snapshot | EPS + SALES `mean/high/low/count/up/down` for the upcoming quarter |
+| `guidance/latest` | snapshot | guidance low/mid/high, `meanBefore`, `surpriseRatio` |
+| `history/beats` | event log | one row per reported quarter (last 8) |
+| `revisions/eps` | tabular | consensus EPS `mean` per `estimate_date` for the upcoming quarter |
+| `target/consensus` | snapshot | PT high/low/consensus/median |
+
+**Narrative feed `<slug>-earnings-preview-narrative`:** ADK agent reads the
+quant outputs + the latest `earnings-transcript` + recent news → one
+`narrative/records` row: `lastCall` (themes management stressed last call) and
+`watchItems` (3-5 checkable items for this print).
+
+## Methodology
+
+The judgment calls — this is what the template exists to encode.
+
+**Consensus selection (critical).** `estimates-guidance` gives one row per
+`estimate_date`; the newest row is often a stale 1-analyst partial. For the
+headline consensus, filter to the upcoming fiscal period and pick the row with
+the **highest `estimate_count`**. `mean` is the headline; `high`/`low` the
+range; `standard_deviation` the dispersion — surface a wide spread, it means
+the print is genuinely uncertain.
+
+**Beat/miss surprise.** Per reported quarter,
+`epsSurprisePct = (epsActual − epsEstimate) / |epsEstimate| × 100`. Use the
+**pre-report** consensus, never a later revision: a reported `earnings-calendar`
+row's `eps_estimated` is the at-report estimate; for quarters older than the
+calendar window, take the `estimates-guidance` row dated just before
+`fiscal_end_date`. Beat rate = share of the last 8 quarters with
+`epsSurprisePct > 0` — this is the hero's track-record number. Revenue surprise
+is computed the same way.
+
+**Revision trend.** Into a print, the *direction* consensus has moved is the
+signal. Plot `mean` for the upcoming quarter across `estimate_date` over ~90
+days. `up`/`down` are the counts of analysts who raised/cut; net-positive with
+a rising mean = upward revision momentum (and vice versa). State the net count.
+
+**Guidance vs consensus.** `type=guidance` gives the company's own guidance for
+the quarter being reported, with `mean_before` (street consensus when guidance
+was issued) and `mean_surprise_amt_ratio`. Frame the *current* consensus against
+the company's guidance midpoint: consensus above the midpoint = the street
+expects a beat of guidance; below = the bar may be set conservatively.
+
+**Price target.** `target_consensus` vs the latest close = implied upside;
+the `high − low` spread = degree of analyst disagreement.
+
+**Watch items.** Each ADK `watchItems` entry must be specific and checkable on
+the print — a segment revenue line, a margin number, the next-quarter guide, a
+named product ramp. Reject vague items ("execution", "macro headwinds").
+
+## Data contract (frozen field names)
+
+```
+schedule/next      { date, time, fiscalPeriod, fiscalYear, daysUntil }
+consensus/upcoming { date, epsMean, epsHigh, epsLow, epsCount, epsUp, epsDown,
+                     salesMean, salesHigh, salesLow, salesCount }
+guidance/latest    { date, metric, guidanceLow, guidanceMid, guidanceHigh,
+                     meanBefore, surpriseRatio }
+history/beats      { date, period, epsEstimate, epsActual, epsSurprisePct,
+                     revEstimate, revActual, revSurprisePct, grossMargin }
+revisions/eps      { date, estimateDate, epsMean, up, down }
+target/consensus   { date, targetHigh, targetLow, targetConsensus, targetMedian }
+narrative/records  { date, recordDate, generatedAt, lastCall, watchItems, source }
+```
+
+`time` ∈ `{amc, bmo}`. `period` normalized `Q1`–`Q4`. `watchItems` is a
+JSON-encoded string array. `source` = `"adk"` for the narrative record.
+
+## Playbook
+
+Single-page scroll, results-first. Hero + four cards in the first fold.
+
+1. **Verdict hero** — Free Text Card, one ≤80-word paragraph: report date +
+   `amc`/`bmo` + days away; consensus EPS and revenue; beat record (N of last
+   8). Numbers inline, `.pos`/`.neg`.
+2. **Four metric cards** — Report date · Consensus EPS · Consensus revenue ·
+   EPS beat rate (`beat N of 8` footer).
+3. **Beat/miss history** — Chart Card, paired estimate-vs-actual EPS bars per
+   quarter, newest right, surprise % in tooltip.
+4. **Estimate revision trend** — Chart Card, consensus EPS line over estimate
+   dates; subtitle = net up/down analyst count.
+5. **Guidance vs consensus** — Chart Card/metric strip, current consensus vs
+   guidance midpoint, surprise ratio signed.
+6. **Price target** — Chart Card, low/consensus/median/high vs last close.
+7. **What to watch** — Free Text Card, ADK `lastCall` + `watchItems`; header
+   labelled AI-generated analysis, kept visually distinct from data widgets.
+8. **References** — Free Text Card, data sources + refresh cadence.
+
+## Template-specific rules
+
+- One company per playbook; it must have an upcoming earnings date (verify with
+  `earnings-calendar` before building — if the next report is >8 weeks out,
+  warn the user the preview will be thin).
+- Cadence: quant feed daily, narrative feed daily ~30 min after — estimates and
+  the calendar move daily into a print.
+- The "What to watch" block is labelled AI analysis; no values presented as
+  sourced data inside it.
+- A "N days until [Company] reports" push notification is a natural fit — see
+  the Alva skill post-release push flow.
+
+## Build
+
+1. Confirm the company; verify the upcoming earnings date.
+2. Shape-check each endpoint with a small `alva run` snippet against the Data
+   table above.
+3. Write + test + grant + deploy + release the quant feed.
+4. Write + deploy the narrative feed to run after the quant feed.
+5. Build the playbook HTML (§Playbook), fetching feed outputs at runtime.
+6. Write `README.md`, draft, screenshot-verify, release the playbook.

--- a/skills/alva/templates/idea-generation/template.md
+++ b/skills/alva/templates/idea-generation/template.md
@@ -1,0 +1,146 @@
+# Idea Generation Template
+
+Systematic stock screening and idea sourcing — quantitative screens (value /
+growth / quality / short / special-situation) plus thematic sweeps, surfacing a
+ranked shortlist of long and short candidates. Mirrors the financial-services
+equity-research `idea-generation` workflow; data re-sourced to Alva data skills.
+
+**Scope** — one screen configuration per playbook (a style + universe +
+direction). The output is a shortlist of *candidates*, never conclusions.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`,
+`Authorization: Bearer <ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` first.
+
+| Need | Alva endpoint + metrics |
+|---|---|
+| Universe by sector / exchange / country | `stocks/screener/basic-info/{sub}` |
+| Value / growth / quality / short factor filters | `stocks/screener/financial-metrics` — `PE_RATIO`, `EV_EBITDA_RATIO`, `PS_RATIO`, `PB_RATIO`, `DIVIDEND_YIELD`, `ROE_TTM`, `ROIC_TTM`, `ROA_TTM`, `REVENUE_GROWTH_YOY_TTM`, `EPS_GROWTH_YOY_TTM`, `FCF_GROWTH_YOY_TTM`, `GROSS/OPERATING/NET/FCF_MARGIN_MRQ`, `DEBT_TO_EQUITY_MRQ`, `CURRENT_RATIO_MRQ` |
+| Price-action filters | `stocks/screener/technical-metrics` — `PRICE_CHANGE_*`, `RSI_14`, `BETA`, `VOLATILITY_*` |
+| Special-situation events | `stocks/screener/events` — `IPO Date`, `Split Date`, `Earnings Date` |
+| Per-idea metric table | `stocks/financial-metrics`, `stocks/market-metrics` |
+| Crowding check | `equity-ownership-and-flow` (institutional, insider); `stocks/estimates-guidance` `estimate_count` (coverage breadth) |
+| Insider buying/selling signal | `equity-ownership-and-flow` (insider transactions) |
+
+**Coverage gaps** — Alva has no short-interest data, no accounting-red-flag
+signal (auditor change / restatement), and no SaaS net-retention metric. Screen
+criteria that need these are dropped or approximated; state the gap in the
+README. Do not fabricate a substitute.
+
+## Feeds
+
+Two feeds (equity-research family pattern); the narrative feed runs after the
+quant feed.
+
+**Quant feed `<screen>-idea-generation`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `screen/results` | tabular | ranked shortlist with the metric table per name |
+| `screen/criteria` | snapshot | the filters applied — for documentation |
+| `enrich/crowding` | tabular | per name: institutional ownership concentration, insider activity, analyst coverage count |
+
+**Narrative feed `<screen>-idea-generation-narrative`** (ADK): per shortlisted
+name — a one-line thesis, why it is mispriced / what the market is missing, the
+catalyst, and the key risks. Labelled AI analysis (these are hypotheses, not
+data).
+
+## Methodology
+
+The original idea-generation workflow, preserved.
+
+**Screens surface candidates, not conclusions.** Every screen output is a
+starting point for fundamental work — never a buy/sell call. The playbook
+frames the shortlist as candidates.
+
+**The five screens** — translate each style into concrete `screener` filters:
+
+- **Value** — `PE_RATIO` below sector median, low `EV_EBITDA_RATIO`, `PB_RATIO`
+  < 1.5, `DIVIDEND_YIELD` above market; cross-check insider buying.
+- **Growth** — `REVENUE_GROWTH_YOY_TTM` > 15%, `EPS_GROWTH_YOY_TTM` > 20%,
+  `ROIC_TTM` > 15%, expanding margins.
+- **Quality** — `ROE_TTM` > 15%, low `DEBT_TO_EQUITY_MRQ`, stable/expanding
+  margins, consistent multi-year revenue growth.
+- **Short** — declining revenue / decelerating growth, margin compression,
+  valuation premium to peers, insider selling.
+- **Special situation** — recent IPOs (`screener/events` `IPO Date`); spin-offs
+  / restructuring / activist involvement have no direct Alva data — approximate
+  via events + news and note the gap.
+
+**Sector-relative, not absolute.** Where the original criterion is relative
+("PE below sector median"), compute the metric against the sector cohort, not a
+fixed cut-off.
+
+**Intersections beat single factors.** The best ideas sit at intersections — a
+quality company at a value price because of a temporary headwind. Support
+multi-factor screens.
+
+**Crowding check.** Before presenting an idea, check ownership concentration,
+insider activity, and analyst coverage breadth. Flag crowded longs and
+heavily-owned names.
+
+**Contrarian needs a catalyst.** A cheap stock with no catalyst is not an idea
+— each idea must name a catalyst.
+
+**Short ideas need higher conviction.** Flag short candidates as higher-bar —
+timing is harder and the risk is asymmetric.
+
+**Thematic sweep.** For a theme, the ADK maps the value chain — direct vs
+indirect beneficiaries, pure-play vs diversified, priced-in vs
+under-appreciated, second-order names. Verify every surfaced ticker's sector
+with `company/detail` — no agent-knowledge ticker-to-sector mapping.
+
+## Data contract (frozen field names)
+
+```
+screen/results  { date, rank, symbol, name, direction, marketCap, evEbitda,
+                  peRatio, revGrowth, ebitdaMargin, fcfYield, roe }
+screen/criteria { date, screenStyle, direction, universe, filters }
+enrich/crowding { date, symbol, instOwnershipPct, insiderNet90d, analystCount }
+narrative/records { date, recordDate, generatedAt, ideas, source }
+```
+
+`direction` ∈ `{long, short}`. `screenStyle` ∈
+`{value, growth, quality, short, special-situation, thematic}`. `filters` and
+`ideas` are JSON-encoded arrays.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Screen hero** — the screen style, direction, universe, and how many names
+   surfaced.
+2. **Shortlist table** — ranked, the metric columns against sector/peer median;
+   crowding flags inline.
+3. **Idea cards** — per name: one-line thesis + 3-5 bullets (why mispriced /
+   what the market is missing) + catalyst + key risks. ADK, labelled AI
+   analysis.
+4. **Screen criteria** — the filters applied, documented.
+5. **References** — data sources + cadence.
+
+## Template-specific rules
+
+- One screen configuration per playbook.
+- Shortlist counts and metric values are feed data; the per-idea thesis,
+  catalyst, and risks are ADK, labelled AI analysis.
+- Verify every thematic-sweep ticker's sector via `company/detail` — no
+  agent-knowledge mapping.
+- Note dropped screen criteria where Alva lacks the data (short interest,
+  accounting red flags, net retention).
+- Cadence: weekly or monthly — screens are not intraday.
+
+## Build
+
+1. Capture the screen config: direction, market cap, sector, style, geography,
+   theme.
+2. Translate the style into concrete `screener/*` metric filters (§Data).
+3. Shape-check the screener endpoints with a small `alva run` snippet.
+4. Write + test + grant + deploy + release the quant feed, then the narrative
+   feed (deployed after the quant feed).
+5. Build the playbook HTML; write `README.md`; draft; screenshot-verify;
+   release.

--- a/skills/alva/templates/morning-note/template.md
+++ b/skills/alva/templates/morning-note/template.md
@@ -1,0 +1,160 @@
+# Morning Note Template
+
+A daily pre-open morning-meeting note for a coverage universe — tight,
+opinionated, actionable, readable in two minutes. Mirrors the
+financial-services equity-research `morning-note` workflow; data re-sourced to
+Alva data skills.
+
+**Scope** — one coverage universe (a watchlist of symbols), one note per day,
+generated pre-open. Single-name pre-earnings depth is the `earnings-preview`
+template; the forward week-ahead calendar is `catalyst-weekly`.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here. This doc is the
+morning-note-specific substance.
+
+## Data
+
+All endpoints are Arrays data skills (`https://data-tools.prd.space.id`,
+`Authorization: Bearer <ARRAYS_JWT>`). Run the `list`→`summary`→`endpoint`
+discovery pipeline before coding.
+
+| Need (from the original Step-1 scan) | Alva endpoint |
+|---|---|
+| Coverage companies reporting today / overnight | `stocks/earnings-calendar` |
+| Earnings surprises (beat/miss vs estimate) | `stocks/earnings-calendar` reported rows; `stocks/company/income-statements` |
+| Guidance changes | `stocks/estimates-guidance` `type=guidance` |
+| Analyst rating changes / price-target moves | `stocks/ratings` (PIT ratings); `stocks/company/price-target-news` |
+| M&A announcements touching coverage | `stocks/mergers-acquisitions` |
+| Management changes, product launches, regulatory news | `stocks/market-news` (symbol-filtered) |
+| Overnight index moves, VIX | `macro/index/real-time`, `macro/index/historical` (`^SPX`, `^IXIC`, `^DJI`, VIX) |
+| Pre-market move per coverage name | `stocks/*` spot price / OHLCV |
+| Sector ETF performance | `stocks/etf/*` holdings/info + spot price |
+| Commodity / FX moves | `macro/commodity/real-time` (`GCUSD`, `CLUSD`), `macro/forex/real-time` |
+| Economic data releases | `macro/economic-indicators`, `macro/treasury-rates` |
+
+**Coverage gap** — Alva has no investor-conference / non-deal-roadshow
+calendar. "Key Events Today" carries earnings calls and economic releases only;
+do not invent conference entries.
+
+## Feeds
+
+Two feeds (equity-research family pattern). The narrative feed is deployed to
+run *after* the quant feed.
+
+**Quant feed `<coverage>-morning-note`** — runs pre-open daily, scans the
+coverage universe and market context:
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `coverage/movers` | tabular | per name: prior close, overnight/pre-market % move |
+| `coverage/earnings` | tabular | coverage names reporting today, or reported overnight with beat/miss |
+| `coverage/ratings` | event log | rating changes and price-target moves across coverage, last 24h |
+| `events/today` | tabular | earnings calls (coverage) + economic releases scheduled today |
+| `events/ma` | event log | M&A touching coverage names, last 24h |
+| `market/context` | snapshot | index overnight, VIX, gold, oil, FX, 10Y treasury |
+
+**Narrative feed `<coverage>-morning-note-narrative`** (ADK) — the opinionated
+layer. Reads the quant outputs + `market-news` → one `narrative/records` row:
+`topCall`, `developments[]`, `eventsToday`, `earningsTakes[]`, `tradeIdeas[]`.
+
+## Methodology
+
+The original morning-note workflow, preserved. The template's job is to encode
+this judgment — the data layer only feeds it.
+
+**Overnight scan.** Surface, across the coverage universe: (a) coverage names
+that reported overnight or report pre-market, with beat/miss; (b) guidance
+changes; (c) M&A; (d) rating and price-target changes; (e) macro/policy moves
+affecting the sector. For market context: overnight index moves, sector ETF,
+commodity and FX, today's economic releases.
+
+**The Top Call.** Lead with the single most important thing — never bury the
+headline. 2-3 sentences on the development and why it matters, plus the stock
+impact.
+
+**Actionable vs noise.** Earnings, M&A, and guidance changes are actionable and
+get a line. Minor analyst notes and non-events are noise and get none. Padding
+a note with noise destroys its two-minute readability.
+
+**Be opinionated.** Every development carries a *take*, not just a summary — a
+morning note that only restates news without a view is useless.
+
+**Earnings quick-takes.** For each coverage name that reported, a
+consensus-vs-actual table — Revenue, EPS, one key metric, Guidance — followed
+by a 2-3 sentence "Our Take" (good or bad for the stock; does it change the
+thesis) and an "Action" (Maintain / Upgrade / Downgrade).
+
+**Trade ideas.** Optional. Long or Short, a 1-2 sentence thesis, the catalyst,
+and the risk — what would make the idea wrong.
+
+**"No news" is a valid note.** On a quiet day, say "nothing material overnight,
+maintaining positioning" — do not manufacture developments.
+
+**Takes and ratings are AI analysis, not desk research.** The original assumes
+a research desk's proprietary rating and price target. Alva has no proprietary
+desk, so this is the one place the data swap forces a content change: the data
+layer surfaces **consensus** rating and price-target changes (real data); the
+opinion layer — Top Call, Our Take, Action, Trade Ideas — is ADK-generated and
+**labelled AI-generated analysis**, kept visually distinct from the data
+widgets. It is reasoning over feed data, never a data source.
+
+## Data contract (frozen field names)
+
+```
+coverage/movers   { date, symbol, name, prevClose, overnightPct }
+coverage/earnings { date, symbol, name, when, epsEstimate, epsActual,
+                    epsSurprisePct, revEstimate, revActual, revSurprisePct }
+coverage/ratings  { date, symbol, name, kind, fromValue, toValue, source }
+events/today      { date, time, symbol, kind, label }
+events/ma         { date, acquirer, target, value, status }
+market/context    { date, spx, ixic, dji, vix, gold, oil, dxy, ust10y }
+narrative/records { date, recordDate, generatedAt, topCall, developments,
+                    eventsToday, earningsTakes, tradeIdeas, source }
+```
+
+`when` ∈ `{amc, bmo}`. `kind` on `coverage/ratings` ∈ `{rating, priceTarget}`.
+`kind` on `events/today` ∈ `{earnings, econ}`. `developments`, `earningsTakes`,
+`tradeIdeas` are JSON-encoded arrays. `source` = `"adk"` for the narrative row.
+
+## Playbook
+
+Single-page scroll, tight — a two-minute read. Order:
+
+1. **Top Call** — Free Text Card hero, ADK; the headline + stock impact. Header
+   labelled AI-generated analysis.
+2. **Market Context** — metric strip: index overnight, VIX, gold, oil, 10Y.
+3. **Overnight Developments** — per-name list: name, overnight % move, one-line
+   development + take.
+4. **Earnings Quick-Takes** — one table per reporting coverage name:
+   consensus vs actual (Revenue / EPS / key metric / Guidance), then Our Take +
+   Action.
+5. **Key Events Today** — time-ordered list: earnings calls + economic releases.
+6. **Trade Ideas** — cards (Long/Short, thesis, catalyst, risk), ADK, labelled.
+   Omit the section entirely when there are none.
+7. **References** — data sources + refresh cadence.
+
+On a quiet day, sections 3-6 collapse to the single "nothing material
+overnight" line from the methodology.
+
+## Template-specific rules
+
+- Coverage universe is a fixed watchlist of symbols, set at build time.
+- Cadence: quant feed daily pre-open (e.g. 06:00 ET), narrative feed ~30 min
+  after. State the real cadence in the README.
+- Opinion surfaces (Top Call, takes, Action, Trade Ideas) are ADK, labelled AI
+  analysis; data surfaces (moves, beat/miss, consensus rating/PT changes) are
+  feed outputs.
+- A pre-open push notification carrying the `topCall` line is a natural fit —
+  see the Alva skill post-release push flow.
+
+## Build
+
+1. Confirm the coverage universe (the watchlist of symbols) with the user.
+2. Shape-check each endpoint with a small `alva run` snippet against the Data
+   table.
+3. Write + test + grant + deploy + release the quant feed.
+4. Write + deploy the narrative feed to run after the quant feed.
+5. Build the playbook HTML (§Playbook), fetching feed outputs at runtime.
+6. Write `README.md`, draft, screenshot-verify, release the playbook.

--- a/skills/alva/templates/thesis-tracker/template.md
+++ b/skills/alva/templates/thesis-tracker/template.md
@@ -1,0 +1,141 @@
+# Thesis Tracker Template
+
+Maintain one investment thesis for a position — the falsifiable claim, the
+pillars that support it, the risks that would break it, a running scorecard of
+how each pillar is tracking, the update log, and the catalysts ahead. Mirrors
+the financial-services equity-research `thesis-tracker` workflow; data
+re-sourced to Alva data skills.
+
+**Scope** — one company, one thesis (long or short). For a multi-position
+review, build one tracker per position. For theme/sector tracking without a
+directional position, use the generic `thesis` template instead.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`,
+`Authorization: Bearer <ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` first.
+
+| Need | Alva endpoint |
+|---|---|
+| Pillar metrics over time (growth, margins, ROE/ROIC) | `stocks/financial-metrics` (metric series per symbol); `stocks/company/income-statements` |
+| Estimate trajectory — does the street agree | `stocks/estimates-guidance` |
+| Update-log developments (earnings, news) | `stocks/earnings-calendar`, `stocks/company/income-statements`, `stocks/market-news` |
+| Upcoming catalysts | `stocks/earnings-calendar`, `stocks/dividends`, `stocks/mergers-acquisitions` |
+| Valuation vs target | `stocks/company/price-target-consensus`; `stocks/market-metrics` (`PE_RATIO`, `EV_EBITDA_RATIO`) |
+| Ownership shifts | `equity-ownership-and-flow` (institutional, insider) |
+
+The thesis itself — statement, pillars, risks, target price, stop trigger — is
+**user-authored config set at build time**, not market data. It lives as static
+labels in the playbook HTML. Only the metrics tracking each pillar flow through
+feeds.
+
+## Feeds
+
+Two feeds (equity-research family pattern); the narrative feed runs after the
+quant feed.
+
+**Quant feed `<company>-thesis-tracker`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `pillars/metrics` | time series | per pillar, its bound metric's value over time |
+| `updates/log` | event log | developments — earnings prints, rating moves, news |
+| `catalysts/upcoming` | tabular | upcoming events that could prove/disprove the thesis |
+| `valuation/snapshot` | snapshot | price, PE, EV/EBITDA, PT consensus, implied vs target |
+
+**Narrative feed `<company>-thesis-tracker-narrative`** (ADK): per pillar, the
+status and trend judged against the original expectation; the conviction level;
+update-log entries with thesis impact and action. All labelled AI analysis.
+
+## Methodology
+
+The original thesis-tracker workflow, preserved.
+
+**Falsifiable pillars.** Each pillar is a measurable claim bound to a concrete
+metric — "revenue growth >20%" → `REVENUE_GROWTH_YOY_TTM`; "margin expansion" →
+`OPERATING_MARGIN_MRQ` trend; "product ramp" → a segment/KPI line. A pillar with
+no bound metric is not trackable — rewrite it until it is. If nothing could
+disprove the thesis, it is not a thesis.
+
+**Scorecard — the core artifact.** Each pillar carries: Original Expectation
+(set at build), Current Status (latest metric value vs the expectation — on
+track / behind / ahead), and Trend (direction over recent prints).
+
+**Disconfirming evidence.** Track evidence that *weakens* a pillar as rigorously
+as confirming evidence. The narrative agent must not soft-pedal a missed pillar.
+
+**Update log.** Each development: date, data point, thesis impact (which pillar;
+strengthens / weakens / neutralizes), action (hold / add / trim / exit), updated
+conviction.
+
+**Conviction (High / Medium / Low).** An ADK judgment over the scorecard,
+labelled AI analysis — it falls when pillars go "behind". Not a price-driven
+number.
+
+**Valuation vs target.** Current price and multiples against the build-time
+target — the implied upside if the thesis plays out.
+
+**Review cadence.** Refresh at least quarterly even on quiet stretches — an
+unchecked thesis is a stale thesis.
+
+## Data contract (frozen field names)
+
+```
+pillars/metrics    { date, pillarId, metricType, value, expectation }
+updates/log        { date, headline, pillarId, impact, action, source }
+catalysts/upcoming { date, eventDate, kind, label }
+valuation/snapshot { date, price, peRatio, evEbitda, ptConsensus, targetPrice,
+                     impliedUpsidePct }
+narrative/records  { date, recordDate, generatedAt, conviction, scorecard,
+                     updates, riskReads, source }
+```
+
+`impact` ∈ `{strengthens, weakens, neutralizes}`. `action` ∈
+`{hold, add, trim, exit}`. `conviction` ∈ `{High, Medium, Low}`. `scorecard`,
+`updates`, `riskReads` are JSON-encoded arrays. The thesis statement, pillar
+definitions, and risk list are static HTML config, not feed records.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Thesis hero** — the thesis statement (static) + current conviction (ADK,
+   labelled).
+2. **Scorecard table** — pillar / original expectation / current status / trend.
+3. **Pillar metric charts** — each pillar's bound metric over time with the
+   expectation line drawn.
+4. **Update log** — recent developments, newest first, each with a
+   thesis-impact tag.
+5. **Catalyst calendar** — upcoming events.
+6. **Valuation vs target** — current price and multiples vs the target, implied
+   upside.
+7. **Risks** — the risk register (static), each with a current read (ADK,
+   labelled).
+8. **References** — data sources + cadence.
+
+## Template-specific rules
+
+- One company, one thesis. A short thesis surfaces disconfirming evidence on
+  the bear case the same way a long does.
+- Thesis statement, pillars, risks, and target are build-time config (static
+  HTML labels); only the tracked metrics come from feeds.
+- Conviction, scorecard status/trend, and risk reads are ADK, labelled AI
+  analysis.
+- Cadence: quant feed daily or weekly (match the pillar metrics' update
+  frequency); narrative feed after quant; flag a full review at least quarterly.
+
+## Build
+
+1. Capture the thesis from the user: statement, position, 3-5 pillars (each
+   with a measurable metric), 3-5 risks, target price, stop trigger.
+2. Bind each pillar to a concrete Alva metric; if a pillar can't be bound, push
+   back before building.
+3. Shape-check each endpoint with a small `alva run` snippet.
+4. Write + test + grant + deploy + release the quant feed, then the narrative
+   feed (deployed after the quant feed).
+5. Build the playbook HTML; write `README.md`; draft; screenshot-verify;
+   release.


### PR DESCRIPTION
## What

Migrates the `anthropics/financial-services` **equity-research** vertical's text-output skills into a family of self-contained Alva playbook templates:

| Template | Migrated from | Output |
|---|---|---|
| `earnings-preview` | equity-research/earnings-preview | Single-company pre-earnings briefing |
| `morning-note` | equity-research/morning-note | Daily pre-open coverage-universe note |
| `thesis-tracker` | equity-research/thesis-tracker | Single-position thesis scorecard |
| `idea-generation` | equity-research/idea-generation | Screened long/short idea shortlist |
| `catalyst-weekly` | equity-research/catalyst-calendar | Week-ahead catalyst calendar |

## Approach

- **Methodology preserved, data layer swapped.** Each `template.md` keeps the original financial-services skill's workflow and judgment rules; the data sources are re-pointed from the 11 institutional MCP connectors (FactSet, PitchBook, etc.) to Alva data skills.
- **Blueprints only.** No feed scripts, no `example/` playbooks — each template is a single self-contained `template.md`. A use-time agent builds the feeds/playbook from the blueprint.
- **Lean.** Generic design-system / content-legitimacy / naming rules are referenced, not reproduced — the templates carry only equity-research-specific substance (data wiring, feed design, methodology, data contract).
- Endpoint field shapes in the data contracts are live-verified via `alva run` shape-checks (e.g. `estimates-guidance` returns `fiscal_period` as int `1-4`, not `"Q1"`).

## Known coverage gaps (documented in the templates)

- No investor-conference / product-launch / FDA-decision calendar → `catalyst-weekly` and `morning-note` cover earnings + dividends + splits + IPO + M&A + macro only.
- No short-interest / accounting-red-flag / SaaS net-retention data → `idea-generation` drops or approximates those screen criteria.
- No proprietary research desk → `morning-note` ratings come from consensus data; the opinion layer is ADK-generated, labelled AI analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)