### PR TITLE
fix(alva): declare @font-face so Delight actually loads in playbooks

### DIFF
--- a/.github/workflows/publish-design-tokens.yml
+++ b/.github/workflows/publish-design-tokens.yml
@@ -25,7 +25,7 @@ jobs:
       # race, admin merge) and leave main stale. Fail here rather
       # than serve drift from the CDN — fix via PR.
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.1.0
         with:
           version: 10
 

--- a/.github/workflows/sync-design-system-css.yml
+++ b/.github/workflows/sync-design-system-css.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.1.0
         with:
           version: 10
 

--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -181,6 +181,21 @@
 
 /* ════ Globals ════ */
 
+@font-face {
+  font-family: "Delight";
+  src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Delight";
+  src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -77,6 +77,29 @@ use of Semibold (600) or Bold (700) is prohibited.
 | < 24px     | Regular(400) or Medium(500) | [Delight-Regular.ttf](https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf) or [Delight-Medium.ttf](https://alva-ai-static.b-cdn.net/fonts/Delight-Medium.ttf) |
 | **≥ 24px** | **Regular(400) only**       | [Delight-Regular.ttf](https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf)                                                                                    |
 
+### Font Loading
+
+The Delight TTFs are served from the static CDN. The bundle ships
+`@font-face` declarations so a single `<link>` to `design-system.css` is
+enough — playbooks do not need to add their own `@font-face`:
+
+```css
+@font-face {
+  font-family: "Delight";
+  src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Delight";
+  src: url("https://alva-ai-static.b-cdn.net/fonts/Delight-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+```
+
 ### Anti-aliasing Standards
 
 Include these anti-aliasing declarations in generated styles (globally, or on


### PR DESCRIPTION
## Why

`design-system.css` set `font-family: "Delight"` 21+ times across body, headings, components, and widgets — but nothing in the bundle or design docs declared `@font-face`. The b-cdn.net TTFs (`Delight-Regular.ttf`, `Delight-Medium.ttf`, both serving HTTP 200) were never fetched. Every playbook silently fell back to `-apple-system` / `sans-serif`, including the `ai-silicon-comps` playbook spotted today — and presumably every production playbook that ever correctly linked the v1 bundle.

This bug had been live since `v1/design-system.css` shipped (#421). No lint rule could catch it: the design contract enforced `font-family-root-must-include: "Delight"`, but the contract has no way to assert "the font is actually loadable."

## Fix

Add `### Font Loading` to `design.md` Typography & Font with two `@font-face` declarations (Regular 400 + Medium 500), pointing at the existing CDN TTFs, with `font-display: swap`. The build script extracts the ```css block from `design.md` automatically, so all playbooks that link `v1/design-system.css` immediately start loading Delight — no per-playbook `@font-face` needed.

## Out of scope

JetBrains Mono is in the same broken state (declared in the bundle, no `@font-face`). The font file 404s at every reasonable `b-cdn.net/fonts/JetBrains*` path — needs upload before `@font-face` can point at it. Separate issue.

## Audit

Verified per `alva-skill-standard` editing-workflow step 5 by a fresh subagent against all four principles. Clean ship-as-is verdict:
- `design-system.css` now contains both `@font-face` declarations
- No SKILL.md change needed (Typography is a design.md detail)
- No design-components.md / design-widgets.md conflict
- No design-contract.yaml change (no rule asserts loadability)

## Test plan

- [x] `curl -I` on both b-cdn.net Delight URLs returns HTTP 200
- [x] `grep -c "@font-face" skills/alva/references/css/design-system.css` returns 2
- [x] `pnpm design-contract-sync` passes
- [ ] After merge & CDN publish: open any playbook linking `v1/design-system.css`, confirm Delight is the rendered face (DevTools → Computed → font-family origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
