### PR TITLE
docs(alva): add analysis & valuation template family

### DIFF
--- a/skills/alva/templates/competitive-analysis/template.md
+++ b/skills/alva/templates/competitive-analysis/template.md
@@ -1,0 +1,133 @@
+# Competitive Analysis Template
+
+A competitive landscape for a set of companies: how the players compare on
+scale, growth and profitability, where each is positioned, their moats, and the
+strategic synthesis. Mirrors the financial-services `competitive-analysis`
+workflow; data re-sourced to Alva, and the deck deliverable re-cast as a
+playbook.
+
+**Scope** — a peer set, optionally with one target company as the protagonist.
+Multi-company.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the family shell
+— not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint |
+|---|---|
+| Company identity, sector | `stocks/company/detail` |
+| Revenue, growth, margins, EBITDA | `stocks/financial-metrics`, `stocks/company/income-statements` |
+| Market cap, enterprise value, multiples | `stocks/market-metrics` |
+| M&A and strategic activity | `stocks/mergers-acquisitions` |
+| Recent developments | `stocks/market-news` |
+
+**Coverage gaps** — Alva has no market-sizing/TAM data and no industry
+operating KPIs (ARR, NRR, GMV, take rate, same-store sales). The comparison
+runs on standard financials and valuation; industry-specific KPIs and market
+sizing are noted as gaps, never fabricated.
+
+## Migration note — the deck becomes a playbook; opinion becomes labelled ADK
+
+The original ships a PowerPoint deck. Here the deliverable is a playbook. The
+quantitative comparison is feed data; the qualitative layer — competitor
+strengths/weaknesses, moat ratings, the strategic synthesis, bull/base/bear —
+is ADK-generated, labelled AI analysis, kept separate from the data widgets.
+
+## Feeds
+
+Two feeds (family pattern); the narrative feed runs after the quant feed.
+
+**Quant feed `<set>-competitive-analysis`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `companies/metrics` | tabular | per company: revenue, growth, gross/EBITDA margin, market cap, EV, EV/EBITDA, PE |
+| `comparison/dimensions` | tabular | per company, per dimension (scale/growth/margins): the value and a rank |
+| `events/strategic` | event log | M&A and strategic moves across the set |
+
+**Narrative feed `<set>-competitive-analysis-narrative`** (ADK): the
+industry-defining metrics, each competitor's qualitative profile (business,
+strengths, weaknesses, strategy), the moat assessment, and the synthesis.
+Labelled AI analysis.
+
+## Methodology
+
+The original competitive-analysis workflow, preserved.
+
+**Industry-defining metrics first.** Identify the 3-5 metrics the industry
+actually runs on, and use them consistently across every competitor. Where
+those are operating KPIs Alva does not carry, note the gap.
+
+**Same-period comparability.** Every competitor's metrics come from the same
+fiscal period; flag any exception explicitly.
+
+**Competitor mapping.** Group the set by a single lens — business model,
+segment, or competitive posture.
+
+**Positioning.** Place the companies on a 2×2 (two dominant factors), a radar
+(multi-factor), or a tier diagram (natural clusters).
+
+**Competitor deep-dives.** Per company: the metrics table (feed data) plus a
+qualitative card — business in one line, 2-3 strengths, 2-3 weaknesses, current
+strategy (ADK).
+
+**Comparative analysis.** Rate each company dimension by dimension, and show
+the actual value behind the rating — "scale ●●● $160B", not a bare dot.
+
+**Moat assessment.** Rate each competitor Strong / Moderate / Weak on network
+effects, switching costs, scale economies, and intangible assets.
+
+**Synthesis.** The durable advantages (hard to replicate), the structural
+vulnerabilities (hard to fix), and current state vs trajectory. For an
+investment context, a bull/base/bear scenario set.
+
+## Data contract (frozen field names)
+
+```
+companies/metrics     { date, symbol, name, revenue, revGrowth, grossMargin,
+                        ebitdaMargin, marketCap, ev, evEbitda, peRatio }
+comparison/dimensions { date, symbol, dimension, value, rank }
+events/strategic      { date, kind, acquirer, target, value, note }
+narrative/records     { date, recordDate, generatedAt, industryMetrics,
+                        profiles, moats, synthesis, source }
+```
+
+`dimension` ∈ `{scale, growth, margins, …}`. `profiles`/`moats`/`synthesis`
+are JSON-encoded; each `moats` entry is `{symbol, networkEffects,
+switchingCosts, scaleEconomies, intangibles}` rated `Strong|Moderate|Weak`.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Competitive hero** — Free Text Card: the shape of the field — who leads on
+   scale, who on growth, the headline read.
+2. **Comparison table** — every company, the metric columns.
+3. **Positioning chart** — a 2×2 or scatter on the two dominant factors.
+4. **Competitor cards** — per company: the metrics plus the ADK qualitative
+   profile (labelled AI analysis).
+5. **Dimension ratings** — the rated comparison, actual values shown.
+6. **Moat assessment** — the four-moat grid, ADK, labelled.
+7. **Strategic activity** — M&A and strategic moves.
+8. **Synthesis** — Free Text Card, ADK, labelled; bull/base/bear if an
+   investment context.
+
+## Template-specific rules
+
+- A peer set, fixed at build; verify each member's sector via `company/detail`.
+- All competitor metrics from the same fiscal period; flag exceptions.
+- The deck is now a playbook; qualitative layers are ADK, labelled AI analysis.
+- No fabricated market-size or operating-KPI numbers — note the gaps.
+- Cadence: quant feed weekly; narrative after quant.
+
+## Build
+
+1. Confirm the peer set (and whether there is a target protagonist).
+2. Verify each company's sector; shape-check the endpoints.
+3. Write + deploy + release the quant feed, then the narrative feed.
+4. Build the playbook HTML; write `README.md`; draft; screenshot; release.

