### PR TITLE
docs(alva): add ONNX skill reference

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1009,6 +1009,7 @@ the full locate-and-edit procedure.
 | [feed-sdk.md](references/feed-sdk.md) | Feed SDK guide: creating data feeds, time series, upstreams, state management |
 | [fundamentals-periods.md](references/fundamentals-periods.md) | Fiscal vs calendar periods for fundamentals: derive period labels from the record, align companies by `calendarEndDate`, compute YoY across matched periods |
 | [altra-trading.md](references/altra-trading.md) | Altra backtesting engine: strategies, features, signals, testing, debugging |
+| [onnx.md](references/onnx.md) | ONNX model playbooks: uploaded `.onnx` artifacts, `@alva/onnx` inference, FeedAltra patterns, output and release checks |
 | [deployment.md](references/deployment.md) | Deploying scripts as cronjobs for scheduled execution |
 | [design-system.md](references/design-system.md) | Alva Design System entry point: tokens, typography, layout; links to widget, component, and playbook specs |
 | [remix-workflow.md](references/remix-workflow.md) | Remix: create a new playbook from an existing template |
@@ -1071,6 +1072,7 @@ variables, or shell. Host-agent permissions still apply. See
 | @alva/algorithm | `require("@alva/algorithm")` | Statistics                                                              |
 | @alva/feed      | `require("@alva/feed")`      | Feed SDK for persistent data pipelines + FeedAltra trading engine       |
 | @alva/adk       | `require("@alva/adk")`       | Agent SDK for LLM requests — `agent()` for LLM agents with tool calling |
+| @alva/onnx      | `require("@alva/onnx")`      | ONNX inference for supplied model artifacts; see [onnx.md](references/onnx.md) |
 | @test/suite     | `require("@test/suite")`     | Jest-style test framework (`describe`, `it`, `expect`, `runTests`)      |
 
 **Runtime libraries**: Built-in computation modules available via `require()`
@@ -1083,6 +1085,12 @@ variables, or shell. Host-agent permissions still apply. See
 from the Arrays backend — see the [Data Skills](#3-data-skills) section. Load
 `ARRAYS_JWT` via `secret.loadPlaintext('ARRAYS_JWT')` and call Arrays endpoints
 with `Authorization: Bearer <ARRAYS_JWT>`.
+
+**ONNX model inference**: If a user supplies, or plans to upload, an exported
+`.onnx` model artifact, read [onnx.md](references/onnx.md). Use `@alva/onnx` with
+`InferenceSession.createFromAlfs({ alfs, path })`, build tensors from real data,
+write prediction outputs through the Feed SDK, and render the playbook from
+released/granted feed paths.
 
 **Secret Manager**: use `const secret = require("secret-manager");` then
 `secret.loadPlaintext("OPENAI_API_KEY")`. This returns a string when present or

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -23,7 +23,7 @@ via `alva run` (inline code or filesystem entry path) or triggered by cronjobs.
 1. **ALFS files** -- paths ending in `.js` that don't start with `@` (e.g.
    `require("./helper.js")`) -- resolved from the filesystem on ALFS
 2. **Official/system modules** -- `alfs`, `env`, `secret-manager`,
-   `net/http`, `@alva/algorithm`, `@alva/feed`, `@alva/adk`
+   `net/http`, `@alva/algorithm`, `@alva/feed`, `@alva/adk`, `@alva/onnx`
 3. **Runtime library modules** -- versioned modules like
    `require("@alva/technical-indicators/rsi:v1.0.0")`
 
@@ -65,7 +65,7 @@ const home = "/alva/home/" + env.username; // absolute ALFS prefix (e.g. '/alva/
 | Method           | Signature                                     | Description                                             |
 | ---------------- | --------------------------------------------- | ------------------------------------------------------- |
 | readFile         | `readFile(path) → string`                     | Read file content as string                             |
-| readFileBytes    | `readFileBytes(path) → Uint8Array`            | Read file as bytes                                      |
+| readFileBytes    | `readFileBytes(path) → string`                | Read file bytes as base64 string                        |
 | writeFile        | `writeFile(path, content)`                    | Write string content to file (auto-creates parent dirs) |
 | stat             | `stat(path) → {exists, isDir, size}`          | Get file metadata                                       |
 | readDir          | `readDir(path) → [{name, isDir, size}, ...]`  | List directory                                          |
