### PR TITLE
docs(alva): add data convention alignment rule for charts and comparisons

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -402,6 +402,26 @@ When building sector or thematic dashboards with curated ticker lists:
 3. Remove mismatches before building the feed. A single wrong ticker (e.g. a
    cybersecurity company in a battery segment) can distort the entire analysis.
 
+### Data Convention Alignment
+
+A financial figure is not self-describing: what it *means* is fixed by
+conventions the record encodes as fields — period basis (fiscal vs calendar),
+price adjustment (split / dividend), currency, units, seasonal adjustment,
+point-in-time vs restated. Before charting, tabulating, comparing, or
+answering with any data series:
+
+- Read each convention from the record's own fields — never infer one from
+  your own knowledge of the company or market.
+- Every series in one chart, table, or comparison MUST share the same
+  conventions, and every label MUST state the convention it carries, derived
+  from the record rather than authored.
+
+The fundamentals **fiscal period** is the case with the most depth: fiscal
+quarters are not always calendar quarters (NVDA's fiscal year ends in late
+January). Read [fundamentals-periods.md](references/fundamentals-periods.md)
+before charting or tabulating quarterly/annual fundamentals or computing
+YoY/QoQ.
+
 ### Description and Provenance Accuracy
 
 1. **Playbook descriptions and methodology sections must only list data sources
@@ -981,6 +1001,7 @@ the full locate-and-edit procedure.
 | `references/api/*.md` | Per-command gotchas the CLI help does not cover — see the [CLI Reference](#cli-reference) below |
 | [jagent-runtime.md](references/jagent-runtime.md) | Writing jagent scripts: module system, built-in modules, async model, constraints |
 | [feed-sdk.md](references/feed-sdk.md) | Feed SDK guide: creating data feeds, time series, upstreams, state management |
+| [fundamentals-periods.md](references/fundamentals-periods.md) | Fiscal vs calendar periods for fundamentals: derive period labels from the record, align companies by `calendarEndDate`, compute YoY across matched periods |
 | [altra-trading.md](references/altra-trading.md) | Altra backtesting engine: strategies, features, signals, testing, debugging |
 | [deployment.md](references/deployment.md) | Deploying scripts as cronjobs for scheduled execution |
 | [design-system.md](references/design-system.md) | Alva Design System entry point: tokens, typography, layout; links to widget, component, and playbook specs |

--- a/skills/alva/references/annotation-edits.md
+++ b/skills/alva/references/annotation-edits.md
@@ -30,6 +30,11 @@ alva fs read --path '/alva/home/{owner}/playbooks/{name}/index.html' > ./index.h
 Process each `index` as a separate, targeted edit — change only what the
 `instruction` asks of the annotated element, nothing around it.
 
+When the instruction is a bug fix, fix the named defect only — do not change
+what displayed data *means* (its period basis, units, or source) as a side
+effect; and if the correct fix does change a number the user has already seen,
+say so explicitly rather than letting it change silently.
+
 ---
 
 ## Locate the Generator

--- a/skills/alva/references/fundamentals-periods.md
+++ b/skills/alva/references/fundamentals-periods.md
@@ -1,0 +1,64 @@
+# Fundamentals: Fiscal vs Calendar Periods
+
+Company fundamentals — income statement, balance sheet, cash flow — are
+reported by **fiscal** period, which is not always the calendar quarter. Apply
+this whenever a chart, table, metric card, or query answer displays quarterly
+or annual fundamentals, and whenever you compute YoY or QoQ growth.
+
+## The record carries its own period — derive the label, never author it
+
+Every fundamentals record has three period fields:
+
+| Field | Meaning |
+| --- | --- |
+| `calendarEndDate` | Last day of the reporting period, e.g. `2024-10-27` |
+| `fiscalYear` | Fiscal year the period belongs to, e.g. `"2025"` |
+| `period` | The **fiscal** quarter, e.g. `"Q3"` (or `"FY"` for annual) |
+
+A period label shown to the user MUST be derived from these fields of the
+record actually plotted. Never write a label from your own sense of the
+calendar, and never shift it to a neighboring quarter to match an expectation.
+
+## `period` is fiscal, not calendar
+
+`fiscalYear` + `period` name the company's fiscal quarter. When a company's
+fiscal year is not the calendar year, its fiscal quarters are offset from
+calendar quarters:
+
+- **NVDA** — fiscal year ends in late January. NVDA `fiscalYear="2025"`,
+  `period="Q4"` has `calendarEndDate ≈ 2025-01-26` and covers **Nov 2024–Jan
+  2025**. NVDA `fiscalYear="2026"`, `period="Q3"` (`calendarEndDate
+  2025-10-26`) covers **Aug–Oct 2025**.
+- **AMD** — fiscal year is the calendar year, so AMD `period="Q4"` covers
+  calendar Oct–Dec.
+
+Never present a fiscal `period` as a calendar quarter.
+
+## Comparing companies in one chart or table
+
+Two companies' records with the same `period` string can have
+`calendarEndDate`s a full quarter apart. To place them under one shared label
+or axis bucket:
+
+1. **Align by `calendarEndDate`, not by the `period` string.** Pick each
+   company's record whose reporting window actually overlaps the others'.
+2. **If the closest records still differ by ~a month** (e.g. NVDA fiscal Q4
+   ends January, AMD fiscal Q4 ends December), that is the closest honest
+   comparison — keep it, but disclose the offset on the artifact: a footnote or
+   axis note such as "NVDA fiscal Q4 ends Jan, ~1 month after AMD".
+3. **If no records overlap acceptably**, label each company by its own fiscal
+   period with `calendarEndDate` shown, or ask the user which basis they want.
+
+A shared bucket label must hold records that actually share that period.
+Bucketing one company's non-overlapping quarter (NVDA Aug–Oct) under another
+company's label (AMD's Oct–Dec "Q4") is forbidden — it makes every ratio drawn
+from that bucket false.
+
+## YoY, QoQ, and other period-derived metrics
+
+A growth metric inherits the alignment of the records it is built from. Compute
+YoY from two records of the **same company** the right distance apart: same
+`period`, `fiscalYear` differing by 1 (equivalently, `calendarEndDate`s
+~12 months apart). QoQ uses consecutive fiscal quarters. A ratio computed
+across misaligned records is wrong, and the error then propagates into every
+metric card and narrative line that cites it.


