### PR TITLE
[codex] Route non-US latest-price queries to finance search

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -537,6 +537,11 @@ updates). Run `alva data-skills list` for the live catalog.
 | Handle subscriptions for news, YouTube, Reddit, podcasts                          | [`feed_widgets`](#runtime-libraries)                     |
 | Topic/keyword search (Twitter, news, web, etc.)                                   | [`unified_search`](#content-search)                      |
 
+**Direct latest-price queries**: use structured intraday kline data for covered
+US equities and crypto; use `searchPerplexityFinance` first for non-US equities
+such as A-shares, HK stocks, and exchange-suffixed tickers (see
+[search.md](references/search.md)).
+
 **Data skill doc lookup is mandatory.** Always fetch the endpoint detail before
 writing code that calls it. Do not guess paths, parameter names, or response
 shapes from memory. The doc lookup ensures you use the correct endpoint and
@@ -1634,9 +1639,10 @@ consistent read pattern (`@last`, `@range`, etc.).
   and safe to call anytime.
 - **Cronjob path must point to an existing script.** The deploy API validates
   the entry_path exists via filesystem stat before creating the cronjob.
-- **Live-price answers must come from an intraday kline.** `interval=1d`
-  returns the previous session's close during trading hours, not the current
-  price — fetch `1min`/`5min` and read the newest record.
+- **Covered US equities and crypto**: live-price answers must come from an
+  intraday kline. `interval=1d` returns the previous session's close during
+  trading hours, not the current price — fetch `1min`/`5min` and read the
+  newest record.
 - **Create new playbooks from scratch unless you are doing a version update.**
   Only version updates may refer to an existing playbook. For all other new
   playbooks, do not read existing ones.


### PR DESCRIPTION
## Summary
- add a direct latest-price routing rule for covered US equities/crypto vs non-US equities
- point non-US latest-price queries such as A-shares, HK stocks, and exchange-suffixed tickers to `searchPerplexityFinance` first
- narrow the existing intraday-kline pitfall so it applies to covered US equities and crypto

## Why
A direct A-share price query like CATL / `300750.SZ` currently tempts agents to probe the structured US-centric stock endpoints first. The skill already documents finance search as the primary path for non-US equities, but that guidance lives deeper in the Content Search section. This change makes the route visible at the source-routing decision point.

## Validation
- `git diff --check`
- `bash /Users/ming/.codex/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/alva-latest-price-routing/skills/alva`
- `npx prettier --check skills/alva/SKILL.md` fails on the existing baseline file as well; no broad formatting rewrite included in this scoped docs change.