@@ -85,9 +85,9 @@ const home = "/alva/home/" + env.username; // absolute ALFS prefix (e.g. '/alva/
 All methods return Promises (async). Construct paths with your user ID:
 
 ```javascript
-const content = alfs.readFile(home + "/data/config.json");
-alfs.writeFile(home + "/data/output.json", JSON.stringify(result));
-const entries = alfs.readDir(home + "/data");
+const content = await alfs.readFile(home + "/data/config.json");
+await alfs.writeFile(home + "/data/output.json", JSON.stringify(result));
+const entries = await alfs.readDir(home + "/data");
 ```
 
 ### env -- Environment
@@ -170,6 +170,44 @@ const bbands = indicators.bb(closePrices, 20, 2);
 Categories: trend (SMA, EMA, DEMA, TEMA, MACD, Parabolic SAR, etc.), momentum
 (RSI, Stochastic, Williams %R, etc.), volatility (ATR, Bollinger Bands, Keltner
 Channel, etc.), volume (OBV, MFI, VWAP, etc.).
+
+### @alva/onnx -- ONNX Inference
+
+```javascript
+const { InferenceSession, Tensor, TensorDataType } = require("@alva/onnx");
+```
+
+Use this module for supplied/exported `.onnx` model artifacts. Read binary model
+artifacts with `InferenceSession.createFromAlfs({ alfs, path })`, build typed
+input tensors, and await `session.run(...)`.
+
+```javascript
+const alfs = require("alfs");
+const env = require("env");
+const { InferenceSession, Tensor, TensorDataType } = require("@alva/onnx");
+
+(async () => {
+  let session;
+  try {
+    session = await InferenceSession.createFromAlfs({
+      alfs,
+      path: `/alva/home/${env.username}/models/my-model/v1/model.onnx`,
+    });
+    const outputs = await session.run({
+      input: new Tensor(TensorDataType.Float32, new Float32Array([1, 2, 3]), [
+        1,
+        3,
+      ]),
+    });
+    console.log(outputs.score.data[0]);
+  } finally {
+    if (session) await session.release();
+  }
+})();
+```
+
+See [onnx.md](onnx.md) for the model-playbook contract, FeedAltra session
+lifecycle, output convention, and release checks.
 
 ### @test/suite -- Testing
 

