### PR TITLE
docs(alva): add annotation-driven edit workflow

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -947,6 +947,18 @@ If Step 4 returns no record or an empty body, **do not claim push is set
 up** — diagnose (missing output write, wrong path, run failure) and fix
 before reporting success.
 
+### 10. Annotation-driven edits
+
+A request to tweak one element of a playbook in session context arrives as one
+or more `<annotation>` tags, each naming a target element by CSS `selector` and
+an `instruction` for it. Locate the **generator** behind the element — the CSS
+rule or render function that produces it — and edit that. Never freeze the
+element's rendered output into static text: that hardcodes live feed values and
+breaks on the next data update.
+
+See [annotation-edits.md](references/annotation-edits.md) for the tag format and
+the full locate-and-edit procedure.
+
 ---
 
 **Detailed sub-documents** (read these for in-depth reference):
@@ -960,6 +972,7 @@ before reporting success.
 | [deployment.md](references/deployment.md) | Deploying scripts as cronjobs for scheduled execution |
 | [design-system.md](references/design-system.md) | Alva Design System entry point: tokens, typography, layout; links to widget, component, and playbook specs |
 | [remix-workflow.md](references/remix-workflow.md) | Remix: create a new playbook from an existing template |
+| [annotation-edits.md](references/annotation-edits.md) | Annotation-driven edits: parse `<annotation>` tags, locate the generator behind an element, edit generation logic not rendered output |
 | [creators-note.md](references/creators-note.md) | Post-release creator's note: composing and posting the pinned author comment |
 | [adk.md](references/adk.md) | Agent Development Kit: `adk.agent()` API, tool calling, ReAct loop, examples |
 | [search.md](references/search.md) | Content search SDKs: per-source usage, enrichment patterns, and gotchas for Twitter/X, news, Reddit, YouTube, podcasts, and web |

--- a/skills/alva/references/annotation-edits.md
+++ b/skills/alva/references/annotation-edits.md
@@ -1,0 +1,71 @@
+# Annotation-Driven Edits
+
+An annotation points at one element of a playbook the user is iterating on and
+asks for a change to it. The request arrives as one or more `<annotation>`
+tags. Find the logic that *generates* that element and edit it there.
+
+---
+
+## Tag Format
+
+```
+<annotation index="1" selector="div.playbook-container > div.tab-panel > div.hero-card" tag-name="div" instruction="Highlight this card"></annotation>
+```
+
+| Attribute     | Description                                                     |
+| ------------- | --------------------------------------------------------------- |
+| `index`       | Sequence number; a message may carry several annotations        |
+| `selector`    | CSS path to the target element in the **rendered** playbook DOM |
+| `tag-name`    | The target element's tag                                        |
+| `instruction` | What the user wants done to that element                        |
+
+The tag carries no playbook identity — an annotation applies to the playbook
+already in session context (just built, remixed, or read). If none is in
+context, ask which playbook, then read its HTML locally before editing:
+
+```bash
+alva fs read --path '/alva/home/{owner}/playbooks/{name}/index.html' > ./index.html
+```
+
+Process each `index` as a separate, targeted edit — change only what the
+`instruction` asks of the annotated element, nothing around it.
+
+---
+
+## Locate the Generator
+
+The `selector` describes the DOM **after** the playbook's JavaScript has run,
+so the target is one of two cases:
+
+- **Static markup** — the selector's tag and classes appear literally in
+  `index.html`. Edit them in place.
+- **JS-generated** (common) — a render function builds the element from feed
+  data, so the `selector` is **not** in the HTML verbatim. Search for the leaf
+  class (e.g. `hero-card`); it surfaces the CSS rule that styles it and the
+  render function that emits it — those are what you edit.
+
+---
+
+## Edit the Generator, Never Freeze the Output
+
+Do not copy the element's rendered DOM and paste it back as static HTML with
+the instruction applied. That hardcodes the live feed value into a literal
+(breaking the [Content Legitimacy Rules](../SKILL.md#content-legitimacy-rules)),
+so the element stops reflowing on the next feed update, and it usually drops
+design-system tokens.
+
+Instead, change what *produces* the element — its CSS rule, the markup its
+render function emits, or the component factory it calls — so every render
+keeps the change and stays data-driven.
+
+Editing playbook HTML re-enters the `before-build-html` gate: read
+[design-system.md](design-system.md), plus
+[design-components.md](design-components.md) for component-level changes.
+
+---
+
+## Re-release
+
+After applying every annotation, write the HTML back to ALFS and re-release.
+A change to an already-released playbook is a version bump: `alva release
+playbook-draft` then `alva release playbook` with the new version (Step 7).


### PR DESCRIPTION
## What

Adds a `### 10. Annotation-driven edits` workflow to the Alva skill so the agent knows how to act on `<annotation>` tags — e.g. `<annotation index="1" selector="div.playbook-container > div.tab-panel > div.hero-card" tag-name="div" instruction="加上高亮"></annotation>`.

## Why

When a user iterating on a playbook annotates one element, the naive move is to copy that element's *rendered* DOM and paste it back as static HTML with the instruction applied. That hardcodes whatever feed value was showing into a literal — breaking the Content Legitimacy Rules — and severs the live data contract, so the next feed update no longer reflows the element.

The correct move is to edit the **generator**: the CSS rule, template literal, or render function that produces the element. The element stays data-driven and every future render carries the change. This PR makes that discipline explicit.

## Changes

- `SKILL.md`: new `### 10` routing section (orienting + core rule + pointer) and a sub-document index row.
- `references/annotation-edits.md`: tag format, locate-the-generator procedure (static vs. JS-generated elements), the freeze-vs-edit rule, a worked example, and verify/re-release steps.

## Standard compliance

Follows the Alva skill standard: depth lives in the reference, `SKILL.md` routes; the freeze-vs-edit rule is stated once at cover-depth in `SKILL.md` and elaborated at contain-depth in the reference (no verbatim duplication). Audit script passes — no broken links, no orphan references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)