### PR TITLE
ci(alva): verify design-system.css in-sync before CDN publish

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -20,6 +20,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Guard against publishing a drifted bundle. The sync workflow
+      # commits-back regen on PRs, but PRs can slip through (squash
+      # race, admin merge) and leave main stale. Fail here rather
+      # than serve drift from the CDN — fix via PR.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: skills/alva/scripts/pnpm-lock.yaml
+
+      - name: Install scripts deps
+        working-directory: skills/alva/scripts
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify design-system.css is in sync with design docs
+        working-directory: skills/alva/scripts
+        run: pnpm design-contract-sync
+
       - name: GCP Auth
         id: auth
         uses: google-github-actions/auth@v1


### PR DESCRIPTION
## Summary

The sync workflow only runs on \`pull_request\` and commits-back regen
to PR branches. Main has no auto-correction safety net, and a PR can
slip through with drift (squash race, admin merge bypassing the
sync commit, force-push after sync committed-back). \`origin/main\`
has actually been drifted since #421 and we only spotted it during
#434 — running \`pnpm build-design-system-css\` against main's
\`design.md\` produces 39104 bytes, but main ships 39496.

## Fix

Add a verify step at the top of \`publish-design-tokens.yml\`
(runs on push to main, gates CDN upload):
1. setup pnpm + node + scripts deps
2. \`pnpm design-contract-sync\` — fails on drift
3. only then upload to GCS

Net effect: a drifted main fails the publish, the CDN keeps serving
the previous correct bundle, and a human notices and fixes via PR.

## What this does *not* do

Doesn't auto-push corrections back to main:
- main is protected; \`GITHUB_TOKEN\` can't push
- bot account would work but introduces loop risk
- by the time the workflow runs, the merge has already happened —
  cleanest path is a follow-up PR

## Test plan

- [ ] Workflow YAML parses (\`actionlint\` if available)
- [ ] On a fresh PR that doesn't touch design files, this workflow
      stays untriggered (paths filter unchanged)
- [ ] Manual \`workflow_dispatch\` runs the new verify step
- [ ] Verify step fails on current main (which we know is drifted)
      until the next PR ships a regenerated bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)