--- a/skills/alva/references/onnx.md
+++ b/skills/alva/references/onnx.md
@@ -1,0 +1,229 @@
+# ONNX Model
+
+Use this reference when a user supplies, or plans to upload, an exported `.onnx`
+model artifact and wants Alva to run real-data inference, then persist the
+prediction as feed data, use it inside a FeedAltra strategy, emit an actionable
+signal, or render it in a released playbook. Do not present this as model
+training: Alva prepares data, runs inference, backtests or simulates supplied
+models, and renders results.
+
+This file is ONNX-only. Use [jagent-runtime.md](jagent-runtime.md) for runtime
+and ALFS details, [feed-sdk.md](feed-sdk.md) for feed writes,
+[altra-trading.md](altra-trading.md) for FeedAltra contracts, and
+[api/release.md](api/release.md) for general release gates.
+
+## Model Handoff From Research
+
+Before writing inference code, confirm the user or upstream training pipeline
+has supplied the research artifacts Alva needs to reproduce scoring:
+
+- investment thesis: asset/universe, prediction horizon, and decision use
+- label definition: return, class, rank, allocation, or signal target
+- feature recipe: raw fields, rolling windows, z-score/normalization, smoothing,
+  missing-data policy, and timestamp convention
+- tensor contract: input name, dtype, shape, flatten order, output name, and
+  output semantics
+- artifact set: `model.onnx` plus `model_meta.json`
+- validation evidence: train/test split, metrics, known failure modes, drift
+  risks, and intended retraining or re-upload cadence
+
+Training and export are external to Alva. The handoff is successful when Alva can
+rebuild the exact feature vector from real data and feed it into the uploaded
+ONNX graph without guessing.
+
+## Runtime Inference
+
+Production playbooks load uploaded models from ALFS inside an async entrypoint:
+
+```javascript
+const { InferenceSession, Tensor, TensorDataType } = require("@alva/onnx");
+
+(async () => {
+  const session = await InferenceSession.createFromAlfs({
+    alfs,
+    path: modelPath,
+  });
+  try {
+    const outputs = await session.run({
+      [inputName]: new Tensor(TensorDataType.Float32, featureVector, dims),
+    });
+    return outputs;
+  } finally {
+    await session.release();
+  }
+})();
+```
+
+Rules:
+
+- Use absolute ALFS paths such as
+  `/alva/home/${env.username}/models/<model>/v1/model.onnx`.
+- `createFromAlfs` delegates to `alfs.readFileBytes`; jagent currently returns
+  base64 for bytes, and `@alva/onnx` decodes it internally. It is also compatible
+  if a future runtime returns raw bytes. Do not hand-roll `atob`, `Uint8Array`,
+  or byte conversion in playbook code.
+- `createFromBase64` is for small demos/tests. Production should use uploaded
+  artifacts through `createFromAlfs`.
+- Tensor dtype, shape, input names, and output names must come from model
+  metadata or the training recipe. Trading vectors are usually
+  `TensorDataType.Float32`, but do not guess.
+- Release every session in `finally`. Sessions belong to the current jagent
+  execution and cannot be persisted across cronjob runs.
+
+## Tensor Shapes
+
+Tensor data is flat, and `dims` describes how the ONNX graph interprets that flat
+array. The product of `dims` must equal the data length.
+
+Common finance shapes:
+
+| Use case | Typical shape | Flatten order |
+| --- | --- | --- |
+| Single tabular row | `[1, features]` | `[f0, f1, ...]` |
+| Multi-asset row | `[1, assets, features]` | asset-major, then feature order |
+| OHLCV window | `[1, bars, 5]` | oldest-to-newest bars, each `[open, high, low, close, volume]` |
+| Regression output | `[1, 1]` | `outputs.<name>.data[0]` |
+| Classification output | `[1, classes]` | `Array.from(outputs.<name>.data)` |
+
+Examples:
+
+```javascript
+const tabular = new Tensor(
+  TensorDataType.Float32,
+  new Float32Array([f1, f2, f3, f4]),
+  [1, 4],
+);
+
+const multiAsset = new Tensor(
+  TensorDataType.Float32,
+  new Float32Array(flatFeatures),
+  [1, assets, features],
+);
+
+const ohlcv = new Tensor(
+  TensorDataType.Float32,
+  new Float32Array(flatOhlcv),
+  [1, bars, 5],
+);
+```
+
+Only include image-style tensors such as `[1, 3, height, width]` when the user's
+actual ONNX model is image-based. Most Alva investing models should document
+tabular, panel, or time-window shapes instead.
+
+## Model Artifacts
+
+Keep model artifacts separate from feed/playbook outputs:
+
+```text
+~/models/<model-name>/v1/model.onnx
+~/models/<model-name>/v1/model_meta.json
+```
+
+Use the directory version for the model contract major version: input names,
+shapes, feature order, output semantics, and decision mapping. Put the exact
+artifact version or hash in `model_meta.json`.
+
+Do not grant public read on model artifacts unless the user explicitly wants to
+share the model. Public playbooks expose feed outputs, not the `.onnx` file.
+
+`model_meta.json` should include:
+
+- model name, contract version, artifact hash/version, owner/source, training
+  time, and training data window
+- task type: regression, classification, ranking, or allocation
+- data contract: universe, asset order, interval, timestamp convention,
+  adjusted/unadjusted prices, units/currency, and missing-data policy
+- input contract: input names, dtypes, dims, feature order, lookback, flatten
+  order, normalization, scaler fit scope, and imputation policy
+- output contract: output names, dtypes, dims, units/classes, horizon, class
+  order, probability/logit semantics, thresholds, and sizing/no-trade rules
+- validation evidence: train/validation/test or walk-forward windows, metrics,
+  cost assumptions, limitations, drift risks, and retraining expectation
+
+If input shape, feature order, normalization, or output meaning is missing, ask
+the user before writing inference code.
+
+## FeedAltra Inference
+
+Use FeedAltra when ONNX output drives a backtest, rebalance, simulation, trading
+signal, or strategy metric. Follow [altra-trading.md](altra-trading.md) for the
+general feature/strategy shape; ONNX adds these constraints:
+
+- Create the session once per jagent execution, not once per bar. A lazy
+  `getSession()` may memoize `sessionPromise`; clear cached state after release.
+- Reproduce training exactly: identifiers, intervals, bar-close timestamps,
+  lookback, missing-data policy, feature order, scaling, target horizon, labels.
+- The feature timestamp is the time input evidence is available, not the
+  prediction horizon. Never use future bars to build the tensor for time `T`.
+- Scalers and normalizers must be fitted on training data or rolling history
+  available at or before `T`, never on the full backtest or live window.
+- Do not read labels, future returns, future ranks, future volatility/drawdown,
+  or other target-derived fields while building the inference tensor.
+- `inputConfig` must request every evidence window needed by the model.
+
+Inside an async feature function, keep the ONNX call explicit:
+
+```javascript
+const result = await session.run({
+  [inputName]: new Tensor(TensorDataType.Float32, row.features, dims),
+});
+return { date: row.date, prediction: result[outputName].data[0] };
+```
+
+The input name, output name, dims, feature builder, and normalization must come
+from `model_meta.json` or the user's training recipe. Raw model outputs are
+predictions, not trading instructions; thresholds, no-trade bands, and position
+sizing must also come from the model metadata or research recipe.
+
+## Feed Outputs
+
+ONNX inference does not create feed outputs by itself. Keep model artifacts under
+`~/models/...`, and explicitly write only the derived prediction rows or summaries
+that the playbook and downstream consumers need.
+
+Recommended output groups, when the playbook needs them:
+
+| Output | Purpose |
+| --- | --- |
+| `model/features` | Feature snapshot plus prediction rows for audit and charts |
+| `model/summary` | Latest verdict, freshness, model version, compact chart arrays, diagnostics |
+| `signal/targets` | Actionable target, if the model emits a trading signal |
+
+If using FeedAltra, its normal `signal`, `sim`, and `perf` outputs are covered by
+[altra-trading.md](altra-trading.md); do not duplicate them unless the playbook
+needs a custom ONNX-specific view.
+
+If released HTML displays ONNX predictions or metrics, it must read released feed
+data at runtime, commonly:
+
+```text
+/alva/home/<username>/feeds/<feed-name>/v1/data/model/summary/@last/1
+/alva/home/<username>/feeds/<feed-name>/v1/data/model/features/@last/500
+```
+
+Preview fixtures must not become the authoritative source or production fallback.
+These names are recommendations, not a required schema; choose the smallest feed
+surface that supports the playbook and downstream consumers.
+
+## README And Release Additions
+
+Follow the normal README and release rules in `SKILL.md` and
+[api/release.md](api/release.md). ONNX only adds these checks:
+
+- README names the model artifact/version, training window, feature contract,
+  output meaning, validation evidence, and re-upload or retraining expectation.
+- `alva run` proves the script fetches real data, loads the `.onnx` file from
+  ALFS, and builds tensors with the documented shape.
+- Released HTML reads released feed data, not embedded prediction arrays or
+  preview fixtures.
+- Public access should normally be granted to released feed outputs, not the
+  model artifact.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Session or tensor error | Reusing a released session, wrong dtype, or `dims` product differs from data length | Create one session per run and rebuild the tensor from `model_meta.json` |
+| Missing graph key | Wrong ONNX input/output name | Use the names from model metadata or runtime introspection, then update code and docs |
+| Local preview works but `alva run` fails | Demo-only base64 or host-file loading leaked into production | Use `InferenceSession.createFromAlfs({ alfs, path })` with absolute ALFS paths |