--- a/skills/alva/templates/comps-analysis/template.md
+++ b/skills/alva/templates/comps-analysis/template.md
@@ -1,0 +1,117 @@
+# Comparable Company Analysis Template
+
+A peer comparison: operating metrics and valuation multiples for a set of
+comparable companies, with quartile statistics that show where each name sits
+in the distribution. Mirrors the financial-services `comps-analysis` workflow;
+data re-sourced to Alva.
+
+**Scope** — a peer set of truly comparable public companies.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the family shell
+— not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint |
+|---|---|
+| Company identity, sector | `stocks/company/detail` |
+| Revenue, growth, gross profit, net income, EBITDA | `stocks/company/income-statements` |
+| Free cash flow | `stocks/company/cashflow-statements` (`free_cash_flow`) |
+| Margins, ROE/ROA, TTM ratios | `stocks/financial-metrics` |
+| Market cap, EV, EV/Revenue, EV/EBITDA, P/E, dividend yield | `stocks/market-metrics` |
+
+## Feeds
+
+**Quant feed `<set>-comps`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `comps/operating` | tabular | per company: revenue, revenue growth, gross margin, EBITDA margin, FCF margin |
+| `comps/valuation` | tabular | per company: market cap, EV, EV/Revenue, EV/EBITDA, P/E, FCF yield |
+| `comps/statistics` | tabular | max / 75th percentile / median / 25th percentile / min, per comparable metric |
+
+A short optional ADK card ("where each name screens rich or cheap vs the peer
+median") can be added as labelled AI analysis — comps is data-first, so keep any
+narrative minimal. A narrative feed is optional for this template.
+
+## Methodology
+
+The original comps-analysis workflow, preserved.
+
+**Define the peer group.** Companies must be genuinely comparable — similar
+business model, scale, and geography. Better three clean comps than six
+questionable ones; verify each member's sector via `company/detail`.
+
+**Consistent period.** All companies on the same basis — LTM smooths
+seasonality. Flag any company on a different fiscal period.
+
+**Operating metrics, then valuation multiples.** ~5 operating columns (revenue,
+growth, 2-3 margins) and ~5 valuation columns (market cap, EV, three core
+multiples). The 5-10 rule — beyond ~15 metrics is noise.
+
+**Cross-reference, don't double-enter.** A valuation multiple is computed from
+the operating data already in the feed — revenue is sourced once.
+
+**Quartile statistics.** For every *comparable* metric — margins, growth,
+multiples — compute max / 75th / median / 25th / min. The 75th percentile is
+where premium names trade, the 25th is discount territory; this answers "is a
+given name rich or cheap versus its peers". Use the **median**, not the mean —
+averaging percentages misleads. Do **not** compute statistics on size metrics
+(revenue, market cap, EV) — absolute size is not comparable across companies of
+different scale.
+
+**Sanity checks.** Gross margin > EBITDA margin > net margin, always. Watch the
+multiple ranges — a negative-EBITDA company cannot be valued on EV/EBITDA (show
+it on revenue multiples instead); a P/E above ~100x needs a hypergrowth story.
+
+## Data contract (frozen field names)
+
+```
+comps/operating  { date, symbol, name, revenue, revGrowth, grossMargin,
+                   ebitdaMargin, fcfMargin }
+comps/valuation  { date, symbol, name, marketCap, ev, evRevenue, evEbitda,
+                   peRatio, fcfYield }
+comps/statistics { date, statistic, metric, value }
+```
+
+`statistic` ∈ `{max, p75, median, p25, min}`. `metric` names match the
+operating/valuation field names. Statistics cover comparable metrics only —
+never `revenue`, `marketCap`, or `ev`.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Comps hero** — Free Text Card: the read — which name screens cheapest and
+   richest against the peer median, on which multiple.
+2. **Four cards** — Peer count · Median EV/EBITDA · Median revenue growth ·
+   Median EBITDA margin.
+3. **Operating metrics table** — every company, the operating columns, with the
+   max/75th/median/25th/min rows below a separating gap.
+4. **Valuation multiples table** — every company, the valuation columns, with
+   the same statistics rows.
+5. **Valuation scatter** — EV/EBITDA vs revenue growth, one point per company,
+   peer-median lines drawn.
+6. **Multiple bars** — each company's EV/EBITDA and P/E against the peer
+   median.
+7. **References** — data sources, the peer-set definition, the period basis.
+
+## Template-specific rules
+
+- A peer set of truly comparable companies; verify each member's sector.
+- Statistics are computed only on comparable metrics (margins, growth,
+  multiples), never on absolute size.
+- Median, not mean, for percentage metrics.
+- A negative-EBITDA name is shown on revenue multiples, not EV/EBITDA.
+- Cadence: quant feed daily (multiples move with price).
+
+## Build
+
+1. Confirm the peer set; verify each company is genuinely comparable.
+2. Shape-check the endpoints.
+3. Write + test + grant + deploy + release the quant feed.
+4. Build the playbook HTML; write `README.md`; draft; screenshot; release.

--- a/skills/alva/templates/dcf-model/template.md
+++ b/skills/alva/templates/dcf-model/template.md
@@ -1,0 +1,135 @@
+# DCF Valuation Template
+
+An intrinsic-value playbook: project a company's free cash flow, discount it,
+add a terminal value, and bridge to a per-share value — with the assumptions as
+interactive inputs and a sensitivity grid. Mirrors the financial-services
+`dcf-model` workflow; data re-sourced to Alva.
+
+**Scope** — one company. A what-if valuation: the base data comes from feeds,
+the assumptions are reader inputs.
+
+Generic rules (design system, content legitimacy, README-as-file, naming) come
+from the Alva skill and the family shell. The interactive what-if shell is
+shared with the `what-if` template — study it as a model.
+
+## Migration note — an Excel model becomes a what-if playbook
+
+The original builds a cell-auditable Excel model. A playbook cannot be that:
+the DCF math runs in the page over feed-sourced historicals and market inputs,
+and the assumptions (growth, margins, WACC inputs, terminal growth) are
+interactive controls. This is **lower fidelity** than an Excel model — there
+are no auditable formula cells — but it is live and shareable. State this limit
+in the README.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint | Key fields (shape-verified) |
+|---|---|---|
+| Historical revenue, EBIT, margins, tax, diluted shares | `stocks/company/income-statements` | `revenue`, `operating_income`, `ebit`, `income_tax_expense`, `weighted_average_shs_out_dil` |
+| D&A, capex, working-capital change, FCF | `stocks/company/cashflow-statements` | `depreciation_and_amortization`, `capital_expenditure`, `change_in_working_capital`, `free_cash_flow` |
+| Net debt, cash | `stocks/company/balance-sheets` | `net_debt`, `total_debt`, `cash_and_cash_equivalents` |
+| Current price, market cap, beta | `stocks/market-metrics` | beta — confirm the exact `indicator` param via the endpoint doc |
+| Risk-free rate (10Y) | `macro/treasury-rates` | `year10` |
+
+Diluted share count: use `income-statements.weighted_average_shs_out_dil` —
+the `outstanding-shares` endpoint returned empty in shape-checks.
+
+## Feeds
+
+**Quant feed `<company>-dcf`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `history/drivers` | event log | last ~5 years: revenue, revenue growth, EBIT margin, D&A % of revenue, capex % of revenue, ΔNWC % of revenue, tax rate |
+| `inputs/market` | snapshot | current price, market cap, diluted shares, net debt, beta, 10Y rate |
+| `valuation/base` | snapshot | the base-case DCF output at default assumptions — EV, equity value, per-share value, implied upside, WACC, terminal value, TV % of EV |
+
+The playbook recomputes the DCF in-browser when the reader changes an
+assumption — client-side math over `history/drivers` and `inputs/market`. The
+feed always publishes the base case so the page has a verified anchor.
+
+## Methodology
+
+The original DCF methodology, preserved.
+
+**Historical analysis (3-5 years).** From `history/drivers`: revenue CAGR,
+margin progression, and D&A / capex / ΔNWC as a percent of revenue — these
+percentages seed the default projection assumptions.
+
+**Revenue projection.** Project 5-10 years; growth starts near recent actuals
+and moderates toward the terminal rate. Offer bear / base / bull assumption
+sets.
+
+**Free cash flow.** EBIT → less taxes → NOPAT → plus D&A → less capex → less
+ΔNWC → unlevered free cash flow.
+
+**WACC (CAPM).** Cost of equity = risk-free rate + β × equity risk premium
+(5-6%). After-tax cost of debt = pre-tax rate × (1 − tax rate). Weight by the
+market values of equity and debt.
+
+**Discounting.** Mid-year convention — discount periods 0.5, 1.5, 2.5, … —
+discount factor `1 / (1 + WACC)^period`.
+
+**Terminal value.** Perpetuity growth — `TV = FCF × (1+g) / (WACC − g)`, and
+`g` must be below WACC — or an exit EBITDA multiple. Terminal value should be
+roughly 50-70% of enterprise value; flag it if it exceeds 75%.
+
+**Equity bridge.** Enterprise value − net debt = equity value; ÷ diluted shares
+= implied per-share value; versus the current price = implied upside.
+
+**Sensitivity.** Grids with an odd number of rows and columns so the base case
+sits in the center cell — WACC × terminal growth, and revenue growth × EBIT
+margin.
+
+## Data contract (frozen field names)
+
+```
+history/drivers  { date, fiscalYear, revenue, revGrowth, ebitMargin,
+                   daPctRev, capexPctRev, nwcPctRev, taxRate }
+inputs/market    { date, price, marketCap, dilutedShares, netDebt, beta,
+                   riskFreeRate }
+valuation/base   { date, enterpriseValue, equityValue, perShareValue,
+                   impliedUpsidePct, wacc, terminalValue, tvPctOfEv }
+```
+
+The page's assumption controls (revenue-growth path, EBIT-margin path, equity
+risk premium, terminal growth, cost of debt) are reader inputs, not feed
+records.
+
+## Playbook
+
+Single-page scroll, results-first. Shares the `what-if` interactive shell.
+
+1. **Value hero** — Free Text Card: the base-case implied per-share value vs
+   the current price, and the implied upside.
+2. **Four cards** — Base-case fair value · Implied upside · WACC · Terminal
+   value % of EV.
+3. **Assumption controls** — interactive inputs: revenue growth, EBIT margin,
+   WACC inputs, terminal growth. Changing one recomputes the page.
+4. **FCF projection chart** — projected unlevered free cash flow by year.
+5. **Equity bridge** — PV of FCF + PV of terminal value → EV → less net debt →
+   equity → per share.
+6. **Sensitivity grids** — WACC × terminal growth, revenue growth × EBIT
+   margin; the base case in the center cell.
+7. **Historical drivers** — the 5-year driver table the assumptions seed from.
+8. **References** — data sources, the lower-fidelity-than-Excel note, cadence.
+
+## Template-specific rules
+
+- One company. A what-if playbook, not an auditable Excel model — state the
+  fidelity limit in the README.
+- Base data (historicals, market inputs) is feed-sourced; assumptions are
+  reader inputs; the recomputation is client-side math over feed data.
+- The feed always publishes the base case as the verified anchor.
+- Cadence: quant feed daily (price and rates move daily).
+
+## Build
+
+1. Confirm the company.
+2. Shape-check the endpoints — especially the `market-metrics` beta param.
+3. Write + test + grant + deploy + release the quant feed.
+4. Build the what-if playbook HTML (reuse the `what-if` shell); write
+   `README.md`; draft; screenshot; release.

