### PR TITLE
feat(alva): publish v1 design-system CSS bundle to CDN

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'skills/alva/references/design-tokens.css'
       - 'skills/alva/references/design-contract.yaml'
+      - 'skills/alva/references/css/design-system.css'
   workflow_dispatch:
 
 permissions:
@@ -44,6 +45,15 @@ jobs:
         with:
           path: skills/alva/references/design-contract.yaml
           destination: alva-ai-stg-ssr-cdn-bucket/design-system/
+          parent: false
+          headers: |
+            cache-control: public,max-age=3600
+
+      - name: Upload v1 design-system bundle to GCS
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: skills/alva/references/css/design-system.css
+          destination: alva-ai-stg-ssr-cdn-bucket/design-system/v1/
           parent: false
           headers: |
             cache-control: public,max-age=3600

--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -15,7 +15,10 @@ permissions:
 
 jobs:
   publish:
-    runs-on: self-hosted
+    # Public skills repo is not authorized for the org self-hosted runner
+    # group (jobs queue indefinitely with runner_group_id=0). Match main's
+    # #433 fix and use github-hosted.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/sync-design-system-css.yml
+++ b/.github/workflows/sync-design-system-css.yml
@@ -1,0 +1,77 @@
+name: Sync design-system.css
+
+on:
+  pull_request:
+    paths:
+      - 'skills/alva/references/design-tokens.css'
+      - 'skills/alva/references/design.md'
+      - 'skills/alva/references/design-components.md'
+      - 'skills/alva/references/design-widgets.md'
+      - 'skills/alva/references/css/design-system.css'
+      - 'skills/alva/references/design-contract.yaml'
+      - 'skills/alva/scripts/build-design-system-css.ts'
+      - 'skills/alva/scripts/design-contract-sync.ts'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Forks can't be pushed to via GITHUB_TOKEN. alva-ai PRs are internal;
+    # this guard prevents the job from failing silently on the rare fork PR.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: skills/alva/scripts/pnpm-lock.yaml
+
+      - name: Install scripts deps
+        working-directory: skills/alva/scripts
+        run: pnpm install --frozen-lockfile
+
+      # build-design-system-css runs validateInputs first; bails on any
+      # orphan declaration in the .md sources. If the .md is malformed,
+      # the workflow fails here and the auto-sync below never runs.
+      - name: Build design-system.css
+        working-directory: skills/alva/scripts
+        run: pnpm build-design-system-css
+
+      - name: Commit regenerated CSS if drift
+        run: |
+          if [[ -n "$(git status --porcelain skills/alva/references/css/design-system.css)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add skills/alva/references/css/design-system.css
+            git commit -m "build(alva): regenerate design-system.css [skip ci]"
+            if ! git push; then
+              echo "::warning::Push failed — likely a race with a concurrent push. Will retry on next CI run."
+              exit 0
+            fi
+            echo "::notice::Pushed regenerated design-system.css to PR branch."
+          else
+            echo "design-system.css already in sync."
+          fi
+
+      # Final guard: design-contract-sync also re-runs build --check, so this
+      # passes iff our auto-sync above worked. If a race left things stale,
+      # this would fail and surface it on the PR — the next push fixes it.
+      - name: Doc-sync final check
+        working-directory: skills/alva/scripts
+        run: pnpm design-contract-sync

--- a/.github/workflows/sync-design-system-css.yml
+++ b/.github/workflows/sync-design-system-css.yml
@@ -31,9 +31,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -892,6 +892,9 @@ Required evidence:
     font-weight 600/700, unregistered component-modifier classes, etc.). To
     pre-check: `alva lint playbook ./index.html`. The full ruleset lives in
     [design-contract.yaml](references/design-contract.yaml).
+    For new playbooks, link `v1/design-system.css` per the template in
+    [design.md](references/design.md) — the linter accepts both legacy
+    and v1 URLs.
 
 If any item fails, do not release. Fix the issue, re-run
 `alva release playbook-draft` if metadata or backing files changed, then
@@ -1038,6 +1041,7 @@ the full locate-and-edit procedure.
 | [deployment.md](references/deployment.md) | Deploying scripts as cronjobs for scheduled execution |
 | [design.md](references/design.md) | Alva Design System entry point: tokens, typography, layout; links to widget, component, and playbook specs |
 | [design-contract.yaml](references/design-contract.yaml) | Machine-readable contract consumed by the design linter that gates `alva release playbook` |
+| [css/design-system.css](references/css/design-system.css) | Canonical CSS bundle published to CDN — playbooks `<link>` it instead of inlining component/widget CSS |
 | [remix-workflow.md](references/remix-workflow.md) | Remix: create a new playbook from an existing template |
 | [annotation-edits.md](references/annotation-edits.md) | Annotation-driven edits: parse `<annotation>` tags, locate the generator behind an element, edit generation logic not rendered output |
 | [creators-note.md](references/creators-note.md) | Post-release creator's note: composing and posting the pinned author comment |

--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -1,0 +1,1927 @@
+/* ════ Tokens ════ */
+
+/* Published at https://alva-ai-static.b-cdn.net/design-system/design-tokens.css */
+
+@layer tokens.static {
+  :root {
+    /* ── Common ── */
+    --b-common-white: #ffffff;
+    --b-common-black: #000000;
+
+    /* ── Semantic Brand ── */
+    --main-m1: #49a3a6; /* Alva Theme */
+    --main-m1-10: rgba(73, 163, 166, 0.1); /* Alva Theme with transparency */
+    --main-m2: #2196f3; /* Link */
+    --main-m2-10: rgba(33, 150, 243, 0.1); /* Link with transparency */
+    --main-m3: #2a9b7d; /* Bullish */
+    --main-m3-10: rgba(42, 155, 125, 0.1); /* Bullish with transparency */
+    --main-m4: #e05357; /* Bearish */
+    --main-m4-10: rgba(224, 83, 87, 0.1); /* Bearish with transparency */
+    --main-m5: #e6a91a; /* Alert */
+    --main-m5-10: rgba(230, 169, 26, 0.1); /* Alert with transparency */
+    --main-m6: #ff9800; /* Emphasize */
+    --main-m6-10: rgba(255, 152, 0, 0.1); /* Emphasize with transparency */
+    --main-m7: rgba(0, 0, 0, 0.6); /* Modal Mask */
+
+    /* ── Chart ── */
+    --chart-orange1-main: #ff9800;
+    --chart-orange1-1: #ffbb1c;
+    --chart-orange1-2: #f8cb86;
+    --chart-green1-main: #40a544;
+    --chart-green1-1: #007949;
+    --chart-green1-2: #78c26d;
+    --chart-green2-main: #8fc13a;
+    --chart-green2-1: #5b8513;
+    --chart-green2-2: #c0d40f;
+    --chart-cyan1-1: #117a7d;
+    --chart-cyan1-2: #77c9c2;
+    --chart-cyan2-main: #7cafad;
+    --chart-cyan2-1: #4c807e;
+    --chart-cyan2-2: #a5c7c6;
+    --chart-blue1-main: #3d8bd1;
+    --chart-blue1-1: #005daf;
+    --chart-blue1-2: #88b7e0;
+    --chart-blue2-main: #54A5C2;
+    --chart-blue2-1: #0D7498;
+    --chart-blue2-2: #91d1db;
+    --chart-purple1-main: #5f75c9;
+    --chart-purple1-1: #3a52be;
+    --chart-purple1-2: #9ab1d7;
+    --chart-purple2-main: #7474d8;
+    --chart-purple2-1: #4646ae;
+    --chart-purple2-2: #afbbf7;
+    --chart-violet1-main: #a878dc;
+    --chart-violet1-1: #7f4eb4;
+    --chart-violet1-2: #d4b2e1;
+    --chart-pink1-main: #dc7aa5;
+    --chart-pink1-1: #ba5883;
+    --chart-pink1-2: #ecb0ca;
+    --chart-red1-main: #c76466;
+    --chart-red1-1: #a94749;
+    --chart-red1-2: #f2a0a1;
+    --chart-grey-main: #838383; /* ⚠ Only When chart has ≥ 3 series */
+    --chart-grey-1: #555555; /* ⚠ Only When chart has ≥ 3 series */
+    --chart-grey-2: #b7b7b7; /* ⚠ Only When chart has ≥ 3 series */
+
+    /* ── Spacing ── */
+    --spacing-xxxs: 2px;
+    --spacing-xxs: 4px;
+    --spacing-xs: 8px;
+    --spacing-s: 12px;
+    --spacing-m: 16px;
+    --spacing-l: 20px;
+    --spacing-xl: 24px;
+    --spacing-xxl: 28px;
+    --spacing-xxxl: 32px;
+    --spacing-xxxxl: 40px;
+    --spacing-xxxxxl: 48px;
+    --spacing-xxxxxxl: 56px;
+
+    /* ── Radius ── */
+    --radius-ct-xs: 2px;
+    --radius-ct-s: 4px;
+    --radius-ct-m: 6px;
+    --radius-ct-l: 8px;
+    --radius-ct-xl: 12px;
+    --radius-pop-dialog: 12px;
+    --radius-pop-action-sheets: 12px;
+    --radius-pop-dropdown: 8px;
+    --radius-pop-popover: 8px;
+    --radius-pop-toast: 8px;
+    --radius-pop-tips: 8px;
+    --radius-btn-xs: 4px;
+    --radius-btn-s: 6px;
+    --radius-btn-m: 8px;
+    --radius-btn-l: 12px;
+  }
+}
+
+@layer tokens.theme {
+  /* Light Mode (default) */
+  [data-theme="light"],
+  :root {
+    /* Text */
+    --text-n9: rgba(0, 0, 0, 0.9); /* Primary */
+    --text-n7: rgba(0, 0, 0, 0.7); /* Secondary */
+    --text-n5: rgba(0, 0, 0, 0.5); /* Supporting Text */
+    --text-n3: rgba(0, 0, 0, 0.3); /* Hint */
+    --text-n2: rgba(0, 0, 0, 0.2); /* Disabled */
+
+    /* Background */
+    --b0-page: #ffffff;
+    --b0-container: #ffffff;
+    --b0-sidebar: #2a2a38;
+    --b0-sidebar-select: rgba(255, 255, 255, 0.03);
+    --grey-g01: #fafafa; /* Dashboard Card */
+    --grey-g02: #f5f5f5;
+    --grey-g03: #f0f0f0;
+    --grey-g05: #eaeaea;
+    --grey-g1: #dedede;
+    --b-r02: rgba(0, 0, 0, 0.02); /* Content Block */
+    --b-r03: rgba(0, 0, 0, 0.03); /* Darker Block */
+    --b-r05: rgba(0, 0, 0, 0.05);
+    --b-r07: rgba(0, 0, 0, 0.07);
+    --b-r1: rgba(0, 0, 0, 0.1);
+
+    /* Line & Border */
+    --line-l07: rgba(0, 0, 0, 0.07); /* Default */
+    --line-l05: rgba(0, 0, 0, 0.05); /* Weaker */
+    --line-l12: rgba(0, 0, 0, 0.12); /* Card Border */
+    --line-l2: rgba(0, 0, 0, 0.2); /* Popup/Dropdown Border */
+    --line-l3: rgba(0, 0, 0, 0.3); /* Button/Input/Select Border */
+    --line-l9: rgba(0, 0, 0, 0.9); 
+
+    /* Shadow */
+    --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.05);
+    --shadow-s: 0 6px 20px 0 rgba(0, 0, 0, 0.04);
+    --shadow-l: 0 10px 20px 0 rgba(0, 0, 0, 0.08);
+  }
+
+  /* Dark Mode (disabled — kept for future use) */
+  [data-theme="dark-disabled"] {
+    /* Text */
+    --text-n9: rgba(255, 255, 255, 0.9);
+    --text-n7: rgba(255, 255, 255, 0.7);
+    --text-n5: rgba(255, 255, 255, 0.5);
+    --text-n3: rgba(255, 255, 255, 0.3);
+    --text-n2: rgba(255, 255, 255, 0.2);
+
+    /* Background */
+    --b0-page: #15161a;
+    --b0-container: #15161a;
+    --b0-sidebar: #1d1e24;
+    --b0-sidebar-select: rgba(255, 255, 255, 0.03);
+    --grey-g01: #1a1b1f;
+    --grey-g02: #1c1d21;
+    --grey-g03: #212225;
+    --grey-g05: #25262a;
+    --grey-g1: #2c2d31;
+    --b-r02: rgba(255, 255, 255, 0.02);
+    --b-r03: rgba(255, 255, 255, 0.03);
+    --b-r05: rgba(255, 255, 255, 0.05);
+    --b-r07: rgba(255, 255, 255, 0.07);
+    --b-r1: rgba(255, 255, 255, 0.1);
+
+    /* Line & Border */
+    --line-l07: rgba(255, 255, 255, 0.07);
+    --line-l05: rgba(255, 255, 255, 0.05);
+    --line-l12: rgba(255, 255, 255, 0.12);
+    --line-l2: rgba(255, 255, 255, 0.2);
+    --line-l3: rgba(255, 255, 255, 0.3);
+    --line-l9: rgba(255, 255, 255, 0.9);
+
+    /* Shadow */
+    --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.25);
+    --shadow-s: 0 6px 20px 0 rgba(0, 0, 0, 0.24);
+    --shadow-l: 0 10px 20px 0 rgba(0, 0, 0, 0.2);
+  }
+}
+
+
+
+/* ════ Globals ════ */
+
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+text-rendering: optimizeLegibility;
+
+html {
+  height: 100%;
+  overflow: hidden;
+}
+body {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+*::-webkit-scrollbar {
+  display: none;
+}
+
+.playbook-container {
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--spacing-s) var(--spacing-xxl) var(--spacing-xxxxl);
+  /* max-width: 2048px; */
+}
+
+@media (max-width: 768px) {
+  .playbook-container {
+    padding: var(--spacing-m);
+  }
+}
+
+
+
+/* ════ Components ════ */
+
+.dropdown {
+  background-color: var(--b0-container);
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-xxs);
+  position: relative;
+  border-radius: var(--radius-pop-dropdown);
+  width: 100%;
+  box-shadow: var(--shadow-s);
+}
+
+.dropdown-border {
+  position: absolute;
+  border: 0.5px solid var(--line-l2);
+  border-radius: var(--radius-pop-dropdown);
+  inset: 0;
+  pointer-events: none;
+}
+
+.list-item {
+  position: relative;
+  width: 100%;
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.list-item:hover,
+.list-item.selected {
+  background-color: rgba(73,163,166,0.08);
+}
+
+.list-item.selected {
+  border-radius: var(--radius-ct-m);
+}
+
+.list-item.selected .list-item-text {
+  color: var(--main-m1);
+}
+
+.list-item-inner {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-s);
+  gap: var(--spacing-xs);
+}
+
+.list-item-text {
+  flex: 1 0 0;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-style: normal;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--text-n9);
+  letter-spacing: 0.14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Container ── */
+.markdown-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+.markdown-container * {
+  box-sizing: border-box;
+}
+
+/* ── Headings ── */
+.markdown-container h1,
+.markdown-container h2,
+.markdown-container h3,
+.markdown-container h4,
+.markdown-container h5,
+.markdown-container h6 {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  color: var(--text-n9);
+  margin: 0;
+  width: 100%;
+}
+.markdown-container h1 {
+  font-size: 18px;
+  line-height: 28px;
+  letter-spacing: 0.18px;
+  padding-top: var(--spacing-xxxs);
+}
+.markdown-container h2 {
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+  padding-top: var(--spacing-xxxs);
+}
+.markdown-container h3 {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  padding-top: 0;
+}
+.markdown-container h4,
+.markdown-container h5,
+.markdown-container h6 {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* ── Paragraph ── */
+.markdown-container p {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+/* ── Lists ── */
+.markdown-container ul,
+.markdown-container ol {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.markdown-container li {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  position: relative;
+  padding-left: var(--spacing-l);
+}
+.markdown-container ul > li::before {
+  content: "";
+  position: absolute;
+  left: 7.5px;
+  top: 8.5px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-n9);
+}
+.markdown-container ol {
+  counter-reset: md-ol;
+}
+.markdown-container ol > li {
+  counter-increment: md-ol;
+}
+.markdown-container ol > li::before {
+  content: counter(md-ol) ".";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 20px;
+  text-align: center;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--text-n9);
+}
+
+/* ── Code ── */
+.markdown-container code,
+.markdown-container pre {
+  background: var(--b-r02);
+  border-radius: var(--radius-ct-xs);
+  font-family: "JetBrains Mono", monospace;
+  color: var(--text-n7);
+}
+.markdown-container code {
+  display: inline-block;
+  vertical-align: middle;
+  box-shadow: inset 0 0 0 1px var(--line-l07);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  padding: 1px var(--spacing-xs);
+  margin: 0 var(--spacing-xxs);
+}
+.markdown-container pre {
+  border: 1px solid var(--line-l07);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  padding: var(--spacing-s) var(--spacing-m);
+  margin: 0;
+  overflow-x: auto;
+}
+.markdown-container pre code {
+  display: inline;
+  vertical-align: baseline;
+  font-size: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  background: none;
+}
+
+/* ── Divider ── */
+.markdown-container hr {
+  height: 1px;
+  background: var(--line-l07);
+  border: none;
+  margin: var(--spacing-xxs) 0;
+}
+
+/* ── Table ── follows Table Card rules (design-widgets.md) */
+.markdown-container table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0;
+}
+.markdown-container th,
+.markdown-container td {
+  padding: 10px var(--spacing-xs);
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  text-align: left;
+  min-height: 176px;
+}
+.markdown-container tr {
+  border-bottom: 1px solid var(--line-l07);
+}
+.markdown-container tr:last-child {
+  border-bottom: none;
+}
+.markdown-container th {
+  color: var(--text-n7);
+  padding-top: 0;
+  padding-bottom: 10px;
+}
+.markdown-container th:first-child,
+.markdown-container td:first-child {
+  padding-left: 0;
+}
+.markdown-container th:last-child,
+.markdown-container td:last-child {
+  padding-right: 0;
+}
+.markdown-container td code {
+  margin: 0;
+}
+
+/* ── Link ── */
+.markdown-container a {
+  color: var(--text-n7);
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--text-n5);
+  text-decoration-thickness: 8%;
+  text-underline-offset: 35%;
+  text-decoration-skip-ink: none;
+  transition: color 0.15s ease;
+}
+.markdown-container a:hover {
+  color: var(--main-m1);
+  text-decoration-color: var(--main-m1);
+}
+.markdown-container a::after {
+  content: "";
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask: url("https://alva-ai-static.b-cdn.net/icons/go-l.svg") center / contain
+    no-repeat;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: var(--spacing-xxs);
+  flex-shrink: 0;
+}
+
+/* ── Large ── */
+.markdown-container--l {
+  gap: var(--spacing-m);
+}
+.markdown-container--l h1,
+.markdown-container--l h2 {
+  font-size: 20px;
+  line-height: 30px;
+  letter-spacing: 0.2px;
+  padding-top: var(--spacing-xs);
+}
+.markdown-container--l h3 {
+  font-size: 18px;
+  line-height: 28px;
+  letter-spacing: 0.18px;
+  padding-top: var(--spacing-xxs);
+}
+.markdown-container--l h4,
+.markdown-container--l h5,
+.markdown-container--l h6 {
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+.markdown-container--l p,
+.markdown-container--l li {
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+.markdown-container--l li {
+  padding-left: var(--spacing-xl);
+}
+.markdown-container--l ul > li::before {
+  left: 9.5px;
+  top: 10.5px;
+}
+.markdown-container--l ol > li::before {
+  font-size: 16px;
+  line-height: 26px;
+  width: 24px;
+}
+.markdown-container--l ul,
+.markdown-container--l ol {
+  gap: var(--spacing-xs);
+}
+.markdown-container--l th,
+.markdown-container--l td {
+  padding: var(--spacing-s) var(--spacing-xs);
+  min-height: auto;
+  max-height: 180px;
+}
+.markdown-container--l code {
+  padding: var(--spacing-xxxs) var(--spacing-xs);
+}
+.markdown-container--l pre {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+.markdown-container--l a::after {
+  width: 16px;
+  height: 16px;
+}
+
+/* ── Small ── */
+.markdown-container--s {
+  gap: var(--spacing-xxs);
+}
+.markdown-container--s h1 {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  padding-top: var(--spacing-xxxs);
+}
+.markdown-container--s h2 {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  padding-top: 0;
+}
+.markdown-container--s h3 {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  padding-top: 0;
+}
+.markdown-container--s h4,
+.markdown-container--s h5,
+.markdown-container--s h6 {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+.markdown-container--s p,
+.markdown-container--s li {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+.markdown-container--s a::after {
+  width: 12px;
+  height: 12px;
+}
+.markdown-container--s li {
+  padding-left: var(--spacing-l);
+}
+.markdown-container--s ul > li::before {
+  left: 7.5px;
+  top: 7.5px;
+}
+.markdown-container--s ol > li::before {
+  font-size: 12px;
+  line-height: 20px;
+  width: 20px;
+}
+.markdown-container--s ul,
+.markdown-container--s ol {
+  gap: var(--spacing-xxs);
+}
+.markdown-container--s code {
+  font-size: 10px;
+  line-height: 16px;
+  padding: var(--spacing-xxxs) 6px;
+}
+.markdown-container--s pre {
+  font-size: 10px;
+  line-height: 16px;
+  padding: var(--spacing-xs) var(--spacing-s);
+}
+.markdown-container--s th,
+.markdown-container--s td {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  padding: var(--spacing-xs);
+  min-height: 176px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .markdown-container {
+    max-width: 100%;
+    padding: 0 var(--spacing-m);
+  }
+  .markdown-container table {
+    overflow-x: scroll;
+  }
+}
+
+/* Base Button Styles */
+.btn {
+  border: none;
+  outline: none;
+  background: none;
+  margin: 0;
+  cursor: pointer;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  transition: all 0.2s ease-in-out;
+  position: relative;
+}
+
+/* Primary Button */
+.btn-primary {
+  background-color: var(--main-m1);
+  color: var(--b-common-white);
+}
+
+.btn-primary:hover:not(.btn-disabled) {
+  background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+}
+
+.btn-primary:active:not(.btn-disabled) {
+  background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2));
+}
+
+.btn-primary.btn-disabled {
+  background-color: var(--b0-container);
+  color: var(--text-n2);
+  cursor: not-allowed;
+  border: 0.5px solid var(--line-l3);
+}
+
+/* Secondary Button */
+.btn-secondary {
+  background-color: transparent;
+  color: var(--text-n9);
+  border: 0.5px solid var(--line-l3);
+}
+
+.btn-secondary:hover:not(.btn-disabled) {
+  border-color: var(--line-l9);
+}
+
+.btn-secondary:active:not(.btn-disabled) {
+  border-color: var(--line-l3);
+  background-color: var(--b-r02);
+}
+
+.btn-secondary.btn-disabled {
+  color: var(--text-n2);
+  border-color: var(--line-l3);
+  cursor: not-allowed;
+}
+
+/* Size - Large */
+.btn-large {
+  height: 48px;
+  padding: 11px var(--spacing-l);
+  gap: var(--spacing-xs);
+  border-radius: var(--radius-btn-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Size - Medium */
+.btn-medium {
+  height: 40px;
+  padding: 9px var(--spacing-l);
+  gap: var(--spacing-xs);
+  border-radius: var(--radius-btn-m);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* Size - Small */
+.btn-small {
+  height: 32px;
+  padding: 6px var(--spacing-m);
+  gap: 6px;
+  border-radius: var(--radius-btn-s);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+/* Size - Extra Small */
+.btn-extra-small {
+  height: 28px;
+  padding: var(--spacing-xxs) var(--spacing-s);
+  gap: var(--spacing-xxs);
+  border-radius: var(--radius-btn-s);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+/* Disabled State */
+.btn-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Loading State */
+.btn-loading {
+  position: relative;
+  color: transparent;
+  pointer-events: none;
+}
+
+.btn-loading::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  top: 50%;
+  left: 50%;
+  margin-left: -7px;
+  margin-top: -7px;
+  border: 1px solid var(--b-common-white);
+  border-radius: 50%;
+  border-top-color: transparent;
+  animation: btn-spin 0.6s linear infinite;
+}
+
+.btn-secondary.btn-loading::after {
+  border-color: var(--line-l9);
+  border-top-color: transparent;
+}
+
+@keyframes btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Focus State */
+.btn:focus-visible {
+  outline: 2px solid var(--main-m1);
+  outline-offset: 2px;
+}
+
+/* Base (default size = Small) */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: var(--radius-ct-s);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  height: 22px;
+  padding: 1px 6px;
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  /* Default color (no semantic meaning) */
+  background-color: var(--b-r05);
+  color: var(--text-n9);
+}
+
+/* Size — Medium */
+.tag-md {
+  height: 26px;
+  padding: var(--spacing-xxxs) var(--spacing-xs);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* Size — Extra Small */
+.tag-xs {
+  height: 18px;
+  padding: 1px 6px;
+  font-size: 10px;
+  line-height: 16px;
+  letter-spacing: 0.1px;
+  border-radius: var(--radius-ct-xs);
+}
+
+/*
+ * Style — Tinted
+ * Light transparent background + colored text.
+ *   background-color: var(--main-mX-10);
+ *   color: var(--main-mX);
+ *
+ * Style — Solid
+ * Full-color background + white text.
+ *   background-color: var(--main-mX);
+ *   color: var(--b-common-white);
+ */
+
+.switch {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: background-color 0.2s ease;
+}
+
+/* Track — Off */
+.switch {
+  background-color: var(--b-r1);
+}
+
+/* Track — On */
+.switch.on {
+  background-color: var(--main-m1);
+}
+
+/* Thumb */
+.switch-thumb {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--b-common-white);
+  border-radius: 50%;
+  transition: left 0.2s ease;
+}
+
+/* Disabled */
+.switch.disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.switch.disabled:not(.on) {
+  opacity: 0.4;
+}
+.switch.disabled.on {
+  opacity: 0.3;
+}
+
+/* Size — Medium (default) */
+.switch {
+  width: 32px;
+  height: 16px;
+  border-radius: 1000px;
+}
+.switch .switch-thumb {
+  width: 10.67px;
+  height: 10.67px;
+  left: 2.67px;
+}
+.switch.on .switch-thumb {
+  left: calc(100% - 10.67px - 2.67px);
+}
+
+/* Size — Small */
+.switch-sm {
+  width: 24px;
+  height: 12px;
+  border-radius: 100px;
+}
+.switch-sm .switch-thumb {
+  width: 8px;
+  height: 8px;
+  left: 2px;
+}
+.switch-sm.on .switch-thumb {
+  left: calc(100% - 8px - 2px);
+}
+
+/* Size — Large */
+.switch-lg {
+  width: 40px;
+  height: 20px;
+  border-radius: 166.67px;
+}
+.switch-lg .switch-thumb {
+  width: 13.33px;
+  height: 13.33px;
+  left: 3.33px;
+}
+.switch-lg.on .switch-thumb {
+  left: calc(100% - 13.33px - 3.33px);
+}
+
+.modal-close {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  cursor: pointer;
+  background-color: var(--text-n9);
+  -webkit-mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg")
+    center / contain no-repeat;
+  mask: url("https://alva-ai-static.b-cdn.net/icons/close-l1.svg") center /
+    contain no-repeat;
+  transition: opacity 0.15s ease;
+}
+
+.modal-close:hover {
+  opacity: 0.6;
+}
+
+.select {
+  display: flex;
+  align-items: center;
+  background-color: var(--b0-container);
+  cursor: pointer;
+  position: relative;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 400;
+  transition: border-color 0.12s ease;
+}
+
+.select-border {
+  position: absolute;
+  inset: 0;
+  border: 0.5px solid var(--line-l3);
+  border-radius: inherit;
+  pointer-events: none;
+  transition: border-color 0.12s ease;
+}
+
+.select:hover .select-border {
+  border-color: var(--line-l9);
+}
+
+.select-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-n3);
+}
+
+/* Filled state — has a selected value */
+.select.filled .select-text {
+  color: var(--text-n9);
+}
+
+.select:hover .select-text {
+  color: var(--text-n9);
+}
+
+.select.filled .select-icon {
+  opacity: 0.2;
+}
+
+/* Size — Large */
+.select-lg {
+  height: 48px;
+  padding: 11px var(--spacing-m);
+  gap: var(--spacing-xs);
+  border-radius: var(--radius-btn-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Size — Medium (default) */
+.select {
+  height: 40px;
+  padding: var(--spacing-xs) var(--spacing-s);
+  gap: var(--spacing-xs);
+  border-radius: var(--radius-btn-m);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* Size — Small */
+.select-sm {
+  height: 28px;
+  padding: var(--spacing-xxs) var(--spacing-xs);
+  gap: var(--spacing-xxs);
+  border-radius: var(--radius-btn-s);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+.select-sm .select-text {
+  width: 70px;
+  flex: none;
+}
+
+/* Arrow Icon */
+.select-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.22;
+  transition: opacity 0.12s ease;
+}
+
+.select:hover .select-icon,
+.select.open .select-icon {
+  opacity: 1;
+}
+
+.select-icon img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.input {
+  display: flex;
+  align-items: center;
+  background-color: var(--b0-container);
+  position: relative;
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-weight: 400;
+  transition: border-color 0.12s ease;
+}
+
+.input-border {
+  position: absolute;
+  inset: 0;
+  border: 0.5px solid var(--line-l3);
+  border-radius: inherit;
+  pointer-events: none;
+  transition: border-color 0.12s ease;
+}
+
+.input:hover .input-border,
+.input:focus-within .input-border {
+  border-color: var(--line-l9);
+}
+
+.input-field {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-n9);
+}
+
+.input-field::placeholder {
+  color: var(--text-n3);
+}
+
+/* Size — Large */
+.input-lg {
+  height: 48px;
+  padding: 11px var(--spacing-m);
+  border-radius: var(--radius-btn-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Size — Medium (default) */
+.input {
+  height: 40px;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border-radius: var(--radius-btn-m);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+}
+
+/* Size — Small */
+.input-sm {
+  height: 28px;
+  padding: var(--spacing-xxs) var(--spacing-xs);
+  border-radius: var(--radius-btn-s);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+/* Shared */
+.tab {
+  display: flex;
+  align-items: center;
+}
+.tab-item {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+/* Prevent width jump when font-weight changes */
+.tab-item::after {
+  content: attr(data-text);
+  font-weight: 500;
+  visibility: hidden;
+  height: 0;
+  display: block;
+  overflow: hidden;
+}
+
+/* Underline */
+.tab-underline {
+  gap: var(--spacing-m);
+  border-bottom: 1px solid var(--line-l07);
+}
+.tab-underline .tab-item {
+  padding-bottom: var(--spacing-xxs);
+  margin-bottom: -1px;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n7);
+  border-bottom: 2px solid transparent;
+}
+.tab-underline .tab-item.active {
+  color: var(--text-n9);
+  font-weight: 500;
+  border-bottom-color: var(--main-m1);
+}
+
+/* Underline — Size L */
+.tab-underline.tab-l {
+  gap: var(--spacing-l);
+}
+.tab-underline.tab-l .tab-item {
+  padding-bottom: 6px;
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Underline — Size S */
+.tab-underline.tab-s {
+  gap: var(--spacing-s);
+}
+.tab-underline.tab-s .tab-item {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+/* Segmented */
+.tab-segmented {
+  gap: 0;
+  background: var(--b-r05);
+  padding: var(--spacing-xxxs);
+  border-radius: var(--radius-ct-m);
+}
+.tab-segmented .tab-item {
+  padding: 6px var(--spacing-s);
+  border-radius: var(--radius-btn-s);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n7);
+  background: transparent;
+}
+.tab-segmented .tab-item.active {
+  background: var(--b0-container);
+  color: var(--text-n9);
+  font-weight: 500;
+}
+
+/* Segmented — Size L */
+.tab-segmented.tab-l {
+  padding: var(--spacing-xxs);
+  border-radius: var(--radius-ct-l);
+}
+.tab-segmented.tab-l .tab-item {
+  padding: 6px var(--spacing-m);
+  border-radius: var(--radius-btn-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Segmented — Size S */
+.tab-segmented.tab-s .tab-item {
+  padding: var(--spacing-xxs) 10px;
+  border-radius: var(--radius-btn-xs);
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+/* Pill */
+.tab-pill {
+  gap: var(--spacing-s);
+}
+.tab-pill .tab-item {
+  padding: 6px var(--spacing-s);
+  border-radius: var(--radius-btn-s);
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  background: var(--b-r03);
+  color: var(--text-n7);
+}
+.tab-pill .tab-item.active {
+  background: rgba(73, 163, 166, 0.2);
+  color: var(--text-n9);
+  font-weight: 500;
+}
+
+/* Pill — Size L */
+.tab-pill.tab-l {
+  gap: var(--spacing-m);
+}
+.tab-pill.tab-l .tab-item {
+  padding: var(--spacing-xs) var(--spacing-m);
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+}
+
+/* Pill — Size S */
+.tab-pill.tab-s {
+  gap: var(--spacing-xs);
+}
+.tab-pill.tab-s .tab-item {
+  padding: var(--spacing-xxs) 10px;
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+}
+
+.tooltip {
+  background-color: var(--b0-container);
+  position: absolute;
+  border-radius: var(--radius-ct-m);
+  box-shadow: var(--shadow-s);
+  padding: var(--spacing-m);
+  width: fit-content;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxxs);
+}
+
+.tooltip-border {
+  position: absolute;
+  border: 0.5px solid var(--line-l2);
+  border-radius: var(--radius-ct-m);
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Simple — text only */
+.tooltip-text {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  font-weight: 400;
+}
+
+/* Rich — title */
+.tooltip-title {
+  font-family:
+    "Delight",
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  font-size: 16px;
+  line-height: 26px;
+  letter-spacing: 0.16px;
+  color: var(--text-n9);
+  font-weight: 500;
+}
+
+/* Rich — description reuses .tooltip-text */
+
+
+
+/* ════ Widgets ════ */
+
+/* ── Widget Card ── */
+.widget-card {
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: visible;
+}
+
+.widget-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-m);
+}
+
+.widget-title-text {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--text-n9);
+  letter-spacing: 0.16px;
+  line-height: 26px;
+}
+
+.widget-timestamp {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  font-size: 12px;
+  color: var(--text-n5);
+  line-height: 20px;
+}
+
+.widget-body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: var(--radius-ct-s);
+}
+
+.alva-watermark {
+  position: absolute;
+  bottom: var(--spacing-m);
+  right: var(--spacing-m);
+  opacity: 0.2;
+  line-height: 0;
+}
+
+/* ── Dividers ── */
+.divider-v {
+  width: 1px;
+  flex-shrink: 0;
+  margin-block: var(--spacing-l);
+  background-color: var(--line-l05);
+}
+
+.divider-h {
+  height: 1px;
+  margin-inline: var(--spacing-l);
+  background-color: var(--line-l05);
+}
+
+/* ── Equal Height Fill ── */
+.widget-card .widget-body.fill {
+  flex: 1;
+  height: 0;
+}
+
+/* ── Widget Grid ── */
+.widget-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: var(--spacing-xl);
+  align-items: stretch;
+}
+
+.col-2 {
+  grid-column: span 2;
+}
+.col-3 {
+  grid-column: span 3;
+}
+.col-4 {
+  grid-column: span 4;
+}
+.col-5 {
+  grid-column: span 5;
+}
+.col-6 {
+  grid-column: span 6;
+}
+.col-8 {
+  grid-column: span 8;
+}
+
+.col-thirds {
+  grid-column: span 8;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-xl);
+  align-items: stretch;
+}
+
+@media (max-width: 768px) {
+  .widget-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--spacing-l);
+  }
+  .col-2 {
+    grid-column: span 2;
+  }
+  .col-3,
+  .col-4,
+  .col-5,
+  .col-6,
+  .col-8 {
+    grid-column: span 4;
+  }
+  .col-thirds {
+    grid-column: span 4;
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Content Reflow ── */
+.widget-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.widget-row > * {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
+
+/* Chart cards clip canvas overflow */
+.widget-card:has(.chart-body) {
+  overflow: hidden;
+}
+
+.chart-dotted-background {
+  background-image: radial-gradient(
+    circle,
+    rgba(0, 0, 0, 0.18) 0.6px,
+    transparent 0.6px
+  );
+  background-size: 3px 3px;
+}
+
+/* Dark Mode (disabled — kept for future use) */
+[data-theme="dark-disabled"] .chart-dotted-background {
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.12) 0.6px,
+    transparent 0.6px
+  );
+}
+
+.chart-body {
+  flex: 1;
+  padding: var(--spacing-m);
+  position: relative;
+}
+
+.chart-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+  height: 16px;
+  margin-bottom: var(--spacing-xxs);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  font-size: 10px;
+  letter-spacing: 0.1px;
+  color: var(--text-n5);
+}
+
+.legend-line {
+  width: 12px;
+  height: 2px;
+  border-radius: 0.5px;
+}
+
+.legend-rect {
+  width: 8px;
+  height: 8px;
+  border-radius: 0.5px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.chart-container {
+  width: 100%;
+  height: 100%;
+  min-height: 180px;
+}
+
+/* ── Metric Column (for stacking metric cards beside a chart) ── */
+.metric-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+.metric-column .metric-card {
+  flex: 1;
+  background: var(--grey-g01);
+  border-radius: var(--radius-ct-m);
+  padding: var(--spacing-m);
+}
+
+.table-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  isolation: isolate;
+  overflow-x: auto;
+}
+
+.table-row {
+  display: flex;
+  width: 100%;
+  gap: var(--spacing-m); /* column spacing between cells */
+  border-bottom: 1px solid var(--line-l07); /* row divider — on the row, not cells */
+  /* min-width is set by initTableAlignment JS — do NOT use CSS min-width here */
+}
+.table-row:last-child {
+  border-bottom: none;
+}
+
+.table-cell {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  font-weight: 400;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+}
+
+/* Gain/loss tinting — use these instead of inline style="color:…" on cells */
+.table-cell.is-bullish { color: var(--main-m3); }
+.table-cell.is-bearish { color: var(--main-m4); }
+
+.free-text-body {
+  padding: var(--spacing-l);
+}
+
+.feed-body {
+  padding: var(--spacing-xxs) 0;
+}
+
+.feed-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-m);
+  padding: var(--spacing-m);
+  position: relative;
+  border-radius: var(--radius-ct-s);
+  transition: background 0.15s;
+}
+
+.feed-item:hover {
+  background: var(--b-r02);
+  cursor: pointer;
+}
+
+.feed-item::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: var(--spacing-m);
+  right: var(--spacing-m);
+  height: 1px;
+  background: var(--line-l05);
+}
+
+.feed-item:last-child::after {
+  display: none;
+}
+
+/* ── Left column: header + indented content ── */
+.feed-item-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+}
+
+/* Header row — avatar + title / user-info */
+.feed-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+
+/* ── Avatar / Logo ── */
+.feed-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 100px;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.feed-avatar.has-badge {
+  overflow: visible;
+}
+
+.feed-avatar.no-radius {
+  border-radius: 0;
+  overflow: visible;
+}
+
+.feed-avatar > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 100px;
+}
+
+.feed-avatar.no-radius > img {
+  border-radius: 0;
+}
+
+.feed-avatar-badge {
+  position: absolute;
+  bottom: -1px;
+  right: -3px;
+  width: 14px;
+  height: 14px;
+  background: var(--b0-container);
+  border-radius: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feed-avatar-badge img {
+  width: 12px;
+  height: 12px;
+  border-radius: 100px;
+}
+
+/* ── Header text variants ── */
+
+/* Podcast / Youtube / News: bold single-line title */
+.feed-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* X / Reddit: name + handle + date inline */
+.feed-header-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  white-space: nowrap;
+}
+
+.feed-display-name {
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+}
+
+.feed-handle,
+.feed-meta-sep,
+.feed-meta-date {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+}
+
+/* ── Indented content below header ── */
+.feed-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+  padding-left: var(--spacing-xxl); /* 28px = 22px avatar + 6px gap */
+  width: 100%;
+}
+
+.feed-post-title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.feed-text {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
+  letter-spacing: 0.14px;
+  color: var(--text-n9);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.feed-text:empty {
+  display: none;
+}
+
+.feed-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+  white-space: nowrap;
+}
+
+/* ── Actions (X / Reddit) ── */
+.feed-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.feed-action {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xxxs);
+  overflow: hidden;
+}
+
+.feed-action-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.feed-action span {
+  font-size: 12px;
+  line-height: 20px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+  white-space: nowrap;
+}
+
+/* ── Thumbnail ── */
+.feed-thumb {
+  width: 88px;
+  height: 70px;
+  border-radius: var(--radius-ct-s);
+  border: 1px solid var(--line-l07);
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.feed-thumb img:not(.feed-thumb-play) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.feed-thumb-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 28px;
+  height: 28px;
+}
+
+.yt-modal {
+    display: none; position: fixed; top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: rgba(0,0,0,0.6); z-index: 9999;
+    align-items: center; justify-content: center;
+  }
+  .yt-modal.open { display: flex; }
+  .yt-modal-inner {
+    position: relative; width: 90%; max-width: 800px;
+    aspect-ratio: 16/9; border-radius: var(--radius-ct-s);
+    overflow: hidden; background: #000;
+  }
+  .yt-modal-inner iframe { width: 100%; height: 100%; border: 0; }
+  .yt-modal-close {
+    position: absolute; top: -32px; right: 0;
+    width: 28px; height: 28px; border: none; background: none;
+    color: #fff; font-size: 20px; cursor: pointer;
+    line-height: 28px; text-align: center;
+  }
+
+.section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.section-title-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.section-title-text {
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--text-n9);
+  letter-spacing: 0.22px;
+}
+
+.section-title-sub {
+  font-size: 12px;
+  letter-spacing: 0.12px;
+  color: var(--text-n5);
+  padding-left: 8px;
+  border-left: 1px solid var(--line-l07);
+}