--- a/skills/alva/references/onnx.md
+++ b/skills/alva/references/onnx.md
@@ -1,27 +1,36 @@
 # ONNX Model
 
-Use this reference when a user supplies, or plans to upload, an exported `.onnx`
-model artifact and wants Alva to run real-data inference, then persist the
-prediction as feed data, use it inside a FeedAltra strategy, emit an actionable
-signal, or render it in a released playbook. Do not present this as model
-training: Alva prepares data, runs inference, backtests or simulates supplied
-models, and renders results.
+This reference covers the boundary between ML research artifacts and Alva
+runtime inference. A request may start from a ready `.onnx` file, or from a
+paper, report, notebook, or third-party methodology that still needs to be made
+runnable before it can become a live playbook.
 
-## Model Handoff From Research
+## From Method To Model
 
-Before writing inference code, confirm the user or upstream training pipeline
-has supplied the research artifacts Alva needs to reproduce scoring:
+If the user provides a method instead of a ready model, first try to reproduce
+the smallest faithful version in the sandbox or local R&D environment. Use real
+Alva data where coverage exists, state source gaps clearly, and avoid treating a
+paper result as a live signal until it passes a point-in-time split or
+walk-forward check. Keep sandbox reproduction CPU-friendly: break the workflow
+into small stages and simplify training before scaling fidelity. If reproduction
+needs packages such as PyTorch, scikit-learn, or ONNX exporters, install them in
+the sandbox and proceed.
 
