### PR TITLE
fix(ci): restore GitHub-hosted runner for design token publish

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- Switch `Publish design tokens to GCS` back to `runs-on: ubuntu-latest`.
- Public `alva-ai/skills` repo is not assigned to the org Default runner group (`runner_group_id=0`), so the current self-hosted job has been stuck in `queued` since the 5/26 push.

## Test plan
- [ ] Merge PR
- [ ] Re-run the queued workflow (or push a design-tokens change) and confirm it completes in ~30s on GitHub-hosted
- [ ] Verify files appear under `gs://alva-ai-stg-ssr-cdn-bucket/design-system/`


Made with [Cursor](https://cursor.com)