### PR TITLE
docs(alva): sharpen ADK trigger; trim quick-reference bleed

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1454,42 +1454,15 @@ altra.setStrategy(strategyFn, {
 
 ## ADK (Agent Development Kit) Quick Reference
 
-See [adk.md](references/adk.md) for the full API, tool-calling patterns, memory
-patterns, and implementation examples.
+`@alva/adk` (`adk.agent()`) embeds an LLM reasoning step inside a deterministic,
+reschedulable pipeline — a feed cronjob's summarization stage, a periodic
+digest, a classification step. For one-off research the user asks for
+interactively, answer them directly; do not wrap it in `adk.agent()`.
 
-ADK is a universal agent development kit that runs inside the Jagent V8 runtime.
-Use it to build LLM-powered agents that can reason over tasks, call tools,
-gather context from multiple sources, and return structured outputs.
-
-It is best suited for workflows where the "thinking" step cannot be expressed as
-pure deterministic code, such as research synthesis, document analysis,
-classification, and summarization over real upstream data.
-
-### When to Use ADK
-
-Use ADK when you need an agent to:
-
-- Fetch real data through tools, APIs, SDKs, or files
-- Reason over multiple inputs before producing an answer
-- Synthesize findings into structured notes, summaries, or classifications
-- Power periodic research or analysis workflows that run on a schedule
-- Add an LLM-driven transformation step inside a larger data pipeline
-
-### When NOT to Use ADK
-
-ADK must **never** be used to fabricate data that should come from real sources.
-Specifically:
-
-- Do NOT use ADK to generate hiring statistics, financial events, analyst
-  reports, or any quantitative data that claims to originate from a real data
-  pipeline.
-- Do NOT present ADK-generated content as if it were sourced from SDKs, APIs,
-  or databases.
-- If a data source is unavailable, report the limitation as a blocker — do not
-  use ADK as a fallback data generator.
-
-ADK output that involves reasoning over real data (sentiment classification,
-trend summarization) is fine, but must be labeled as AI-generated analysis.
+See [adk.md](references/adk.md) for triggers, the API, tool-calling and memory
+patterns, and examples. The "never fabricate data as if sourced" gate is
+Content Legitimacy Rule #2 above — read that before using ADK to produce any
+user-facing number, event, or report.
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1454,15 +1454,19 @@ altra.setStrategy(strategyFn, {
 
 ## ADK (Agent Development Kit) Quick Reference
 
-`@alva/adk` (`adk.agent()`) embeds an LLM reasoning step inside a deterministic,
-reschedulable pipeline — a feed cronjob's summarization stage, a periodic
-digest, a classification step. For one-off research the user asks for
-interactively, answer them directly; do not wrap it in `adk.agent()`.
+`@alva/adk` (`adk.agent()`) embeds a fixed LLM reasoning step inside a
+deterministic, reschedulable pipeline — a feed cronjob's summarization stage,
+a scheduled digest, a "why it matters" headline, a classification step. The
+prompt and tool set are locked in; only the upstream data changes each run.
 
-See [adk.md](references/adk.md) for triggers, the API, tool-calling and memory
-patterns, and examples. The "never fabricate data as if sourced" gate is
-Content Legitimacy Rule #2 above — read that before using ADK to produce any
-user-facing number, event, or report.
+Do **not** use it for one-off research, exploratory analysis, or "help me look
+into X" the user asks interactively — answer directly with your own tools;
+wrapping it in `adk.agent()` adds a sandbox without buying anything. And do
+not use it to produce numbers, events, or reports that should come from a real
+data source (see Content Legitimacy Rule #2 above).
+
+See [adk.md](references/adk.md) for the API, tool-calling and memory patterns,
+and examples.
 
 ---
 

--- a/skills/alva/references/adk.md
+++ b/skills/alva/references/adk.md
@@ -6,30 +6,6 @@ A SDK for building LLM-powered agents with tool calling to enable agentic featur
 > delta body, push line, etc.), include the voice block from
 > [narrative-voice.md](narrative-voice.md) verbatim in `system`.
 
-## When to use ADK
-
-ADK is for embedding a fixed LLM reasoning step inside a deterministic,
-reschedulable pipeline. The shape of the work is locked in; only the input
-changes each run.
-
-Use it for:
-
-- A feed cronjob's summarization, classification, or extraction stage (raw
-  fetched items → TLDR, sentiment label, structured note).
-- A scheduled digest, daily push body, "why it matters" headline, or delta
-  rationale generated on each release.
-- A pipeline step where the prompt and tool set are fixed but the upstream
-  data refreshes.
-
-Do **not** use it for:
-
-- One-off research, exploratory analysis, or "help me look into X" the user
-  asks interactively. Answer directly with your own tools; wrapping it in
-  `adk.agent()` adds a sandbox without buying anything.
-- Producing numbers, events, or reports that should come from a real data
-  source. ADK reasons over real data; it does not invent it. See SKILL.md's
-  Content Legitimacy Rules.
-
 ## Quick Start
 
 ```javascript

--- a/skills/alva/references/adk.md
+++ b/skills/alva/references/adk.md
@@ -6,6 +6,30 @@ A SDK for building LLM-powered agents with tool calling to enable agentic featur
 > delta body, push line, etc.), include the voice block from
 > [narrative-voice.md](narrative-voice.md) verbatim in `system`.
 
+## When to use ADK
+
+ADK is for embedding a fixed LLM reasoning step inside a deterministic,
+reschedulable pipeline. The shape of the work is locked in; only the input
+changes each run.
+
+Use it for:
+
+- A feed cronjob's summarization, classification, or extraction stage (raw
+  fetched items → TLDR, sentiment label, structured note).
+- A scheduled digest, daily push body, "why it matters" headline, or delta
+  rationale generated on each release.
+- A pipeline step where the prompt and tool set are fixed but the upstream
+  data refreshes.
+
+Do **not** use it for:
+
+- One-off research, exploratory analysis, or "help me look into X" the user
+  asks interactively. Answer directly with your own tools; wrapping it in
+  `adk.agent()` adds a sandbox without buying anything.
+- Producing numbers, events, or reports that should come from a real data
+  source. ADK reasons over real data; it does not invent it. See SKILL.md's
+  Content Legitimacy Rules.
+
 ## Quick Start
 
 ```javascript


### PR DESCRIPTION
## Summary

- The SKILL.md "ADK Quick Reference" section was ~39 lines. "When to Use ADK" listed things any agent does (fetch data, reason, synthesize) and "When NOT to Use ADK" paralleled Content Legitimacy Rule #2 in different words — cover/contain bleed.
- The trigger that actually distinguishes ADK was missing: it embeds a fixed LLM step inside a deterministic, reschedulable pipeline. Ad-hoc research the user asks for interactively does not need ADK at all.
- Trim SKILL.md to a Principle-2-shaped mention (what + when + pointer + backref to Rule #2). Move the substantive framing into `references/adk.md` with a sharper Use / Do-Not-Use split.

## Test plan

- [x] `scripts/audit.sh` clean (no broken links, no orphan refs).
- [x] Cold-read judgment pass: SKILL.md section matches the allowed mention shape; new `adk.md` "Do not use it for" routes to Rule #2 instead of restating it.
- [x] No other ADK call-site (`feed-sdk.md`, `jagent-runtime.md`, `narrative-voice.md`, `api/release.md`) depended on the deleted text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)