### PR TITLE
docs(alva): mention alva auth login --no-browser

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -122,6 +122,10 @@ Third-party vendor secrets belong in Alva Secret Manager
 Run `alva whoami`. If it fails (no API key), run `alva auth login` to open
 browser-based login, then re-run `alva whoami` to confirm.
 
+For SSH / container / headless environments where the CLI cannot open a
+browser locally, use `alva auth login --no-browser` — it prints a URL to
+open on any device, then prompts you to paste the code shown on that page.
+
 ### 3. User Profile
 
 ```bash


### PR DESCRIPTION
## Summary

3-line addition to `skills/alva/SKILL.md` section 2a documenting the new `alva auth login --no-browser` flag for SSH / container / headless environments.

Trivial doc change; part of the cross-service work that adds OAuth no-browser CLI login.

## Breaking Changes

None.

## Database Migrations

None.

## Merge Order

Merge after `alva-ai/toolkit-ts` PR ships the `--no-browser` flag (otherwise the doc references a CLI feature that doesn't exist yet for users who upgrade their skill but not their CLI).

## Related

- Primary: alva-ai/alva-gateway#422
- alva-ai/toolkit-ts PR — CLI implementation of `--no-browser`

## Test Plan

- [x] Minimal addition kept tight per `/alva-skill-standard` (SKILL.md should stay lean and route to references)
- [x] No new references/ file needed for a single-sentence addition
- [ ] User reads the new section after merge and confirms it's clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)