### PR TITLE
[jaxxjj] docs(alva): notify/message uses canonical `body` field

### DIFF
--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -270,7 +270,7 @@ const feed = new Feed({ path: feedPath("daily-briefing") });
 feed.def("notify", {
   message: makeDoc("Notification", "Agent-generated push content", [
     str("title"),
-    str("text"),
+    str("body"),
   ]),
 });
 
@@ -282,7 +282,7 @@ feed.def("notify", {
       {
         date: Date.now(),
         title: "Daily Crypto Briefing",
-        text: result.text,
+        body: result.text,
       },
     ]);
   });
@@ -309,10 +309,14 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - The group **must** be named `notify` and the output **must** be named
   `message` — this is the path the notification system looks for.
 - `title` is optional — if provided, the notification renders as
-  `**title**\n\ncontent`.
-- `text` is the notification body (required for content push).
+  `**title**\n\nbody`.
+- `body` is the notification body (required for content push). The
+  legacy field name `text` is still accepted for backwards compatibility,
+  but `body` is the canonical name and matches FCM / APNS / Web Push
+  / HTTP / email convention — prefer `body` in new feeds. If both
+  `body` and `text` are set on the same record, `body` wins.
 - **`alva release feed` is required** — without it, the push is still
-  dispatched but arrives with an empty body (no `title`/`text`).
+  dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal or group subscriptions.
 - Real delivery requires an explicit subscription: personal


### PR DESCRIPTION
## Summary

\`notify/message\` push schema docs now use \`body\` as the canonical body field, with \`text\` documented as a legacy alias for backwards compatibility.

LLM agents default to \`body\` from their training distribution (every comparable push API — FCM, APNS, W3C Web Push, HTTP, email — uses \`body\`), so canonicalizing on \`body\` eliminates the most common silent-drop case: wrong field name → empty render → dispatcher skips with no log.

Discovered when a QA playbook used \`str(\"body\")\` and pushes silently dropped. Cronjob completed, ALFS row landed, every publisher signal was green, but TG / Discord / Web push delivered nothing — zero breadcrumb.

## Backend support

Backend back-compat patch: alva-ai/alva-backend#1127 — \`notifyMessage.Body\` accepted as canonical, \`Text\` kept as alias, \`Body\` wins when both set.

## Test plan

- [x] Read-only doc change; no code path touched.
- [ ] After merge, follow up on \`code/backend/sdkhub/assets/@alva/alvaask\` examples if any reference Pattern E (currently none do — verified by grep).