### PR TITLE
docs(alva): require feed release for push-notify cronjobs

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -853,9 +853,10 @@ Required evidence:
    cronjobs. Pass it via `--readme-url` as an absolute ALFS path (see the
    `--readme-url` rule in Step 7 above).
 9. **Push feeds are released**: Every cronjob this playbook deploys with
-   `push_notify: true` has a released feed (`alva release feed`, passing
-   `before-feed-release`) — without it the push fires a blank body. Items 1–3
-   only check feeds the HTML reads; a push-only feed is not caught there.
+   `push_notify: true` has a current `alva release feed --cronjob-id <that
+   cronjob>` — run after the cronjob's latest source write and passing
+   `before-feed-release`; otherwise the push dispatches an empty body. Items
+   1–3 only check feeds the HTML reads; a push-only feed is not caught there.
 
 If any item fails, do not release. Fix the issue, re-run
 `alva release playbook-draft` if metadata or backing files changed, then
@@ -948,10 +949,10 @@ verification.
    or `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`;
    for group push, run `/alva subscribe feed <id>` or
    `/alva subscribe playbook <id>` in that group.
-5. **Verify the release and a real run:** confirm the feed is released, then
-   trigger a run (or wait for the next cron fire) and read `@last/1` of the
-   configured sidecar. Confirm the record is fresh and the message body is
-   non-empty.
+5. **Verify the release and a real run:** confirm `alva release feed
+   --cronjob-id <this cronjob>` ran after Step 1 added the sidecar. Then trigger
+   a run (or wait for the next cron fire) and read `@last/1` of the configured
+   sidecar: confirm the record is fresh and the message body is non-empty.
 6. **Confirm to the user** with the specifics: which feed/playbook is
    subscribed, what the next push will say, and when it will fire.
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -852,6 +852,10 @@ Required evidence:
    Its source / cadence claims match the actual feed scripts and deployed
    cronjobs. Pass it via `--readme-url` as an absolute ALFS path (see the
    `--readme-url` rule in Step 7 above).
+9. **Push feeds are released**: Every cronjob this playbook deploys with
+   `push_notify: true` has a released feed (`alva release feed`, passing
+   `before-feed-release`) — without it the push fires a blank body. Items 1–3
+   only check feeds the HTML reads; a push-only feed is not caught there.
 
 If any item fails, do not release. Fix the issue, re-run
 `alva release playbook-draft` if metadata or backing files changed, then
@@ -920,9 +924,10 @@ Present a concrete recommendation, not a generic "want push?":
 
 If the feed already has the right push sidecar for the intended event
 (`signal/targets` for signal-style alerts, `notify/message` for feed
-completion / AlvaAsk reports) and `push_notify: true`, the publisher side is
-already configured. Still verify or create the user's/group's explicit
-subscription before claiming notifications are set up.
+completion / AlvaAsk reports), `push_notify: true`, and a current
+`alva release feed`, the publisher side is already configured. Still verify or
+create the user's/group's explicit subscription before claiming notifications
+are set up.
 
 #### Configure and verify
 
@@ -933,21 +938,26 @@ verification.
 1. **Add the intended push sidecar** to the feed script:
    `signal/targets` for playbook signals (Pattern D), or `notify/message` for
    feed completion / AlvaAsk reports (Pattern E).