--- a/skills/alva/templates/earnings-analysis/template.md
+++ b/skills/alva/templates/earnings-analysis/template.md
@@ -1,0 +1,124 @@
+# Earnings Analysis Template
+
+Post-earnings update for a company under coverage: what the just-reported
+quarter showed against expectations, the metric and margin detail, where
+estimates moved, and whether the thesis holds. Mirrors the financial-services
+equity-research `earnings-analysis` workflow; data re-sourced to Alva.
+
+**Scope** — one company, the most recent reported quarter. The pre-earnings
+counterpart is `earnings-preview`; the daily coverage note is `morning-note`.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint |
+|---|---|
+| Reported-quarter actuals (revenue, EPS, EBITDA, margins) | `stocks/company/income-statements` `period_type=quarter` |
+| Free cash flow | `stocks/company/cashflow-statements` (`free_cash_flow`, `operating_cash_flow`) |
+| Beat/miss vs consensus | `stocks/earnings-calendar` (`eps`/`eps_estimated`, `revenue`/`revenue_estimated`) |
+| Pre-print and post-print consensus | `stocks/estimates-guidance` `type=estimate` |
+| Company guidance | `stocks/estimates-guidance` `type=guidance` |
+| Prior-quarter trend | `stocks/company/income-statements` (last 8 quarters) |
+| Last call transcript | `stocks/earnings-transcript` |
+| Valuation context | `stocks/market-metrics`, `stocks/company/price-target-consensus` |
+
+Gotchas — `earnings-calendar` values are strings; `estimates-guidance`
+`fiscal_period` is an integer 1-4. See the alva-template-migration skill's
+`data-source-mapping.md` for the full gotcha list. **Coverage gap**: Alva
+income statements carry no segment/geographic breakdown; `company/kpi` exposes
+some KPIs but not a reliable segment P&L — note the limit, never split revenue
+from model knowledge.
+
+## Feeds
+
+Two feeds (family pattern); the narrative feed runs after the quant feed.
+
+**Quant feed `<company>-earnings-analysis`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `results/reported` | snapshot | the reported quarter: revenue, EPS, EBITDA, margins — actual vs consensus vs year-ago |
+| `trends/quarterly` | event log | last 8 quarters: revenue, EPS, gross/operating margin |
+| `revisions/consensus` | tabular | consensus EPS/SALES for the forward periods, pre-print vs latest |
+| `valuation/snapshot` | snapshot | price, PE, EV/EBITDA, PT consensus |
+
+**Narrative feed `<company>-earnings-analysis-narrative`** (ADK): the "what's
+new" read — the beat/miss explanation, the margin and guidance read, and the
+thesis impact (does the quarter change the call). Labelled AI analysis.
+
+## Methodology
+
+The original earnings-analysis workflow, preserved.
+
+**Lead with beat or miss.** State whether the company beat or missed, and
+quantify the variance — "revenue beat by $120M, or 3%". Then explain *why*
+results differed from expectations.
+
+**What's new only.** An earnings update is about the delta — do not rehash
+company background. Every section answers "what changed this quarter".
+
+**Beat/miss per key metric.** Revenue, EPS, EBITDA, margins, and guidance each
+get an actual-vs-consensus line. The pre-print consensus is the bar — use the
+`estimates-guidance` row dated just before the report, not a later revision.
+
+**Margin and guidance analysis.** Walk gross → operating → net margin against
+the year-ago quarter; read the guidance against the prior consensus.
+
+**Estimate revisions.** Show consensus EPS for the forward periods before the
+print versus after — the post-print revision direction is the Street's verdict.
+
+**Revised thesis.** The ADK read states plainly whether the quarter is
+thesis-changing or noise, and what it means for the rating.
+
+## Data contract (frozen field names)
+
+```
+results/reported    { date, period, revenue, revEstimate, revYoY, eps,
+                      epsEstimate, epsYoY, ebitda, grossMargin, operatingMargin }
+trends/quarterly    { date, period, revenue, eps, grossMargin, operatingMargin }
+revisions/consensus { date, fiscalPeriod, epsPrePrint, epsLatest,
+                      salesPrePrint, salesLatest }
+valuation/snapshot  { date, price, peRatio, evEbitda, ptConsensus }
+narrative/records   { date, recordDate, generatedAt, verdict, whatsNew,
+                      thesisImpact, source }
+```
+
+`verdict` ∈ `{beat, miss, mixed}`. `whatsNew`/`thesisImpact` JSON-encoded.
+
+## Playbook
+
+Single-page scroll, results-first. Hero + four cards in the first fold.
+
+1. **Verdict hero** — Free Text Card: beat or miss, the headline variances,
+   one line on why. Inline colored numbers.
+2. **Four metric cards** — Revenue vs consensus · EPS vs consensus · Operating
+   margin · Guidance read.
+3. **Beat/miss bars** — actual vs consensus for revenue, EPS, EBITDA.
+4. **Quarterly trend** — revenue and margin over the last 8 quarters.
+5. **Estimate revisions** — consensus EPS pre-print vs latest, per forward
+   period.
+6. **What's new / thesis impact** — Free Text Card, ADK, labelled AI analysis.
+7. **References** — data sources + cadence.
+
+## Template-specific rules
+
+- One company, the most recent reported quarter.
+- Cadence: quant feed daily (catches the print and the revision wave that
+  follows); narrative feed after quant.
+- The "what's new / thesis impact" block is ADK, labelled AI analysis.
+- Segment/geographic analysis only where `company/kpi` actually provides it —
+  otherwise note the gap.
+
+## Build
+
+1. Confirm the company; confirm its most recent quarter has reported.
+2. Shape-check the endpoints.
+3. Write + test + grant + deploy + release the quant feed, then the narrative
+   feed (after quant).
+4. Build the playbook HTML; write `README.md`; draft; screenshot; release.

