### PR TITLE
docs(alva): split runtime artifacts out of the read-references index

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1067,8 +1067,6 @@ the full locate-and-edit procedure.
 | [onnx.md](references/onnx.md) | ONNX model playbooks: uploaded `.onnx` artifacts, `@alva/onnx` inference, FeedAltra patterns, output and release checks |
 | [deployment.md](references/deployment.md) | Deploying scripts as cronjobs for scheduled execution |
 | [design.md](references/design.md) | Alva Design System entry point: tokens, typography, layout; links to widget, component, and playbook specs |
-| [design-contract.yaml](references/design-contract.yaml) | Machine-readable contract consumed by the design linter that gates `alva release playbook` |
-| [css/design-system.css](references/css/design-system.css) | Canonical CSS bundle published to CDN — playbooks `<link>` it instead of inlining component/widget CSS |
 | [remix-workflow.md](references/remix-workflow.md) | Remix: create a new playbook from an existing template |
 | [annotation-edits.md](references/annotation-edits.md) | Annotation-driven edits: parse `<annotation>` tags, locate the generator behind an element, edit generation logic not rendered output |
 | [creators-note.md](references/creators-note.md) | Post-release creator's note: composing and posting the pinned author comment |
@@ -1079,6 +1077,14 @@ the full locate-and-edit procedure.
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
 | [language.md](references/language.md) | Canonical product vocabulary: automation, playbook, alert, Agent, and when feed must stay internal |
 | [udf-runtime.md](references/api/udf-runtime.md) | User-defined functions for playbooks: strict trigger rule, creator registration, browser invocation, PBSV, allowance consent, and `UdfButton` |
+
+**Runtime artifacts** (use, don't read as reference — the spec lives in the
+`.md` files above):
+
+| Artifact | Role |
+| --- | --- |
+| [css/design-system.css](references/css/design-system.css) | CDN bundle. Playbook HTML `<link>`s the canonical URL (see [design.md](references/design.md) for the tag). Built from the design `.md` sources — not a spec, do not read for rules. |
+| [design-contract.yaml](references/design-contract.yaml) | The design linter's contract. `alva release playbook` (and `alva lint playbook`) consume it and surface findings. Rules and their "why" live in the design `.md` sources. |
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -701,10 +701,11 @@ before creating or editing HTML. Do not rely on memory of prior sessions.
 </HARD-GATE>
 
 After your data pipelines are deployed and producing data, build the playbook's
-web interface. Create HTML5 pages with Alva Design System that read from Alva's
-data gateway and visualize the results. Follow the Alva Design System for
-styling, layout, and component guidelines. Unless the user explicitly asks for a
-static snapshot, default to a live playbook.
+web interface. Create HTML5 pages that read from Alva's data gateway and
+visualize the results. In `<head>`, `<link>` the Alva Design System bundle —
+canonical tag in [design.md](references/design.md); the linter's
+`required-stylesheets` rule blocks release if missing. Unless the user
+explicitly asks for a static snapshot, default to a live playbook.
 **Data fetching requirement**: Apply the
 [Content Legitimacy Rules](#content-legitimacy-rules) when building the UI.
 All quantitative data in charts, tables, or metric cards must come from feed
@@ -920,8 +921,7 @@ Required evidence:
     ./index.html` (Step 6); the full ruleset lives in
     [design-contract.yaml](references/design-contract.yaml).
     Use `--bypass-lint` for playbooks that intentionally diverge from
-    the design system (findings still printed). For new playbooks, link
-    `v1/design-system.css` per [design.md](references/design.md).
+    the design system (findings still printed).
 
 If any item fails, do not release. Fix the issue, re-run
 `alva release playbook-draft` if metadata or backing files changed, then


### PR DESCRIPTION
## Why

The references index table is framed as "Detailed sub-documents (read these for in-depth reference)". Two entries sitting in it are not specs:

- `design-contract.yaml` — machine-readable contract for the design linter (rules' "why" lives in the design `.md` sources)
- `css/design-system.css` — CDN-published runtime bundle, generated from the design `.md` sources (build output, not source)

An agent skimming the index can be drawn into either one as authoritative spec. The build artifact is the worst case: reading compiled CSS instead of `design.md` / `design-components.md` / `design-widgets.md` strips away the rationale, do/don't framing, and examples that only exist in the `.md` sources.

## What

- Remove the two non-spec rows from the read-references table.
- Add a new "**Runtime artifacts** (use, don't read as reference — the spec lives in the `.md` files above)" subsection immediately after, with one row per artifact:
  - `design-system.css`: CDN bundle; playbook HTML `<link>`s the canonical URL (template in `design.md`); built from the design `.md` sources — not a spec, do not read for rules.
  - `design-contract.yaml`: design linter's contract; `alva release playbook` / `alva lint playbook` consume it and surface findings; rules and their "why" live in the design `.md` sources.

Both artifacts stay reachable: §7 Release checklist item 11 still links them at the point of use, and §Alva Design System routes via `design.md` which lists them inbound.

## Audit

Verified per `alva-skill-standard` editing-workflow step 5 by a fresh subagent against all four principles. Clean ship-as-is verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