-2. **Enable the flag on the cronjob:** `alva deploy update --id <ID> --push-notify`.
-3. **Subscribe the delivery target:** for personal push use
+2. **Release the feed.** A push script is a feed: its push body is served from
+   the *released* feed, not the cronjob's raw run output. Run the changed
+   script through the [feed lifecycle](#deploying-feeds), `before-feed-release`
+   included.
+3. **Enable the flag on the cronjob:** `alva deploy update --id <ID> --push-notify`.
+4. **Subscribe the delivery target:** for personal push use
    `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`
    or `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`;
    for group push, run `/alva subscribe feed <id>` or
    `/alva subscribe playbook <id>` in that group.
-4. **Verify a real run produced push content:** trigger a run (or wait for
-   the next cron fire) and read `@last/1` of the configured sidecar. Confirm
-   the record is fresh and the message body is non-empty.
-5. **Confirm to the user** with the specifics: which feed/playbook is
+5. **Verify the release and a real run:** confirm the feed is released, then
+   trigger a run (or wait for the next cron fire) and read `@last/1` of the
+   configured sidecar. Confirm the record is fresh and the message body is
+   non-empty.
+6. **Confirm to the user** with the specifics: which feed/playbook is
    subscribed, what the next push will say, and when it will fire.
 
-If Step 4 returns no record or an empty body, **do not claim push is set
-up** — diagnose (missing output write, wrong path, run failure) and fix
-before reporting success.
+If Step 5 finds the feed unreleased, or the run returns no record or an empty
+body, **do not claim push is set up** — diagnose (missing release, missing
+output write, wrong path, run failure) and fix before reporting success.
 
 ### 10. Annotation-driven edits
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -43,10 +43,12 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 
 When `--push-notify` is set, every successful cronjob execution checks the
 feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
-canonical `feed_alert_ready` event with different feed-alert sources. Delivery
-still requires an explicit personal or group subscription to the feed or to a
-playbook that references the feed; `--push-notify` does not subscribe the
-owner, any user, or any group.
+canonical `feed_alert_ready` event with different feed-alert sources. The push
+body is read from the *released* feed: a cronjob with `--push-notify` but no
+`alva release feed` dispatches an empty body. Delivery also requires an
+explicit personal or group subscription to the feed or to a playbook that
+references the feed; `--push-notify` does not subscribe the owner, any user, or
+any group.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -311,8 +311,8 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - `title` is optional — if provided, the notification renders as
   `**title**\n\ncontent`.
 - `text` is the notification body (required for content push).
-- **`alva release feed` is required** — without it, push notifications
-  will not be delivered.
+- **`alva release feed` is required** — without it, the push is still
+  dispatched but arrives with an empty body (no `title`/`text`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal or group subscriptions.
 - Real delivery requires an explicit subscription: personal


### PR DESCRIPTION
## Problem

Fixes alva-ai/mono-meta#409. A trialing paying user's playbook deployed two cronjobs with `push_notify: true` (`notify/message`, Pattern E) but the agent never ran `alva release feed` on them — so the pushes fire with an **empty body**. The user would receive blank Telegram messages.

## Root cause

A push-notification cronjob's script *is a feed* — the push body is served from the **released** feed, not the cronjob's raw run output. The skill already mandates `alva release feed` as step 6 of the feed lifecycle, but two places let the agent skip it for push-only feeds:

1. **Section 9 "Post-release push notification flow"** — the only push workflow in `SKILL.md` — described push setup as: add sidecar → `alva deploy update --push-notify` → subscribe → verify. `alva release feed` was absent. Its verify step read `notify/message/@last/1`, which a run populates *regardless* of release, so it passed while the push stayed blank.
2. **`before-playbook-release` HARD-GATE** — its "backing feed" checks only cover feeds the HTML reads at runtime / appear in `--feeds`. A push-only feed is neither, so no gate ever inspected it. The playbook ships green.

## Changes

- **`SKILL.md` Section 9 "Configure and verify"** — add a release step, reframe the push script as a feed routed through the feed lifecycle (`before-feed-release` included), and change verification to confirm the release (not just a non-empty sidecar record).
- **`SKILL.md` `before-playbook-release`** — add item 9: every `push_notify: true` cronjob must have a released feed; notes that items 1–3 miss push-only feeds.
- **`references/deployment.md`** — note that `--push-notify` on an unreleased feed dispatches an empty body.

Out of scope (issue's optional suggestion #3): a platform-side guardrail in `alva release playbook` — belongs in a separate platform issue.

## Verification

Changed against the `alva-skill-standard`: placed each edit in its layer, kept `feed-sdk.md` Pattern D/E as the canonical explanation, routing/gate-chain intact. Audited by a cold-read subagent (mechanical script + judgment pass) — within-item duplication it flagged was trimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)