--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -181,9 +181,11 @@
 
 /* ════ Globals ════ */
 
--webkit-font-smoothing: antialiased;
--moz-osx-font-smoothing: grayscale;
-text-rendering: optimizeLegibility;
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
 
 html {
   height: 100%;

--- a/skills/alva/references/design-components.md
+++ b/skills/alva/references/design-components.md
@@ -1,5 +1,11 @@
 # Base Component Templates
 
+> ⚠️ **The ```css blocks in this file are the source of truth for
+> [css/design-system.css](css/design-system.css) (published to CDN).**
+> When you edit any ```css block, run `pnpm build-design-system-css`
+> from `skills/alva/scripts/` and commit the regenerated `design-system.css`
+> alongside your `.md` edit. CI doc-sync catches drift.
+
 ## Table of Contents
 
 - [Dropdown](#dropdown)

--- a/skills/alva/references/design-contract.yaml
+++ b/skills/alva/references/design-contract.yaml
@@ -14,7 +14,11 @@ global:
     selector: ".playbook-container"
     must-exist: true
   required-stylesheets:
-    - url: "https://alva-ai-static.b-cdn.net/design-system/design-tokens.css"
+    - any-of:
+        - url: "https://alva-ai-static.b-cdn.net/design-system/design-tokens.css"
+        - url: "https://alva-ai-static.b-cdn.net/design-system/v1/design-system.css"
+  canonical-css-urls:
+    - "https://alva-ai-static.b-cdn.net/design-system/v1/design-system.css"
   scroll:
     sole-scroll-container: ["body", "html"]
   typography:

--- a/skills/alva/references/design-contract.yaml
+++ b/skills/alva/references/design-contract.yaml
@@ -147,38 +147,8 @@ components:
       - "tooltip-text"
       - "tooltip-title"
 
-  # ── Widget Layout & Shared Styles (design-widgets.md §Shared Styles) ──────
-  widget-card:
-    root: "widget-card"
-    children:
-      - "widget-title"
-      - "widget-title-text"
-      - "widget-timestamp"
-      - "widget-body"
-      - "widget-grid"
-      - "widget-row"
-    states:
-      - "fill"
-
-  alva-watermark:
-    root: "alva-watermark"
-
-  divider:
-    root: "divider-h"
-    variants:
-      - "divider-v"
-
-  grid:
-    root: "col-2"
-    variants:
-      - "col-3"
-      - "col-4"
-      - "col-5"
-      - "col-6"
-      - "col-8"
-      - "col-thirds"
-
   # ── Chart Card (design-widgets.md §Chart Card) ────────────────────────────
+  # Kept because tab.required-scripts references chart-card via when-also.
   chart-card:
     root: "chart-container"
     children:
@@ -186,20 +156,8 @@ components:
       - "chart-legend"
       - "chart-dotted-background"
 
-  legend:
-    root: "legend-item"
-    variants:
-      - "legend-line"
-      - "legend-rect"
-      - "legend-dot"
-
-  # ── Metric Card (design-widgets.md §Metric Card) ──────────────────────────
-  metric-card:
-    root: "metric-column"
-    children:
-      - "metric-card"
-
   # ── Table Card (design-widgets.md §Table Card) ────────────────────────────
+  # Kept because tab.required-scripts references table-card via when-also.
   table-card:
     root: "table-card"
     children:
@@ -208,10 +166,6 @@ components:
     states:
       - "is-bullish"
       - "is-bearish"
-
-  # ── Free Text Card (design-widgets.md §Free Text Card) ────────────────────
-  free-text-card:
-    root: "free-text-body"
 
   # ── Feed Card (design-widgets.md §Feed Card) ──────────────────────────────
   feed-card:
@@ -240,19 +194,3 @@ components:
     states:
       - "has-badge"
       - "no-radius"
-
-  yt-modal:
-    root: "yt-modal"
-    children:
-      - "yt-modal-inner"
-      - "yt-modal-close"
-    states:
-      - "open"
-
-  # ── Group Title (design-widgets.md §Group Title) ──────────────────────────
-  group-title:
-    root: "section-title"
-    children:
-      - "section-title-icon"
-      - "section-title-text"
-      - "section-title-sub"

--- a/skills/alva/references/design-contract.yaml
+++ b/skills/alva/references/design-contract.yaml
@@ -129,12 +129,23 @@ components:
     children:
       - "tab-item"
     required-scripts:
+      # Canonical path: chart-card component used → check resize handler.
       - when-also: ["chart-card"]
         must-contain:
           - "[_echarts_instance_]"
           - "echarts.getInstanceByDom"
           - ".resize()"
         message: "Hidden ECharts containers report 0×0; when a tab panel becomes visible, resize all ECharts instances inside it. See design-components.md §Tab JS Interaction."
+      # Semantic-trigger path: any tab playbook that calls echarts.init
+      # — regardless of whether the chart wrapper uses canonical .chart-container
+      # class. Catches playbooks that style charts with ad-hoc wrapper classes
+      # but still need the same resize-on-tab-switch handler.
+      - when-script-contains: ["echarts.init"]
+        must-contain:
+          - "[_echarts_instance_]"
+          - "echarts.getInstanceByDom"
+          - ".resize()"
+        message: "ECharts is in use anywhere in this tab playbook; the canonical resize-on-tab-switch handler is required regardless of which class wraps the chart. See design-components.md §Tab JS Interaction."
       - when-also: ["table-card"]
         must-contain:
           - "initTableAlignment"

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -1,5 +1,11 @@
 # Widget Design Guideline
 
+> ⚠️ **The ```css blocks in this file are the source of truth for
+> [css/design-system.css](css/design-system.css) (published to CDN).**
+> When you edit any ```css block, run `pnpm build-design-system-css`
+> from `skills/alva/scripts/` and commit the regenerated `design-system.css`
+> alongside your `.md` edit. CI doc-sync catches drift.
+
 ## Widget Types
 
 - [Critical Rules (TL;DR)](#critical-rules-tldr)

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -83,9 +83,11 @@ Include these anti-aliasing declarations in generated styles (globally, or on
 any text container):
 
 ```css
--webkit-font-smoothing: antialiased;
--moz-osx-font-smoothing: grayscale;
-text-rendering: optimizeLegibility;
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
 ```
 
 - If the project already has a global reset or typography base class, ensure the

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -10,12 +10,18 @@ Full token definitions (colors, spacing, radius, theme) are in
 [design-tokens.css](./design-tokens.css). Always read that file for exact
 token values.
 
-In generated HTML, import tokens from the CDN — do not copy token values
-inline:
+In generated HTML, link the canonical design-system stylesheet from the CDN.
+**For new playbooks, use the v1 bundle** — one file contains tokens + global
+rules + components + widgets:
 
 ```html
-<link rel="stylesheet" href="https://alva-ai-static.b-cdn.net/design-system/design-tokens.css" />
+<link rel="stylesheet" href="https://alva-ai-static.b-cdn.net/design-system/v1/design-system.css" />
 ```
+
+Existing playbooks that only link the legacy `design-tokens.css` URL continue
+to work (the linter accepts both forms). For new playbooks, prefer the v1
+bundle so component and widget CSS comes from the CDN instead of inlined per
+playbook.
 
 Always reference tokens via `var(--token-name)` — never hardcode hex or rgba
 values. Below is a quick reference:
@@ -39,6 +45,10 @@ the **design linter** that runs inside `alva release playbook`:
 - [design-contract.yaml](./design-contract.yaml) — token-free contract: the
   required global container, scroll/typography/link rules, and the registered
   components (root class, variants, sizes, states, bindings).
+- [css/design-system.css](./css/design-system.css) — the canonical CSS bundle
+  (tokens + globals + components + widgets) generated from this doc's
+  ```css blocks plus design-components.md / design-widgets.md. Published
+  to the CDN; new playbooks `<link>` it to get all canonical styling.
 
 The linter is shipped in the `alva` CLI and runs as a hard gate. To pre-check
 a playbook before release:

--- a/skills/alva/scripts/build-design-system-css.test.ts
+++ b/skills/alva/scripts/build-design-system-css.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { extractCssBlocks, buildDesignSystemCss } from './build-design-system-css.js';
+
+describe('extractCssBlocks', () => {
+  it('extracts all ```css fenced blocks in document order', () => {
+    const md = `
+# Title
+Some prose.
+\`\`\`css
+.btn { color: red; }
+\`\`\`
+More prose.
+\`\`\`css
+.tag { color: blue; }
+\`\`\`
+`;
+    const blocks = extractCssBlocks(md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain('.btn { color: red; }');
+    expect(blocks[1]).toContain('.tag { color: blue; }');
+  });
+
+  it('returns [] when no css blocks present', () => {
+    expect(extractCssBlocks('# Title\nProse only.')).toEqual([]);
+  });
+
+  it('ignores non-css code blocks (js, html, etc.)', () => {
+    const md = `
+\`\`\`js
+const x = 1;
+\`\`\`
+\`\`\`css
+.btn {}
+\`\`\`
+\`\`\`html
+<div></div>
+\`\`\`
+`;
+    expect(extractCssBlocks(md)).toHaveLength(1);
+  });
+});
+
+describe('buildDesignSystemCss', () => {
+  it('concatenates sources in order: tokens, globals, components, widgets', () => {
+    const out = buildDesignSystemCss({
+      tokensCss: ':root { --x: 1; }',
+      designMd: '# design\n```css\nbody { font-family: Delight; }\n```',
+      componentsMd: '## Button\n```css\n.btn { padding: 8px; }\n```',
+      widgetsMd: '## Chart Card\n```css\n.chart-container { height: 100%; }\n```',
+    });
+    const tokensIdx = out.indexOf('--x: 1');
+    const globalIdx = out.indexOf('font-family: Delight');
+    const componentIdx = out.indexOf('.btn { padding: 8px');
+    const widgetIdx = out.indexOf('.chart-container');
+    expect(tokensIdx).toBeGreaterThanOrEqual(0);
+    expect(globalIdx).toBeGreaterThan(tokensIdx);
+    expect(componentIdx).toBeGreaterThan(globalIdx);
+    expect(widgetIdx).toBeGreaterThan(componentIdx);
+  });
+
+  it('emits section-header comments', () => {
+    const out = buildDesignSystemCss({
+      tokensCss: ':root {}',
+      designMd: '',
+      componentsMd: '',
+      widgetsMd: '',
+    });
+    expect(out).toMatch(/\/\* ════ Tokens ════ \*\//);
+    expect(out).toMatch(/\/\* ════ Globals ════ \*\//);
+    expect(out).toMatch(/\/\* ════ Components ════ \*\//);
+    expect(out).toMatch(/\/\* ════ Widgets ════ \*\//);
+  });
+
+  it('is deterministic for same inputs', () => {
+    const inputs = {
+      tokensCss: ':root { --x: 1; }',
+      designMd: '```css\nbody{}\n```',
+      componentsMd: '```css\n.btn{}\n```',
+      widgetsMd: '```css\n.chart-container{}\n```',
+    };
+    expect(buildDesignSystemCss(inputs)).toEqual(buildDesignSystemCss(inputs));
+  });
+});

--- a/skills/alva/scripts/build-design-system-css.test.ts
+++ b/skills/alva/scripts/build-design-system-css.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { extractCssBlocks, buildDesignSystemCss } from './build-design-system-css.js';
+import {
+  extractCssBlocks,
+  buildDesignSystemCss,
+  findOrphanDeclarations,
+  validateInputs,
+} from './build-design-system-css.js';
 
 describe('extractCssBlocks', () => {
   it('extracts all ```css fenced blocks in document order', () => {
@@ -79,5 +84,70 @@ describe('buildDesignSystemCss', () => {
       widgetsMd: '```css\n.chart-container{}\n```',
     };
     expect(buildDesignSystemCss(inputs)).toEqual(buildDesignSystemCss(inputs));
+  });
+});
+
+describe('findOrphanDeclarations', () => {
+  it('returns [] for valid CSS (all declarations nested in selectors)', () => {
+    expect(findOrphanDeclarations('.btn { padding: 8px; color: red; }')).toEqual([]);
+  });
+
+  it('detects bare declarations at top level', () => {
+    const orphans = findOrphanDeclarations(
+      '-webkit-font-smoothing: antialiased;\n-moz-osx-font-smoothing: grayscale;'
+    );
+    expect(orphans).toHaveLength(2);
+    expect(orphans[0]!.property).toBe('-webkit-font-smoothing');
+    expect(orphans[1]!.property).toBe('-moz-osx-font-smoothing');
+  });
+
+  it('mixed: one orphan, one nested', () => {
+    const orphans = findOrphanDeclarations(
+      'color: red;\nbody { padding: 0; }'
+    );
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0]!.property).toBe('color');
+  });
+
+  it('records 1-based line numbers', () => {
+    const orphans = findOrphanDeclarations('\n\ncolor: red;');
+    expect(orphans[0]!.line).toBe(3);
+  });
+});
+
+describe('validateInputs', () => {
+  it('returns [] when every block is valid', () => {
+    const errs = validateInputs({
+      tokensCss: ':root { --x: 1; }',
+      designMd: '```css\nbody { font-family: Delight; }\n```',
+      componentsMd: '```css\n.btn { padding: 8px; }\n```',
+      widgetsMd: '```css\n.chart-container { height: 100%; }\n```',
+    });
+    expect(errs).toEqual([]);
+  });
+
+  it('flags the original anti-aliasing bug: bare declarations in design.md', () => {
+    const errs = validateInputs({
+      tokensCss: ':root {}',
+      designMd:
+        '```css\n-webkit-font-smoothing: antialiased;\n-moz-osx-font-smoothing: grayscale;\ntext-rendering: optimizeLegibility;\n```',
+      componentsMd: '',
+      widgetsMd: '',
+    });
+    expect(errs).toHaveLength(3);
+    expect(errs[0]!.source).toContain('design.md');
+    expect(errs[0]!.property).toBe('-webkit-font-smoothing');
+  });
+
+  it('attributes errors to the right source file + block index', () => {
+    const errs = validateInputs({
+      tokensCss: '',
+      designMd: '```css\nbody { padding: 0; }\n```\n```css\norphan: 1px;\n```',
+      componentsMd: '',
+      widgetsMd: '',
+    });
+    expect(errs).toHaveLength(1);
+    expect(errs[0]!.source).toContain('design.md');
+    expect(errs[0]!.source).toContain('#2');
   });
 });

--- a/skills/alva/scripts/build-design-system-css.ts
+++ b/skills/alva/scripts/build-design-system-css.ts
@@ -1,0 +1,92 @@
+// Build the v1 design-system.css bundle from .md sources + design-tokens.css.
+// Run: pnpm build-design-system-css         (writes the file)
+//      pnpm build-design-system-css --check (CI mode: diff against committed)
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REFERENCES = path.resolve(__dirname, '../references');
+const OUT_PATH = path.join(REFERENCES, 'css/design-system.css');
+
+export function extractCssBlocks(md: string): string[] {
+  const out: string[] = [];
+  const re = /```css\s*\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(md))) {
+    out.push(m[1]!);
+  }
+  return out;
+}
+
+export interface BuildInputs {
+  tokensCss: string;
+  designMd: string;
+  componentsMd: string;
+  widgetsMd: string;
+}
+
+export function buildDesignSystemCss(inputs: BuildInputs): string {
+  const sections: string[] = [];
+
+  sections.push('/* ════ Tokens ════ */');
+  sections.push(inputs.tokensCss.trim());
+
+  sections.push('');
+  sections.push('/* ════ Globals ════ */');
+  for (const block of extractCssBlocks(inputs.designMd)) {
+    sections.push(block.trim());
+  }
+
+  sections.push('');
+  sections.push('/* ════ Components ════ */');
+  for (const block of extractCssBlocks(inputs.componentsMd)) {
+    sections.push(block.trim());
+  }
+
+  sections.push('');
+  sections.push('/* ════ Widgets ════ */');
+  for (const block of extractCssBlocks(inputs.widgetsMd)) {
+    sections.push(block.trim());
+  }
+
+  return sections.join('\n\n') + '\n';
+}
+
+function readSources(): BuildInputs {
+  return {
+    tokensCss: fs.readFileSync(path.join(REFERENCES, 'design-tokens.css'), 'utf8'),
+    designMd: fs.readFileSync(path.join(REFERENCES, 'design.md'), 'utf8'),
+    componentsMd: fs.readFileSync(path.join(REFERENCES, 'design-components.md'), 'utf8'),
+    widgetsMd: fs.readFileSync(path.join(REFERENCES, 'design-widgets.md'), 'utf8'),
+  };
+}
+
+async function main() {
+  const checkMode = process.argv.includes('--check');
+  const css = buildDesignSystemCss(readSources());
+
+  if (checkMode) {
+    if (!fs.existsSync(OUT_PATH)) {
+      console.error(`design-system.css drift: ${OUT_PATH} does not exist`);
+      process.exit(1);
+    }
+    const existing = fs.readFileSync(OUT_PATH, 'utf8');
+    if (existing !== css) {
+      console.error(
+        `design-system.css drift: file does not match build output. Run 'pnpm build-design-system-css' and commit the result.`
+      );
+      process.exit(1);
+    }
+    console.log('design-system.css: in sync');
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, css, 'utf8');
+  console.log(`design-system.css: wrote ${css.length} bytes`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/skills/alva/scripts/build-design-system-css.ts
+++ b/skills/alva/scripts/build-design-system-css.ts
@@ -4,6 +4,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import * as csstree from 'css-tree';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REFERENCES = path.resolve(__dirname, '../references');
@@ -19,11 +20,98 @@ export function extractCssBlocks(md: string): string[] {
   return out;
 }
 
+/**
+ * Find CSS property declarations sitting OUTSIDE any selector block.
+ * Returns one entry per orphan, with the property name and 1-based line.
+ *
+ * Catches the case where a doc author writes a ```css block as a
+ * documentation snippet (just declarations) instead of a complete CSS rule.
+ * Such blocks would produce dead-code declarations in the built bundle
+ * (browsers silently drop top-level declarations).
+ */
+export function findOrphanDeclarations(
+  css: string
+): { line: number; property: string }[] {
+  const orphans: { line: number; property: string }[] = [];
+  let ast: csstree.CssNode;
+  try {
+    ast = csstree.parse(css, { positions: true });
+  } catch {
+    return orphans; // parse error — let downstream handle
+  }
+  if (ast.type !== 'StyleSheet') return orphans;
+
+  // css-tree is "be liberal in what you accept": it never produces a
+  // top-level Declaration node. Bare declarations end up as:
+  //  (a) a top-level Raw node when there is no following selector, OR
+  //  (b) the prelude of a Rule, with prelude.type === 'Raw' (the bare
+  //      declarations get folded into the selector position).
+  // We probe both cases by pattern-matching `property: value;` inside
+  // Raw text. Vendor prefixes (-webkit-…) and CSS custom properties
+  // (--foo) both start with one or two dashes.
+  const DECL_RE = /(-{0,2}[a-zA-Z][\w-]*)\s*:\s*[^;{}]+;/g;
+
+  const probeRaw = (rawText: string, baseLine: number): void => {
+    let m: RegExpExecArray | null;
+    while ((m = DECL_RE.exec(rawText))) {
+      const before = rawText.slice(0, m.index);
+      const lineOffset = before.split('\n').length - 1;
+      orphans.push({ property: m[1]!, line: baseLine + lineOffset });
+    }
+    DECL_RE.lastIndex = 0;
+  };
+
+  ast.children.forEach((node) => {
+    const startLine = node.loc?.start.line ?? 0;
+    if (node.type === 'Raw') {
+      probeRaw(node.value, startLine);
+    } else if (node.type === 'Rule' && node.prelude.type === 'Raw') {
+      probeRaw(node.prelude.value, node.prelude.loc?.start.line ?? startLine);
+    }
+  });
+  return orphans;
+}
+
 export interface BuildInputs {
   tokensCss: string;
   designMd: string;
   componentsMd: string;
   widgetsMd: string;
+}
+
+export interface CssBlockError {
+  source: string; // e.g. "design.md block #2"
+  property: string;
+  line: number; // line within the block
+}
+
+/**
+ * Validate every ```css block across the .md sources. Returns a list of
+ * orphan declarations (declarations that appear at top level, not nested
+ * in any selector). An empty list means every block is structurally valid.
+ *
+ * Builders should fail loudly when this returns anything.
+ */
+export function validateInputs(inputs: BuildInputs): CssBlockError[] {
+  const errors: CssBlockError[] = [];
+  const docs = [
+    { name: 'design.md', md: inputs.designMd },
+    { name: 'design-components.md', md: inputs.componentsMd },
+    { name: 'design-widgets.md', md: inputs.widgetsMd },
+  ];
+  for (const doc of docs) {
+    const blocks = extractCssBlocks(doc.md);
+    blocks.forEach((block, idx) => {
+      for (const o of findOrphanDeclarations(block)) {
+        errors.push({
+          source: doc.name + ' ```css block #' + String(idx + 1),
+          property: o.property,
+          line: o.line,
+        });
+      }
+    });
+  }
+  return errors;
 }
 
 export function buildDesignSystemCss(inputs: BuildInputs): string {
@@ -64,7 +152,27 @@ function readSources(): BuildInputs {
 
 async function main() {
   const checkMode = process.argv.includes('--check');
-  const css = buildDesignSystemCss(readSources());
+  const inputs = readSources();
+
+  // Validate ```css blocks before building. Catches "documentation snippet"
+  // blocks that contain bare property declarations without a selector —
+  // browsers silently drop those, so a passing build with orphans is a
+  // false negative.
+  const inputErrors = validateInputs(inputs);
+  if (inputErrors.length > 0) {
+    console.error(
+      `design-system.css build aborted: ${inputErrors.length} orphan declaration(s) in .md \`\`\`css blocks:`
+    );
+    for (const e of inputErrors) {
+      console.error(`  ${e.source} (L${e.line}): '${e.property}' is not inside any selector`);
+    }
+    console.error(
+      `Wrap each property declaration inside a selector block (e.g. \`body { ... }\`), or remove the block.`
+    );
+    process.exit(1);
+  }
+
+  const css = buildDesignSystemCss(inputs);
 
   if (checkMode) {
     if (!fs.existsSync(OUT_PATH)) {

--- a/skills/alva/scripts/design-contract-sync.test.ts
+++ b/skills/alva/scripts/design-contract-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CSS_PATH = path.resolve(here, '../references/css/design-system.css');
+
+describe('design-contract-sync — CSS freshness check', () => {
+  it('exits 0 when design-system.css matches build output', () => {
+    const out = execSync('tsx design-contract-sync.ts', { cwd: here, encoding: 'utf8' });
+    expect(out).toMatch(/in sync/);
+  });
+
+  it('exits 1 when design-system.css is stale', () => {
+    const original = fs.readFileSync(CSS_PATH, 'utf8');
+    try {
+      fs.writeFileSync(CSS_PATH, original + '\n/* INTENTIONAL DRIFT */\n');
+      let exitCode = 0;
+      try {
+        execSync('tsx design-contract-sync.ts', { cwd: here, encoding: 'utf8' });
+      } catch (e: unknown) {
+        exitCode = (e as { status: number }).status;
+      }
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.writeFileSync(CSS_PATH, original);
+    }
+  });
+});

--- a/skills/alva/scripts/design-contract-sync.ts
+++ b/skills/alva/scripts/design-contract-sync.ts
@@ -5,6 +5,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { spawnSync } from 'node:child_process';
 import YAML from 'yaml';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -117,8 +118,21 @@ function check(): string[] {
 }
 
 const errors = check();
+
+// CSS freshness check — re-run the design-system.css build and compare
+const cssCheck = spawnSync('tsx', ['build-design-system-css.ts', '--check'], {
+  cwd: __dirname,
+  stdio: 'pipe',
+  encoding: 'utf8',
+});
+if (cssCheck.status !== 0) {
+  errors.push(
+    `design-system.css drift: ${(cssCheck.stderr || '').trim() || 'build --check failed'}`
+  );
+}
+
 if (errors.length === 0) {
-  console.log('design-contract.yaml ⇄ design docs: in sync');
+  console.log('design-contract.yaml ⇄ design docs: in sync\ndesign-system.css: in sync');
   process.exit(0);
 } else {
   console.error('design-contract.yaml ⇄ design docs DRIFT:');

--- a/skills/alva/scripts/package.json
+++ b/skills/alva/scripts/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
+    "vitest": "^2.0.0",
     "yaml": "^2.0.0"
   }
 }

--- a/skills/alva/scripts/package.json
+++ b/skills/alva/scripts/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "design-contract-sync": "tsx design-contract-sync.ts"
+    "design-contract-sync": "tsx design-contract-sync.ts",
+    "build-design-system-css": "tsx build-design-system-css.ts",
+    "build-design-system-css:check": "tsx build-design-system-css.ts --check"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/skills/alva/scripts/package.json
+++ b/skills/alva/scripts/package.json
@@ -8,7 +8,9 @@
     "build-design-system-css:check": "tsx build-design-system-css.ts --check"
   },
   "devDependencies": {
+    "@types/css-tree": "^2.3.11",
     "@types/node": "^20.0.0",
+    "css-tree": "^3.2.1",
     "tsx": "^4.0.0",
     "vitest": "^2.0.0",
     "yaml": "^2.0.0"

--- a/skills/alva/scripts/pnpm-lock.yaml
+++ b/skills/alva/scripts/pnpm-lock.yaml
@@ -14,11 +14,20 @@ importers:
       tsx:
         specifier: ^4.0.0
         version: 4.22.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.41)
       yaml:
         specifier: ^2.0.0
         version: 2.9.0
 
 packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -26,10 +35,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -38,16 +59,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -56,10 +95,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -68,10 +119,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -80,10 +143,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -92,10 +167,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -104,16 +191,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.28.0':
     resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.0':
@@ -128,6 +233,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.0':
     resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
@@ -138,6 +249,12 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -152,16 +269,34 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
@@ -170,24 +305,301 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.0':
     resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tsx@4.22.3:
     resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
@@ -197,6 +609,72 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -204,52 +682,103 @@ packages:
 
 snapshots:
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
@@ -258,10 +787,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -270,21 +805,202 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@20.19.41':
     dependencies:
       undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.41))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.41)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -315,8 +1031,85 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tsx@4.22.3:
     dependencies:
@@ -325,5 +1118,72 @@ snapshots:
       fsevents: 2.3.3
 
   undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@20.19.41):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.41)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.41):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 20.19.41
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.41):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.41))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.41)
+      vite-node: 2.1.9(@types/node@20.19.41)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yaml@2.9.0: {}