-- investment thesis: asset/universe, prediction horizon, and decision use
-- label definition: return, class, rank, allocation, or signal target
-- feature recipe: raw fields, rolling windows, z-score/normalization, smoothing,
-  missing-data policy, and timestamp convention
-- tensor contract: input name, dtype, shape, flatten order, output name, and
-  output semantics
-- artifact set: `model.onnx` plus `model_meta.json`
-- validation evidence: train/test split, metrics, known failure modes, drift
-  risks, and intended retraining or re-upload cadence
+Before writing inference code, freeze this handoff:
 
+- thesis: asset/universe, prediction horizon, and decision use
+- label: return, class, rank, allocation, or signal target
+- features: raw fields, rolling windows, normalization, smoothing,
+  missing-data policy, timestamp convention, and asset order
+- tensor: input name, dtype, shape, flatten order, output name, and output
+  semantics
+- artifacts: `model.onnx` plus `model_meta.json`
+- evidence: train/test split, metrics, costs, known failure modes, drift risks,
+  and retraining or re-upload cadence
+
+If the output is a strategy, rebalance rule, allocation model, or
+portfolio-following signal, route the exported model through FeedAltra. Use a
+plain Feed SDK pipeline only for prediction-only inspection.
 
 ## Runtime Inference
 
@@ -48,19 +57,14 @@ const { InferenceSession, Tensor, TensorDataType } = require("@alva/onnx");
 
 Rules:
 
-- Use absolute ALFS paths such as
-  `/alva/home/${env.username}/models/<model>/v1/model.onnx`.
-- `createFromAlfs` delegates to `alfs.readFileBytes`; jagent currently returns
-  base64 for bytes, and `@alva/onnx` decodes it internally. It is also compatible
-  if a future runtime returns raw bytes. Do not hand-roll `atob`, `Uint8Array`,
-  or byte conversion in playbook code.
-- `createFromBase64` is for small demos/tests. Production should use uploaded
-  artifacts through `createFromAlfs`.
-- Tensor dtype, shape, input names, and output names must come from model
-  metadata or the training recipe. Trading vectors are usually
-  `TensorDataType.Float32`, but do not guess.
-- Release every session in `finally`. Sessions belong to the current jagent
-  execution and cannot be persisted across cronjob runs.
+- Store production models under `~/models/<model>/v<major>/model.onnx` with
+  `model_meta.json` beside it.
+- Load production models with `InferenceSession.createFromAlfs({ alfs, path })`.
+  Do not decode model bytes manually.
+- Tensor dtype, shape, input names, and output names must come from
+  `model_meta.json` or the training recipe.
+- Create and release the ONNX session inside each scheduled run; release it in
+  `finally`.
 
 ## Tensor Shapes
 
@@ -77,25 +81,13 @@ Common finance shapes:
 | Regression output | `[1, 1]` | `outputs.<name>.data[0]` |
 | Classification output | `[1, classes]` | `Array.from(outputs.<name>.data)` |
 
-Examples:
+Example:
 
 ```javascript
 const tabular = new Tensor(
   TensorDataType.Float32,
   new Float32Array([f1, f2, f3, f4]),
   [1, 4],
-);
-
-const multiAsset = new Tensor(
-  TensorDataType.Float32,
-  new Float32Array(flatFeatures),
-  [1, assets, features],
-);
-
-const ohlcv = new Tensor(
-  TensorDataType.Float32,
-  new Float32Array(flatOhlcv),
-  [1, bars, 5],
 );
 ```
 
@@ -117,11 +109,10 @@ share the model. Public playbooks expose feed outputs, not the `.onnx` file.
 
 `model_meta.json` should include:
 
-- model name, contract version, artifact hash/version, owner/source, training
-  time, and training data window
-- task type: regression, classification, ranking, or allocation
-- data contract: universe, asset order, interval, timestamp convention,
-  adjusted/unadjusted prices, units/currency, and missing-data policy
+- model identity, contract version, artifact hash/version, source, training
+  window, and task type
+- data contract: universe, asset order, interval, timestamp convention, units,
+  and missing-data policy
 - input contract: input names, dtypes, dims, feature order, lookback, flatten
   order, normalization, scaler fit scope, and imputation policy
 - output contract: output names, dtypes, dims, units/classes, horizon, class
@@ -138,8 +129,7 @@ Use FeedAltra when ONNX output drives a backtest, rebalance, simulation, trading
 signal, or strategy metric. Follow [altra-trading.md](altra-trading.md) for the
 general feature/strategy shape; ONNX adds these constraints:
 
