### PR TITLE
fix(alva): set body font-family so Delight applies outside components

### DIFF
--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -197,6 +197,11 @@
 }
 
 body {
+  font-family: "Delight", -apple-system, "OPPO Sans 4.0",
+    BlinkMacSystemFont, sans-serif;
+}
+
+body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -100,6 +100,20 @@ enough — playbooks do not need to add their own `@font-face`:
 }
 ```
 
+### Global Font Family
+
+The bundle sets `font-family` on registered component classes (e.g.
+`.btn`, `.tab-item`, `.markdown-container`). Free-flowing HTML outside
+components — bare `<div>`, `<p>`, ad-hoc headings — needs an explicit
+`body` rule so the cascade carries Delight everywhere:
+
+```css
+body {
+  font-family: "Delight", -apple-system, "OPPO Sans 4.0",
+    BlinkMacSystemFont, sans-serif;
+}
+```
+
 ### Anti-aliasing Standards
 
 Include these anti-aliasing declarations in generated styles (globally, or on


### PR DESCRIPTION
## Why

#438 made Delight loadable via `@font-face`. But the bundle still had **no global `body` `font-family` rule**. `font-family: "Delight", …` was set on every registered component class (`.btn`, `.tab-item`, `.markdown-container`, …), but plain HTML outside components — bare `<div>`, `<p>`, ad-hoc headings — fell back to the browser default (typically Times/system serif). Free-flowing text in playbooks rendered in the wrong face even after the @font-face fix landed.

This was a separate bug, not a regression: a stricter inspection of `design-system.css` (looking for `^body {`) showed only anti-aliasing and overflow rules — never a `font-family`.

## Fix

Add a "### Global Font Family" subsection to `design.md` Typography & Font, between Font Loading and Anti-aliasing Standards:

```css
body {
  font-family: "Delight", -apple-system, "OPPO Sans 4.0",
    BlinkMacSystemFont, sans-serif;
}
```

The fallback chain matches the existing §General Rules line verbatim. The build script extracts the ```css block and the bundle now ships three disjoint `body` rulesets (font-family / anti-aliasing / height-overflow) which browsers coalesce — intentional, not duplication.

## Lint rule gap (separate follow-up)

Subagent auditor flagged that `design-contract.yaml`'s `font-family-root-must-include: "Delight"` rule was passing on `origin/main` **despite no body `font-family` declaration existing**. The matcher in `toolkit-ts/src/lint/contract.ts` is satisfied by ANY occurrence of `font-family: "Delight"` in the cascade — e.g. on a `.btn` — rather than requiring the root (`body` / `html` / `:root`) to carry it. The rule name overstates its check. Filed as a follow-up against toolkit-ts; not blocking this fix.

## Test plan

- [x] `grep -c "^body {" skills/alva/references/css/design-system.css` shows 3 disjoint rulesets, first one with `font-family`
- [x] `pnpm design-contract-sync` passes
- [x] Subagent audit per `alva-skill-standard` editing-workflow step 5 — ship-as-is verdict
- [ ] After merge + CDN publish + Bunny TTL (~1h) or cache-bust: confirm Delight on bare `<p>`/`<h1>` in a playbook via DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
