### PR TITLE
[jaxxjj] docs(alva): add `alva playbook` and `alva feed list` CLI guidance

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -814,19 +814,25 @@ deleted by the user.
    a new one**, stop before calling `alva release playbook`. Tell the
    user the existing playbook must be deleted first, and ask which path
    they want:
-   - **Delete the old playbook** — direct the user to remove their
-     existing playbook from the Alva dashboard, then resume. Do not
-     attempt to "rename around" the cap, reuse the old playbook's
-     name without an explicit deletion, or assume any in-app replace
-     flow will migrate `display_name`, feeds, or cronjobs cleanly —
-     it currently does not, and the old public URL can end up showing
-     the new playbook's HTML with stale metadata.
+   - **Delete the old playbook** — list their existing playbooks and
+     confirm which one to remove, then call the CLI directly:
+     ```bash
+     alva playbook list                        # show what they have
+     alva playbook delete --name <old-name>    # soft-delete (frees the quota immediately)
+     ```
+     Do **not** suggest `alva fs remove --path ~/playbooks/<name>` —
+     that only clears ALFS files; the DB row stays and the quota stays
+     consumed. Do not attempt to "rename around" the cap, reuse the
+     old playbook's name without an explicit deletion, or assume any
+     in-app replace flow will migrate `display_name`, feeds, or
+     cronjobs cleanly — it currently does not, and the old public URL
+     can end up showing the new playbook's HTML with stale metadata.
    - **Keep both** — only possible on Pro. Offer the upgrade path at
      <https://alva.ai/pricing>.
 
-   After the user confirms the deletion, re-run the full release
-   pipeline (draft → README → release) for the new playbook from
-   scratch under a fresh `name`.
+   After the deletion call returns, re-run the full release pipeline
+   (draft → README → release) for the new playbook from scratch under
+   a fresh `name`.
 3. **Upsell only on friction**: Do **not** proactively suggest upgrading.
    But when the user's experience is degraded because of free-tier
    limitations — wanting private playbooks, hitting the one-playbook cap,

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -1,8 +1,17 @@
 # Deployment Guide
 
-Deploy scripts as cronjobs for scheduled, automated execution. This is essential
-for feeds that need regular updates (e.g. hourly price data) and recurring
-tasks.
+Deploy scripts as cronjobs for scheduled, automated execution and manage the
+downstream feed / playbook resources they produce. This is essential for feeds
+that need regular updates (e.g. hourly price data), recurring tasks, and for
+cleaning up when a deployment is retired or replaced.
+
+The three lifecycle CLI groups:
+
+| Group           | Manages                              | Common commands                  |
+| --------------- | ------------------------------------ | -------------------------------- |
+| `alva deploy`   | Cronjobs (schedule + entry script)   | `create`, `list`, `update`, `delete`, `runs` |
+| `alva feed`     | Released feed records + active majors | `list`, `delete`                |
+| `alva playbook` | Published playbook records           | `list`, `delete`                 |
 
 ---
 
@@ -155,6 +164,44 @@ execution, useful for tracing errors or verifying output.
 ```bash
 alva deploy run-logs --id 42 --run-id 123
 ```
+
+---
+
+## Feed / Playbook lifecycle — extras not in CLI help
+
+Run `alva feed --help` and `alva playbook --help` for subcommands,
+flags, and response shapes. This section only covers the conceptual
+boundaries and the deletion gotcha — the help text is authoritative
+on flags.
+
+**What each group manages.**
+
+- `alva deploy` — the **cronjob** (schedule + entry script + args). Lives
+  in the `cronjobs` table.
+- `alva feed` — the **released feed record + active majors** (the row
+  written by `alva release feed`, consumed by the push-fanout path).
+  Lives in `feeds` / `feed_majors`.
+- `alva playbook` — the **published playbook** (rendered HTML +
+  display_name + visibility + ACL). Lives in `playbooks` and is
+  surfaced at `https://alva.ai/u/<username>/playbooks/<name>`.
+
+These three move in lockstep at create time (`alva deploy create` →
+`alva release feed` → `alva release playbook`) but each has its own
+lifecycle row. Deleting one does **not** automatically delete the
+others — see the cascade notes in each `--help`.
+
+**Don't use `alva fs remove` to delete a feed or playbook.** It clears
+the ALFS files (the rendered HTML, the data mount), but the
+`playbooks` / `feeds` DB row stays alive. The platform still:
+
+- counts the playbook against the free-tier 1-playbook cap
+- serves the (now empty) public URL with stale metadata
+- fires push fanout for the (now empty) feed
+
+The cap-gate symptom is "the platform still has a playbook record for
+me even after I cleaned the ALFS files". The fix is `alva playbook
+delete --name <X>` (or `alva feed delete --id <X>`), which
+soft-deletes the DB row and frees the quota / ACL immediately.
 
 ---
 


### PR DESCRIPTION
## Summary

Two related additions to support the new CLI commands landing in alva-ai/toolkit-ts#60 (\`alva playbook list/delete\` + \`alva feed list\`) and the gateway endpoints in alva-ai/alva-gateway#404.

## Changes

### \`SKILL.md\` — free-tier 1-playbook cap section

Previously the section told the agent to "direct the user to remove their existing playbook from the Alva dashboard". With the new CLI, the agent can now resolve this without leaving the chat. Updated to:

\`\`\`bash
alva playbook list                        # show what they have
alva playbook delete --name <old-name>    # soft-delete (frees the quota immediately)
\`\`\`

Also adds an explicit warning that \`alva fs remove ~/playbooks/<name>\` only clears ALFS files and leaves the DB row alive — this was the tungwu cap-gate root cause on 2026-05-19.

### \`references/deployment.md\` — new "Feed / Playbook lifecycle" section

Followed the lean pattern used by \`references/api/filesystem.md\`: defer the flag tables to \`alva feed --help\` / \`alva playbook --help\` (which the toolkit-ts PR keeps authoritative), and only document what the help text doesn't cover:

- Conceptual boundaries between \`alva deploy\` (cronjob) / \`alva feed\` (released feed) / \`alva playbook\` (published playbook), and which DB tables each backs.
- The \`alva fs remove\` gotcha — explains exactly why "I cleaned the ALFS files" doesn't free the cap and what the symptom looks like.

## Depends on

- \`alva-ai/alva-gateway#404\` — REST routes \`GET /api/v1/playbook\` + \`GET /api/v1/feed\`
- \`alva-ai/toolkit-ts#60\` — CLI subcommands

Merge after those two land.