-- Create the session once per jagent execution, not once per bar. A lazy
-  `getSession()` may memoize `sessionPromise`; clear cached state after release.
+- Create the session once per run, not once per bar.
 - Reproduce training exactly: identifiers, intervals, bar-close timestamps,
   lookback, missing-data policy, feature order, scaling, target horizon, labels.
 - The feature timestamp is the time input evidence is available, not the
@@ -182,17 +172,11 @@ If using FeedAltra, its normal `signal`, `sim`, and `perf` outputs are covered b
 [altra-trading.md](altra-trading.md); do not duplicate them unless the playbook
 needs a custom ONNX-specific view.
 
-If released HTML displays ONNX predictions or metrics, it must read released feed
-data at runtime, commonly:
-
-```text
-/alva/home/<username>/feeds/<feed-name>/v1/data/model/summary/@last/1
-/alva/home/<username>/feeds/<feed-name>/v1/data/model/features/@last/500
-```
-
-Preview fixtures must not become the authoritative source or production fallback.
-These names are recommendations, not a required schema; choose the smallest feed
-surface that supports the playbook and downstream consumers.
+If released HTML displays ONNX predictions or metrics, it must read released
+feed data at runtime. Preview fixtures must not become the authoritative source
+or production fallback. These names are recommendations, not a required schema;
+choose the smallest feed surface that supports the playbook and downstream
+consumers.
 
 ## README And Release Additions
 
@@ -203,8 +187,6 @@ Follow the normal README and release rules in `SKILL.md` and
   output meaning, validation evidence, and re-upload or retraining expectation.
 - `alva run` proves the script fetches real data, loads the `.onnx` file from
   ALFS, and builds tensors with the documented shape.
-- Released HTML reads released feed data, not embedded prediction arrays or
-  preview fixtures.
 - Public access should normally be granted to released feed outputs, not the
   model artifact.
 
@@ -214,4 +196,4 @@ Follow the normal README and release rules in `SKILL.md` and
 | --- | --- | --- |
 | Session or tensor error | Reusing a released session, wrong dtype, or `dims` product differs from data length | Create one session per run and rebuild the tensor from `model_meta.json` |
 | Missing graph key | Wrong ONNX input/output name | Use the names from model metadata or runtime introspection, then update code and docs |
-| Local preview works but `alva run` fails | Demo-only base64 or host-file loading leaked into production | Use `InferenceSession.createFromAlfs({ alfs, path })` with absolute ALFS paths |
+| Local preview works but `alva run` fails | Host-file or local-only loading leaked into production | Use `InferenceSession.createFromAlfs({ alfs, path })` with an ALFS model path |

--- a/skills/alva/references/onnx.md
+++ b/skills/alva/references/onnx.md
@@ -7,11 +7,6 @@ signal, or render it in a released playbook. Do not present this as model
 training: Alva prepares data, runs inference, backtests or simulates supplied
 models, and renders results.
 
-This file is ONNX-only. Use [jagent-runtime.md](jagent-runtime.md) for runtime
-and ALFS details, [feed-sdk.md](feed-sdk.md) for feed writes,
-[altra-trading.md](altra-trading.md) for FeedAltra contracts, and
-[api/release.md](api/release.md) for general release gates.
-
 ## Model Handoff From Research
 
 Before writing inference code, confirm the user or upstream training pipeline
@@ -27,9 +22,6 @@ has supplied the research artifacts Alva needs to reproduce scoring:
 - validation evidence: train/test split, metrics, known failure modes, drift
   risks, and intended retraining or re-upload cadence
 
-Training and export are external to Alva. The handoff is successful when Alva can
-rebuild the exact feature vector from real data and feed it into the uploaded
-ONNX graph without guessing.
 
 ## Runtime Inference
 
@@ -106,10 +98,6 @@ const ohlcv = new Tensor(
   [1, bars, 5],
 );
 ```
-
-Only include image-style tensors such as `[1, 3, height, width]` when the user's
-actual ONNX model is image-based. Most Alva investing models should document
-tabular, panel, or time-window shapes instead.
 
 ## Model Artifacts
 


### PR DESCRIPTION
Summary:
- Add ONNX model reference covering artifact paths, tensor contracts, FeedAltra inference, feed outputs, and release checks.
- Register @alva/onnx in the Alva skill index and jagent runtime guide.
- Correct readFileBytes docs to describe base64 string bytes.

Tests:
- Documentation-only change.
- Verified references with rg for @alva/onnx, v1 model paths, readFileBytes base64, and feed output names.