### PR DESCRIPTION
## Problem

A cross-company revenue chart compared NVDA and AMD under one shared **"Q4 2024 (Oct-Dec)"** label, but pulled NVDA's **fiscal Q3** income-statement record (`calendarEndDate` 2024-10-27, period Aug-Oct) — a full quarter off the label. NVDA's fiscal year ends in late January, so its fiscal quarters do not align to calendar quarters; AMD's do. The period label was authored by the model, not derived from the record.

This is one instance of a **general** failure: a financial figure is not self-describing. Its meaning is fixed by conventions the record encodes — period basis (fiscal vs calendar), price adjustment, currency, units, seasonal adjustment, point-in-time vs restated — and the model fills them from training priors instead of reading them off the record, or mixes conventions across one comparison.

## Change

- **`SKILL.md` — new "Data Convention Alignment" standing rule** in Content Legitimacy Rules: read each convention off the record's fields, never infer it; every series in one chart/table/comparison must share the same conventions; labels are derived from the record, not authored. Routes the one case with real depth to the reference below.
- **`references/fundamentals-periods.md` (new)** — the fiscal-period case in depth: fundamentals records carry their own period (`calendarEndDate` / `fiscalYear` / `period`). Derive period labels from the record, align companies by `calendarEndDate`, compute YoY across matched periods only.
- **`references/annotation-edits.md`** — a bug fix must change only the named defect, not silently change what displayed data means (period basis, units, source).

Other convention cases (split adjustment, currency, GAAP/non-GAAP, etc.) are covered by the general rule; deeper references accrete only when a case has genuine depth and has actually bitten — no speculative documentation.

Audited twice against the Alva skill standard by cold-context subagents (layer placement, routing indexes, links/anchors, DRY) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)