--- a/skills/alva/scripts/pnpm-lock.yaml
+++ b/skills/alva/scripts/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     devDependencies:
+      '@types/css-tree':
+        specifier: ^2.3.11
+        version: 2.3.11
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.41
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
       tsx:
         specifier: ^4.0.0
         version: 4.22.3
@@ -445,6 +451,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/css-tree@2.3.11':
+    resolution: {integrity: sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -499,6 +508,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -542,6 +555,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -906,6 +922,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@types/css-tree@2.3.11': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
@@ -967,6 +985,11 @@ snapshots:
       pathval: 2.0.1
 
   check-error@2.1.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   debug@4.4.3:
     dependencies:
@@ -1045,6 +1068,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## What

Skills repo side of the design-system CSS publishing project. Publishes a single canonical \`v1/design-system.css\` bundle (tokens + globals + components + widgets) so new playbooks can \`<link>\` one file instead of inlining ~3000 lines of canonical CSS each.

## Changes

- New \`scripts/build-design-system-css.ts\` — extracts \`\`\`css blocks from design.md / design-components.md / design-widgets.md, prepends design-tokens.css, writes \`references/css/design-system.css\` (committed). 6 unit tests.
- doc-sync extended: rebuilds in --check mode and diffs against the committed file. CI catches drift.
- Publish workflow: extended with v1/ upload step + path trigger on \`references/css/design-system.css\`.
- \`design-contract.yaml\`: \`required-stylesheets\` → any-of group (legacy URL OR v1 URL passes); new \`canonical-css-urls\` lists URLs that signal "playbook has full canonical CSS".
- \`design.md\` template: recommends v1 URL for new playbooks; legacy still allowed.
- SKILL.md: sub-doc index row for design-system.css, Release Checklist note.
- Drift banners on \`design-components.md\` + \`design-widgets.md\` — pointing readers at the build script when they edit \`\`\`css blocks.

Generated bundle: 38,591 bytes uncompressed, ~8-10KB gzip.

## Paired PR

- toolkit-ts (linter side, any-of + canonical-css-urls + new forbid-core-selector-override rule): https://github.com/alva-ai/toolkit-ts/pull/64

## Foundation PRs (must merge first)

- toolkit-ts #61 — design linter v1
- skills #413 — design contract + doc-sync + Alva skill doc updates
- mono-meta #461 — design-linter spec + plan
- mono-meta #468 — this project's spec + plan

## Migration

- Existing playbooks linking only legacy \`design-tokens.css\` continue to pass lint
- New playbooks generated from the updated template link \`v1/design-system.css\` and get all CSS from CDN
- No forced upgrade for old playbooks

## Once merged

The publish workflow will fire on this commit and upload \`design-system.css\` to \`alva-ai-stg-ssr-cdn-bucket/design-system/v1/\`, making the CDN URL live. After that, the toolkit-ts paired PR's CDN fallback will populate on the next \`npm run vendor-contract\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)