### PR TITLE
docs: document playbook UDF runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Start with a simple prompt:
 Build me an NVDA dashboard with insider trading data and financial metrics
 ```
 
-That's it. Your agent now has full access to the Alva platform. By default, the skill builds live playbooks unless you explicitly ask for a static snapshot. Interactive playbooks use the current PBSV + UDF runtime.
+That's it. Your agent now has full access to the Alva platform. By default, the skill builds live playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive playbooks use the current PBSV + UDF runtime.
 
 ---
 
@@ -99,7 +99,7 @@ That's it. Your agent now has full access to the Alva platform. By default, the 
 | Trading Strategy | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing"*                 |
 | Macro Overview   | *"Build a macro dashboard with CPI, GDP, Treasury rates, and recession probability"*      |
 | Screening Tool   | *"Screen for stocks with PE < 15, ROE > 20%, and positive insider buying"*                |
-| Interactive Tool | *"Create a playbook with a Run analysis button that invokes a UDF for the selected ticker"* |
+| Interactive Tool | *"Register a playbook UDF and expose it through a Run analysis button for the selected ticker"* |
 
 ---
 
@@ -134,7 +134,7 @@ Event-driven backtesting with historical data and live paper trading. Define str
 
 ### Deploy & Share — Playbook Web Apps
 
-Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and interactive UDF controls powered by playbook-scoped viewer tokens. You can also remix published playbooks and add a creator's note after release.
+Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and optional UDF controls for explicitly requested user-registered functions. You can also remix published playbooks and add a creator's note after release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Start with a simple prompt:
 Build me an NVDA dashboard with insider trading data and financial metrics
 ```
 
-That's it. Your agent now has full access to the Alva platform. By default, the skill builds live playbooks unless you explicitly ask for a static snapshot.
+That's it. Your agent now has full access to the Alva platform. By default, the skill builds live playbooks unless you explicitly ask for a static snapshot. Interactive playbooks use the current PBSV + UDF runtime.
 
 ---
 
@@ -99,6 +99,7 @@ That's it. Your agent now has full access to the Alva platform. By default, the 
 | Trading Strategy | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing"*                 |
 | Macro Overview   | *"Build a macro dashboard with CPI, GDP, Treasury rates, and recession probability"*      |
 | Screening Tool   | *"Screen for stocks with PE < 15, ROE > 20%, and positive insider buying"*                |
+| Interactive Tool | *"Create a playbook with a Run analysis button that invokes a UDF for the selected ticker"* |
 
 ---
 
@@ -133,7 +134,7 @@ Event-driven backtesting with historical data and live paper trading. Define str
 
 ### Deploy & Share — Playbook Web Apps
 
-Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and more. You can also remix published playbooks and add a creator's note after release.
+Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and interactive UDF controls powered by playbook-scoped viewer tokens. You can also remix published playbooks and add a creator's note after release.
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -166,20 +166,6 @@ Use the loaded memory to tailor your responses to the user's profile,
 preferences, and investment style. See the [Memory](#memory) section below for
 reading and writing rules.
 
-### Playbook Runtime Authentication
-
-Playbook pages hosted on Alva must use the PBSV runtime protocol for
-viewer-scoped browser access. The parent Alva page mints a playbook-scoped
-viewer token and appends it to the iframe URL as `_pbsv`, together with
-`parent_origin` and `api_origin`. Browser code inside the playbook should load
-`@alva-ai/toolkit` and use `window.alva.udf` for interactive UDF calls.
-
-### Browser SDK Resources
-
-`client.user`, `client.fs`, `client.run`, `client.deploy`, `client.release`,
-`client.secrets`, `client.sdk`, `client.comments`, `client.remix`,
-`client.screenshot`
-
 ---
 
 ## Communication
@@ -742,57 +728,21 @@ async function readAlfsJson(path) {
 not emit it into browser HTML; published HTML must call the public read gateway
 above so anonymous viewers can load feed output without authentication.
 
-#### Interactive UDFs in Playbooks
+#### User-Defined Functions in Playbooks
 
-Use UDFs when the playbook needs user-triggered computation from the browser
-after the page has loaded, such as "analyze this ticker", "rebalance with these
-assumptions", or "summarize the selected scenario".
+UDFs are user-registered functions that a playbook owner can expose to other
+users. They have two separate surfaces: creator-side function registration and
+viewer-side invocation from the playbook HTML. Only use this path when the user
+strictly asks for registerable/shareable interactive functions (for example,
+"register a UDF", "let viewers run this function", or "add a button that calls
+my analysis function"). Do not introduce UDFs for ordinary dashboards,
+scheduled data refresh, static filters, or feed-backed charts.
 
-1. **Register creator functions** through the service API before or during
-   release. Each function belongs to one playbook and declares:
-   `playbook_id`, `function_name`, `entry_script_path`, and `params_schema`.
-   Keep `entry_script_path` in creator-controlled ALFS paths; viewers never see
-   it through PBSV reads.
-2. **Load the browser SDK** in the playbook HTML and call:
-   `window.alva.udf.list()` for function metadata and
-   `window.alva.udf.call(functionName, params)` for invocation.
-3. **Use `window.alva.udf.renderButton(...)`** for simple one-click
-   interactions. It disables itself when the viewer is not signed in, invokes
-   with PBSV headers, and emits `alva:udf-button:loading`,
-   `alva:udf-button:result`, and `alva:udf-button:error` DOM events.
-4. **Do not handle bearer headers yourself** in playbook HTML. The SDK reads
-   `_pbsv`, strips it from the URL, accepts parent token refresh messages, and
-   sends `Authorization: Bearer <pbsv>` plus `X-Pbsv: 1`.
-5. **Expect allowance consent**. If the backend returns `CONSENT_REQUIRED`
-   (HTTP 402), the SDK asks the parent Alva page to show the allowance modal,
-   then retries once if the user approves. Do not build your own credit
-   authorization dialog inside the playbook iframe.
-
-Minimal browser pattern:
-
-```html
-<script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>
-<button id="run-analysis" type="button">Run analysis</button>
-<pre id="udf-output"></pre>
-<script>
-  const button = document.querySelector('#run-analysis');
-  const output = document.querySelector('#udf-output');
-
-  button.addEventListener('click', async () => {
-    try {
-      button.disabled = true;
-      const result = await window.alva.udf.call('analyze', {
-        ticker: 'AAPL',
-      });
-      output.textContent = JSON.stringify(result, null, 2);
-    } catch (error) {
-      output.textContent = error.message || String(error);
-    } finally {
-      button.disabled = false;
-    }
-  });
-</script>
-```
+When the trigger is met, read
+[udf-runtime.md](references/api/udf-runtime.md) before registration or browser
+implementation. The reference covers PBSV browser authentication, service API
+registration, `window.alva.udf`, allowance consent, and release checks. Never
+hand-write bearer headers in playbook HTML; use the browser SDK.
 
 ### 7. Release
 
@@ -939,8 +889,9 @@ Required evidence:
 4. **HTML fetches from feeds**: The playbook HTML reads quantitative data from
    feed output paths at runtime, not from inline literals, consistent with the
    [Content Legitimacy Rules](#content-legitimacy-rules).
-5. **UDF runtime is current**: If the playbook includes interactive UDFs, the
-   HTML loads the current toolkit browser SDK and uses `window.alva.udf`.
+5. **UDF runtime is current**: If the playbook includes user-registered UDFs,
+   [udf-runtime.md](references/api/udf-runtime.md) has been read, the function
+   is registered, and the HTML uses `window.alva.udf`.
 6. **Data is fresh**: Read the latest data point from each referenced feed via
    `@last/1` and check its timestamp. If the latest timestamp is older than 2x
    the cron interval, warn the user that the playbook will display stale data.
@@ -1124,7 +1075,7 @@ the full locate-and-edit procedure.
 | [memory.md](references/memory.md) | Per-user memory: storage layout, `user.md` template, what to save, read/write rules |
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
 | [language.md](references/language.md) | Canonical product vocabulary: automation, playbook, alert, Agent, and when feed must stay internal |
-| [udf-runtime.md](references/api/udf-runtime.md) | Playbook browser UDF runtime: PBSV, allowance consent, service endpoints, and `UdfButton` |
+| [udf-runtime.md](references/api/udf-runtime.md) | User-defined functions for playbooks: strict trigger rule, creator registration, browser invocation, PBSV, allowance consent, and `UdfButton` |
 
 ---
 
@@ -1159,7 +1110,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 
 Non-CLI references:
 [error-responses.md](references/api/error-responses.md) — HTTP status → error-code table for programmatic error handling.
-[udf-runtime.md](references/api/udf-runtime.md) — playbook iframe UDF calls.
+[udf-runtime.md](references/api/udf-runtime.md) — user-defined function registration and playbook iframe calls.
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -166,6 +166,20 @@ Use the loaded memory to tailor your responses to the user's profile,
 preferences, and investment style. See the [Memory](#memory) section below for
 reading and writing rules.
 
+### Playbook Runtime Authentication
+
+Playbook pages hosted on Alva must use the PBSV runtime protocol for
+viewer-scoped browser access. The parent Alva page mints a playbook-scoped
+viewer token and appends it to the iframe URL as `_pbsv`, together with
+`parent_origin` and `api_origin`. Browser code inside the playbook should load
+`@alva-ai/toolkit` and use `window.alva.udf` for interactive UDF calls.
+
+### Browser SDK Resources
+
+`client.user`, `client.fs`, `client.run`, `client.deploy`, `client.release`,
+`client.secrets`, `client.sdk`, `client.comments`, `client.remix`,
+`client.screenshot`
+
 ---
 
 ## Communication
@@ -724,6 +738,58 @@ async function readAlfsJson(path) {
 not emit it into browser HTML; published HTML must call the public read gateway
 above so anonymous viewers can load feed output without authentication.
 
+#### Interactive UDFs in Playbooks
+
+Use UDFs when the playbook needs user-triggered computation from the browser
+after the page has loaded, such as "analyze this ticker", "rebalance with these
+assumptions", or "summarize the selected scenario".
+
+1. **Register creator functions** through the service API before or during
+   release. Each function belongs to one playbook and declares:
+   `playbook_id`, `function_name`, `entry_script_path`, and `params_schema`.
+   Keep `entry_script_path` in creator-controlled ALFS paths; viewers never see
+   it through PBSV reads.
+2. **Load the browser SDK** in the playbook HTML and call:
+   `window.alva.udf.list()` for function metadata and
+   `window.alva.udf.call(functionName, params)` for invocation.
+3. **Use `window.alva.udf.renderButton(...)`** for simple one-click
+   interactions. It disables itself when the viewer is not signed in, invokes
+   with PBSV headers, and emits `alva:udf-button:loading`,
+   `alva:udf-button:result`, and `alva:udf-button:error` DOM events.
+4. **Do not handle bearer headers yourself** in playbook HTML. The SDK reads
+   `_pbsv`, strips it from the URL, accepts parent token refresh messages, and
+   sends `Authorization: Bearer <pbsv>` plus `X-Pbsv: 1`.
+5. **Expect allowance consent**. If the backend returns `CONSENT_REQUIRED`
+   (HTTP 402), the SDK asks the parent Alva page to show the allowance modal,
+   then retries once if the user approves. Do not build your own credit
+   authorization dialog inside the playbook iframe.
+
+Minimal browser pattern:
+
+```html
+<script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>
+<button id="run-analysis" type="button">Run analysis</button>
+<pre id="udf-output"></pre>
+<script>
+  const button = document.querySelector('#run-analysis');
+  const output = document.querySelector('#udf-output');
+
+  button.addEventListener('click', async () => {
+    try {
+      button.disabled = true;
+      const result = await window.alva.udf.call('analyze', {
+        ticker: 'AAPL',
+      });
+      output.textContent = JSON.stringify(result, null, 2);
+    } catch (error) {
+      output.textContent = error.message || String(error);
+    } finally {
+      button.disabled = false;
+    }
+  });
+</script>
+```
+
 ### 7. Release
 
 #### Common steps (all users)
@@ -869,20 +935,22 @@ Required evidence:
 4. **HTML fetches from feeds**: The playbook HTML reads quantitative data from
    feed output paths at runtime, not from inline literals, consistent with the
    [Content Legitimacy Rules](#content-legitimacy-rules).
-5. **Data is fresh**: Read the latest data point from each referenced feed via
+5. **UDF runtime is current**: If the playbook includes interactive UDFs, the
+   HTML loads the current toolkit browser SDK and uses `window.alva.udf`.
+6. **Data is fresh**: Read the latest data point from each referenced feed via
    `@last/1` and check its timestamp. If the latest timestamp is older than 2x
    the cron interval, warn the user that the playbook will display stale data.
-6. **Description is accurate**: Update frequency claims match actual cronjob
+7. **Description is accurate**: Update frequency claims match actual cronjob
    status. Data source claims match actual SDK/BYOD calls in the feed script.
-7. **Target user is correct**: The playbook is being released under the
+8. **Target user is correct**: The playbook is being released under the
    requesting user's namespace (see user scope enforcement above).
-8. **README is present and accurate**: `~/playbooks/{name}/README.md` exists
+9. **README is present and accurate**: `~/playbooks/{name}/README.md` exists
    on ALFS and covers the required sections (see
    [Playbook README in release.md](references/api/release.md#playbook-readme)).
    Its source / cadence claims match the actual feed scripts and deployed
    cronjobs. Pass it via `--readme-url` as an absolute ALFS path (see the
    `--readme-url` rule in Step 7 above).
-9. **Push feeds are released**: Every cronjob this playbook deploys with
+10. **Push feeds are released**: Every cronjob this playbook deploys with
    `push_notify: true` has a current `alva release feed --cronjob-id <that
    cronjob>` — run after the cronjob's latest source write and passing
    `before-feed-release`; otherwise the push dispatches an empty body. Items
@@ -1041,6 +1109,7 @@ the full locate-and-edit procedure.
 | [memory.md](references/memory.md) | Per-user memory: storage layout, `user.md` template, what to save, read/write rules |
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
 | [language.md](references/language.md) | Canonical product vocabulary: automation, playbook, alert, Agent, and when feed must stay internal |
+| [udf-runtime.md](references/api/udf-runtime.md) | Playbook browser UDF runtime: PBSV, allowance consent, service endpoints, and `UdfButton` |
 
 ---
 
@@ -1074,6 +1143,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 
 Non-CLI references:
 [error-responses.md](references/api/error-responses.md) — HTTP status → error-code table for programmatic error handling.
+[udf-runtime.md](references/api/udf-runtime.md) — playbook iframe UDF calls.
 
 ---
 

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -1,0 +1,213 @@
+# Playbook UDF Runtime
+
+Use this reference when a playbook needs interactive browser-triggered
+functions. This is the current runtime contract.
+
+## Runtime Model
+
+Alva renders released playbooks inside an iframe. The parent Alva page mints a
+playbook-scoped viewer token (PBSV) for signed-in viewers and appends these
+query parameters to the iframe URL:
+
+| Parameter       | Description                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `_pbsv`         | Short-lived playbook-scoped viewer JWT. Scope is fixed to read + `udf:invoke`. |
+| `parent_origin` | Origin allowed to send token refresh and consent messages.                     |
+| `api_origin`    | Alva API origin for service calls.                                             |
+
+Playbook HTML should load the browser bundle from `@alva-ai/toolkit`. The
+runtime installs `window.alva.udf`, reads `_pbsv`, removes only `_pbsv` from the
+visible URL, accepts parent token refreshes, and sends service requests with:
+
+```http
+Authorization: Bearer <pbsv-jwt>
+X-Pbsv: 1
+Content-Type: application/json
+```
+
+## Browser API
+
+```html
+<script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>
+<script>
+  const functions = await window.alva.udf.list();
+  const result = await window.alva.udf.call('analyze', { ticker: 'AAPL' });
+</script>
+```
+
+### `window.alva.udf.list()`
+
+Fetches metadata for functions registered on the current playbook.
+
+- Uses `GET /api/v1/service/functions?playbook_id=<id>`.
+- Sends PBSV headers.
+- Under PBSV, `entry_script_path` is intentionally hidden; only function
+  metadata and `params_schema` are exposed to viewers.
+
+### `window.alva.udf.call(functionName, params)`
+
+Invokes a registered playbook function.
+
+- Uses `POST /api/v1/service/invoke`.
+- Request body:
+
+```json
+{
+  "playbook_id": "<playbook-id>",
+  "function_name": "analyze",
+  "parameters_json": "{\"ticker\":\"AAPL\"}"
+}
+```
+
+- Response body:
+
+```json
+{
+  "result": {},
+  "logs": [],
+  "credits_used_total": 3,
+  "credits_charged_owner": 0,
+  "credits_charged_consumer": 3
+}
+```
+
+### `window.alva.udf.renderButton(target, options)`
+
+Mounts a simple `UdfButton` for one-click interactions.
+
+```html
+<div id="analysis-button"></div>
+<pre id="analysis-output"></pre>
+<script>
+  const button = window.alva.udf.renderButton("#analysis-button", {
+    functionName: "analyze",
+    params: { ticker: "AAPL" },
+    label: "Run analysis",
+  });
+
+  button.addEventListener("alva:udf-button:result", (event) => {
+    document.querySelector("#analysis-output").textContent = JSON.stringify(
+      event.detail.result,
+      null,
+      2,
+    );
+  });
+</script>
+```
+
+The button disables itself when no PBSV token is present. It dispatches:
+
+| Event                     | Meaning                                                    |
+| ------------------------- | ---------------------------------------------------------- |
+| `alva:udf-button:loading` | Invocation started.                                        |
+| `alva:udf-button:result`  | Invocation resolved; `event.detail.result` has the result. |
+| `alva:udf-button:error`   | Invocation failed; `event.detail.error` has the error.     |
+
+For richer forms, call `list()` to read `params_schema`, render your own inputs,
+then call `call()`.
+
+## Allowance Consent
+
+If a viewer has not authorized enough credits for this playbook, the backend
+returns `CONSENT_REQUIRED` as HTTP 402. The gateway body uses:
+
+```json
+{
+  "error": {
+    "code": "CONSENT_REQUIRED",
+    "message": "..."
+  },
+  "details": {
+    "metadata": {
+      "playbook_id": "<playbook-id>",
+      "min_allowance_suggested": 3
+    }
+  }
+}
+```
+
+The SDK posts an `alva:udf:consent-request` message to the parent Alva page. The
+parent shows the product allowance modal, creates or updates the allowance, then
+responds with `alva:udf:consent-response`. If granted, the SDK retries the
+invocation once.
+
+Do not implement a custom credit authorization modal inside the playbook iframe.
+
+## Creator Function Registration
+
+Creators register or update UDF functions through the service API:
+
+```http
+POST /api/v1/service/functions
+Content-Type: application/json
+Authorization: Bearer <creator-session-token>
+```
+
+```json
+{
+  "playbook_id": "<playbook-id>",
+  "function_name": "analyze",
+  "entry_script_path": "~/playbooks/my-playbook/udf/analyze.js",
+  "params_schema": {
+    "type": "object",
+    "properties": {
+      "ticker": { "type": "string" }
+    },
+    "required": ["ticker"]
+  }
+}
+```
+
+Delete a function with:
+
+```http
+DELETE /api/v1/service/functions?playbook_id=<playbook-id>&function_name=<name>
+```
+
+Function entry scripts should live in creator-controlled ALFS paths and should
+validate `parameters_json` before doing expensive work.
+
+## Allowance Management
+
+Consumer allowance is managed by the Alva app. For product UI or session-user
+tools, prefer GraphQL because timestamps are normalized:
+
+```graphql
+query {
+  allowance(playbookId: "...")
+  myAllowances
+}
+
+mutation {
+  createAllowance(input: { playbookId: "...", amount: 25 }) {
+    allowance {
+      id
+      playbookId
+      amount
+      used
+      remaining
+      createdAtMs
+      updatedAtMs
+    }
+  }
+}
+
+mutation {
+  revokeAllowance(playbookId: "...") {
+    ok
+  }
+}
+```
+
+PBSV is explicitly rejected from allowance-management APIs. Only signed-in
+session users can create, edit, or revoke allowances.
+
+## Pre-Release Checklist
+
+- The playbook HTML loads `@alva-ai/toolkit` before calling `window.alva.udf`.
+- UDF controls handle unauthenticated viewers by disabling controls or showing a
+  sign-in prompt; do not expose raw tokens.
+- `params_schema` matches the UI inputs and server-side validation.
+- Error UI handles auth, consent denied, insufficient credits, function not
+  found, disabled function, rate limit, and execution failures.
+- Viewer-facing copy explains that allowance is a cap, not an immediate charge.

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -1,7 +1,34 @@
 # Playbook UDF Runtime
 
-Use this reference when a playbook needs interactive browser-triggered
-functions. This is the current runtime contract.
+User-defined functions (UDFs) are functions registered by a playbook creator and
+made available for viewers to invoke from the playbook UI. A UDF flow always has
+two parts:
+
+1. **Registration**: the creator registers a named function, its entry script,
+   and its parameter schema against a playbook.
+2. **Use**: the playbook HTML lists or invokes registered functions through the
+   browser SDK.
+
+Use this reference only when the user strictly asks for a registerable or
+shareable interactive function, such as "register a UDF", "let viewers run this
+analysis", or "add a button that calls my function". Do not use UDFs for
+ordinary dashboards, scheduled data refresh, feed-backed charts, local-only
+helpers, static filters, or interactions that can run entirely in browser state.
+
+## Trigger Boundary
+
+Before adding UDFs, confirm the request needs a user-registered function that
+other users can call from the released playbook. If the request only asks for
+fresh data, recurring computation, or visual interactivity, use feeds and
+browser UI instead.
+
+If the trigger is met, implement both sides:
+
+- register or update the creator function with the service API
+- load the toolkit browser SDK and invoke the function with `window.alva.udf`
+
+Do not build only the browser button without registering the function, and do
+not register a function without wiring the intended viewer-facing use.
 
 ## Runtime Model
 
@@ -26,6 +53,9 @@ Content-Type: application/json
 ```
 
 ## Browser API
+
+The browser API is the viewer-side use surface. It assumes the function has
+already been registered for the playbook.
 
 ```html
 <script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>


### PR DESCRIPTION
## Summary
- Document the current PBSV-based playbook UDF runtime in the public Alva skill.
- Add a dedicated UDF runtime reference with browser API, consent flow, function registration, and allowance management guidance.
- Update the skill overview so agents generate interactive playbooks using `window.alva.udf`.

## Breaking Changes
None

## Database Migrations
None

## Merge Order
None

## Related
- alva-ai/frontend-monorepo#3740
- alva-ai/toolkit-ts#69
- alva-ai/skills#428

## Test Plan
- [x] `/Users/yancy/dev/mono-meta/code/frontend/toolkit-ts/node_modules/.bin/prettier --check skills/alva/references/api/udf-runtime.md`
- [x] `rg -n 'retired|query-token|older .*example|Never use the retired|Never create, preserve' README.md skills/alva/SKILL.md skills/alva/references/api/udf-runtime.md` returned no matches

Generated with Codex.