--- a/skills/alva/templates/model-update/template.md
+++ b/skills/alva/templates/model-update/template.md
@@ -1,0 +1,121 @@
+# Model Update Template
+
+Track how a company's consensus estimates and implied valuation move as new
+data lands — reported actuals against the prior estimate, the forward-estimate
+revisions, and the valuation impact. Mirrors the financial-services
+equity-research `model-update` workflow; data re-sourced to Alva.
+
+**Scope** — one company. A consensus-estimate and valuation revision tracker.
+The post-earnings narrative report is `earnings-analysis`; the intrinsic-value
+model is `dcf-model`.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Migration note — the "model" is the consensus
+
+The original updates the user's own Excel model. Alva has no editable
+proprietary model, so this template tracks the **consensus** model — the
+Street's estimates and the implied valuation, and how they revise. It is not a
+private analyst model. The DCF-based fair-value leg reuses the `dcf-model`
+template's logic at default assumptions. State this in the README.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint |
+|---|---|
+| Reported actuals | `stocks/company/income-statements` |
+| Consensus estimates over time (revisions) | `stocks/estimates-guidance` `type=estimate` |
+| Company guidance | `stocks/estimates-guidance` `type=guidance` |
+| Valuation inputs | `stocks/market-metrics` (PE, EV/EBITDA), `stocks/company/price-target-consensus` |
+| DCF fair-value leg | `stocks/company/cashflow-statements`, `stocks/company/balance-sheets` |
+
+## Feeds
+
+Two feeds (family pattern); the narrative feed runs after the quant feed.
+
+**Quant feed `<company>-model-update`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `actuals/reported` | tabular | latest reported quarter vs the pre-print estimate, per line item, with the delta |
+| `estimates/revisions` | tabular | consensus revenue/EBITDA/EPS for this FY and next FY — value over time |
+| `valuation/recalc` | snapshot | forward-PE, EV/EBITDA, and DCF fair values; prior vs updated; vs current price |
+
+**Narrative feed `<company>-model-update-narrative`** (ADK): the estimate-change
+summary — what changed, why, thesis-changing or noise — and the rating /
+price-target implication. Labelled AI analysis.
+
+## Methodology
+
+The original model-update workflow, preserved.
+
+**Identify what changed.** The update trigger — an earnings release, a guidance
+change, an estimate revision, a macro move, or an event.
+
+**Reconcile actuals first.** Before projecting anything, reconcile the reported
+figures against the prior estimate — actual vs estimate vs delta, per line.
+Note GAAP vs adjusted.
+
+**Track forward-estimate revisions.** Consensus revenue / EBITDA / EPS for this
+fiscal year and next — the old value vs the new, and the change. The revision
+direction and magnitude are the signal.
+
+**Valuation impact.** Recalculate fair value three ways — a forward-PE
+multiple, an EV/EBITDA multiple, and a DCF — prior vs updated, and the implied
+price target.
+
+**Summary and action.** One read: what changed, why, and whether it is
+thesis-changing or noise; maintain or change the rating.
+
+**Share count matters** — dilution from stock comp, converts, or buybacks moves
+EPS independent of operations; reconcile it.
+
+## Data contract (frozen field names)
+
+```
+actuals/reported    { date, period, lineItem, priorEstimate, actual, deltaPct }
+estimates/revisions { date, fiscalPeriod, metric, estimateOld, estimateNew,
+                      changePct }
+valuation/recalc    { date, method, fairValuePrior, fairValueNew, currentPrice,
+                      impliedUpsidePct }
+narrative/records   { date, recordDate, generatedAt, trigger, changeSummary,
+                      ratingAction, source }
+```
+
+`method` ∈ `{forwardPE, evEbitda, dcf}`. `metric` ∈ `{revenue, ebitda, eps}`.
+`trigger` ∈ `{earnings, guidance, revision, macro, event}`.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Update hero** — Free Text Card: what changed and the direction of the
+   revision; the valuation impact.
+2. **Four cards** — Revenue delta · EPS delta · New FY EPS estimate ·
+   Valuation impact.
+3. **Reported vs estimate table** — the reconciliation, per line item.
+4. **Estimate revision chart** — consensus EPS for this FY and next FY over
+   time, with the latest revision marked.
+5. **Valuation recalc** — fair value by the three methods, prior vs updated vs
+   price.
+6. **Estimate change summary / action** — Free Text Card, ADK, labelled.
+7. **References** — data sources + cadence.
+
+## Template-specific rules
+
+- One company. The tracked "model" is consensus, not a proprietary model —
+  state this in the README.
+- Cadence: quant feed daily (estimates revise continuously); narrative after.
+- The change summary and rating action are ADK, labelled AI analysis.
+
+## Build
+
+1. Confirm the company.
+2. Shape-check the endpoints.
+3. Write + deploy + release the quant feed, then the narrative feed.
+4. Build the playbook HTML; write `README.md`; draft; screenshot; release.

