### PR TITLE
[codex] Hard gate playbook README refresh

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -763,7 +763,9 @@ hand-write bearer headers in playbook HTML; use the browser SDK.
    Blind spots, plus shape-specific sections for screener / thesis /
    what-if). The README is the single source of truth for the playbook's
    "How does this work?" surface — releasing without one leaves the
-   playbook unexplained.
+   playbook unexplained. For version bumps and re-releases, regenerate the
+   README from the current implementation and upload it again before release;
+   see [release.md](references/api/release.md#freshness-and-version-updates).
 3. **Create playbook draft**: `alva release playbook-draft` — creates DB
    records, writes draft files and `playbook.json` to ALFS automatically.
 
@@ -908,9 +910,11 @@ Required evidence:
 9. **README is present and accurate**: `~/playbooks/{name}/README.md` exists
    on ALFS and covers the required sections (see
    [Playbook README in release.md](references/api/release.md#playbook-readme)).
-   Its source / cadence claims match the actual feed scripts and deployed
-   cronjobs. Pass it via `--readme-url` as an absolute ALFS path (see the
-   `--readme-url` rule in Step 7 above).
+   For every release, including version bumps and re-releases, regenerate it
+   from the current HTML, feeds, metadata, and blind spots, then upload it
+   again before release. Its source / cadence claims match the actual feed
+   scripts and deployed cronjobs. Pass it via `--readme-url` as an absolute
+   ALFS path (see the `--readme-url` rule in Step 7 above).
 10. **Push feeds are released**: Every cronjob this playbook deploys with
    `push_notify: true` has a current `alva release feed --cronjob-id <that
    cronjob>` — run after the cronjob's latest source write and passing

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -50,6 +50,18 @@ HTML's "How does this work?" / methodology modal renders the same content,
 so there is one source of truth — the README — not a separate per-template
 copy.
 
+### Freshness and version updates
+
+Every `alva release playbook` call needs a freshly reviewed README for the
+version being released. Initial releases, version bumps, and re-releases all
+follow the same rule: regenerate the README from the current HTML, feed
+scripts, feed ids, cron cadences, metadata, and known blind spots, then
+upload it again to `~/playbooks/<name>/README.md` before release.
+
+Do not point `--readme-url` at a README copied from a prior version. A README
+may keep the same wording only if you have re-checked it against the current
+implementation and re-uploaded the reviewed file for this release.
+
 ### Path and `--readme-url` form
 
 The flow is: **first** write the README to ALFS at


### PR DESCRIPTION
## Summary
- Make the playbook README refresh rule explicit for every playbook release, including version bumps and re-releases.
- Add the README regeneration/re-upload requirement to the `before-playbook-release` hard gate.
- Document the canonical freshness rule in `references/api/release.md` so `SKILL.md` can stay concise and route to the detailed guidance.

## Validation
- `git diff --check`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/alva-readme-hard-gate/skills/alva`
  - Reports no orphan references.
  - Reports an existing broken-link warning for `references/design-components.md -> ./design.md#typography--font`; investigation showed the target heading exists, but the audit script treats an indented inline ```css mention in `design.md` as an opening fence and misses later headings. This PR does not touch that design doc path.