--- a/skills/alva/templates/sector-overview/template.md
+++ b/skills/alva/templates/sector-overview/template.md
@@ -1,0 +1,124 @@
+# Sector Overview Template
+
+An industry/sector landscape: the competitive set, how the players compare on
+growth and profitability, sector valuation, M&A activity, and the investment
+implications. Mirrors the financial-services equity-research `sector-overview`
+workflow; data re-sourced to Alva.
+
+**Scope** — one sector or subsector, public companies. Multi-company.
+
+Generic rules (design system, content legitimacy, README-as-file, naming, the
+single-page results-first shell) come from the Alva skill and the
+equity-research family shell — not repeated here.
+
+## Data
+
+Arrays data skills (`https://data-tools.prd.space.id`, `Authorization: Bearer
+<ARRAYS_JWT>`). Run `list`→`summary`→`endpoint` before coding.
+
+| Need | Endpoint |
+|---|---|
+| Sector universe | `stocks/screener/basic-info/sector` (or `industry`) |
+| Company profiles | `stocks/company/detail` |
+| Revenue, growth, margins, EBITDA | `stocks/financial-metrics`, `stocks/company/income-statements` |
+| Valuation multiples (PE, EV/EBITDA, EV/Revenue) | `stocks/market-metrics` |
+| Sector M&A | `stocks/mergers-acquisitions` |
+| Trends, drivers, news | `stocks/market-news`, content search |
+
+**Coverage gaps** — Alva has no total-addressable-market / market-sizing data
+and no true market-share data. Compute *revenue share within the screened
+universe* as a labelled proxy ("share of the tracked peer set", not "market
+share"). Never fabricate a TAM number; if market size is needed, source it
+narratively with a citation, or omit the section.
+
+## Feeds
+
+Two feeds (family pattern); the narrative feed runs after the quant feed.
+
+**Quant feed `<sector>-sector-overview`:**
+
+| Output | Pattern | Contents |
+|---|---|---|
+| `universe/members` | tabular | the screened companies + profile (name, industry, market cap) |
+| `metrics/companies` | tabular | per company: revenue, growth, gross/EBITDA margin, universe revenue share |
+| `valuation/multiples` | tabular | per company: PE, EV/EBITDA, EV/Revenue, plus sector median/quartile rows |
+| `events/ma` | event log | sector M&A, trailing window |
+
+**Narrative feed `<sector>-sector-overview-narrative`** (ADK): the industry
+structure read (fragmented vs consolidated, value chain, barriers), the key
+trends and drivers, and the investment implications and bull/bear debates.
+Labelled AI analysis.
+
+## Methodology
+
+The original sector-overview workflow, preserved.
+
+**Define the scope.** Sector vs subsector, and the angle — a neutral landscape
+or a thematic thesis. Public-company universe.
+
+**Market overview.** Size, growth, segmentation. Alva has no TAM data — state
+sizing narratively with a citation or omit it; never fabricate a market-size
+number, and distinguish TAM hype from realistic addressable market.
+
+**Industry structure.** Fragmented vs consolidated — use the top-5 share of the
+*screened universe's* revenue as the concentration proxy, labelled as such.
+Value chain, business-model types, barriers to entry.
+
+**Competitive landscape.** The top players as a comparison table — revenue,
+growth, EBITDA margin, valuation — each with a one-line profile.
+
+**Valuation context.** Sector trading multiples now versus their historical
+range; what drives the premium or discount.
+
+**Investment implications.** Where the best risk/reward sits, the key bull/bear
+debates, the catalysts that could shift the sector narrative.
+
+**Sector overviews age fast** — the feed refresh keeps the data current; the
+playbook carries no stale point-in-time figures.
+
+## Data contract (frozen field names)
+
+```
+universe/members    { date, symbol, name, industry, marketCap }
+metrics/companies   { date, symbol, revenue, revGrowth, grossMargin,
+                      ebitdaMargin, universeRevSharePct }
+valuation/multiples { date, symbol, peRatio, evEbitda, evRevenue }
+narrative/records   { date, recordDate, generatedAt, structure, trends,
+                      implications, source }
+```
+
+Sector median/quartile rows ride on `valuation/multiples` with `symbol` set to
+`__median__` / `__p75__` / `__p25__`. `structure`/`trends`/`implications` are
+JSON-encoded.
+
+## Playbook
+
+Single-page scroll, results-first.
+
+1. **Sector hero** — Free Text Card: the sector snapshot — how many names, the
+   growth and valuation picture, the headline structural read.
+2. **Four cards** — Universe size · Sector median revenue growth · Sector
+   median EV/EBITDA · M&A deal count.
+3. **Company comparison table** — the players: revenue, growth, EBITDA margin,
+   PE, EV/EBITDA, universe revenue share.
+4. **Valuation scatter** — growth vs EV/EBITDA, one point per company.
+5. **Sector multiple vs history** — the sector median multiple over time.
+6. **M&A activity** — recent sector deals.
+7. **Structure / trends / implications** — Free Text Card, ADK, labelled.
+8. **References** — data sources, the proxy/gap notes, cadence.
+
+## Template-specific rules
+
+- One sector; the universe is the screened member set, fixed at build time.
+- "Revenue share" is universe-relative and labelled a proxy — never presented
+  as true market share.
+- No fabricated TAM/market-size numbers.
+- Cadence: quant feed weekly (sector data moves slowly); narrative after quant.
+
+## Build
+
+1. Confirm the sector/subsector and the angle (neutral vs thematic).
+2. Screen the universe; verify each member's sector via `company/detail`.
+3. Shape-check the endpoints.
+4. Write + deploy + release the quant feed, then the narrative feed.
+5. Build the playbook HTML; write `README.md`; draft; screenshot; release.


### PR DESCRIPTION
## What

Migrates a second batch of `anthropics/financial-services` skills into self-contained Alva playbook templates — three from the **equity-research** vertical, three from **financial-analysis**:

| Template | Migrated from | Shape |
|---|---|---|
| `earnings-analysis` | equity-research/earnings-analysis | Post-earnings update report (single company) |
| `sector-overview` | equity-research/sector-overview | Sector landscape (multi-company) |
| `model-update` | equity-research/model-update | Consensus-estimate & valuation revision tracker |
| `competitive-analysis` | financial-analysis/competitive-analysis | Competitive landscape (peer set) |
| `dcf-model` | financial-analysis/dcf-model | Intrinsic-value what-if playbook |
| `comps-analysis` | financial-analysis/comps-analysis | Comparable-company table with quartile stats |

## Approach

- **Methodology preserved, data layer swapped** — each `template.md` keeps the original skill's workflow and judgment; data is re-pointed from institutional MCP connectors to Alva data skills.
- **Modeling skills migrated as what-if / tracker playbooks** — `dcf-model` becomes an interactive what-if valuation (assumptions are reader inputs, the DCF recomputes client-side over feed-sourced historicals); `model-update` tracks the *consensus* model, not a proprietary Excel model. Both note the lower fidelity vs an Excel model.
- **Deck → playbook** — `competitive-analysis`'s PowerPoint deliverable is re-cast as a playbook; the qualitative layer (moats, synthesis) is labelled ADK analysis.
- DCF data-contract fields are live-verified via `alva run` shape-checks (`cashflow-statements`, `balance-sheets`).

## Documented coverage gaps

- No TAM / market-size or true market-share data → `sector-overview` uses a labelled universe-revenue-share proxy; `competitive-analysis` notes the gap.
- No segment/geographic P&L → `earnings-analysis` limits segment analysis to what `company/kpi` provides.
- No industry operating KPIs (ARR, NRR, GMV) → `competitive-analysis` runs on standard financials.

Follows the `alva-template-migration` skill. Batch 1 (equity-research text workflows): alva-ai/skills#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)