### PR TITLE
ci(alva): design-contract-sync verifies bundle delivers root font-family

### DIFF
--- a/skills/alva/scripts/design-contract-sync.test.ts
+++ b/skills/alva/scripts/design-contract-sync.test.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { bundleDeliversRootFontFamily } from './design-contract-sync.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const CSS_PATH = path.resolve(here, '../references/css/design-system.css');
@@ -24,6 +25,72 @@ describe('design-contract-sync — CSS freshness check', () => {
         exitCode = (e as { status: number }).status;
       }
       expect(exitCode).toBe(1);
+    } finally {
+      fs.writeFileSync(CSS_PATH, original);
+    }
+  });
+});
+
+describe('bundleDeliversRootFontFamily — unit', () => {
+  it('returns true when body declares the required family', () => {
+    const css = 'body { font-family: "Delight", -apple-system, sans-serif; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(true);
+  });
+
+  it('returns true when html declares the required family', () => {
+    const css = 'html { font-family: "Delight"; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(true);
+  });
+
+  it('returns true when :root declares the required family', () => {
+    const css = ':root { font-family: "Delight", sans-serif; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(true);
+  });
+
+  it('returns false when only a component class declares it', () => {
+    const css = '.btn { font-family: "Delight", sans-serif; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(false);
+  });
+
+  it('returns false when body declares font-family without the required family', () => {
+    const css = 'body { font-family: Helvetica, Arial, sans-serif; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(false);
+  });
+
+  it('returns false when body only declares anti-aliasing (no font-family)', () => {
+    const css = 'body { -webkit-font-smoothing: antialiased; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(false);
+  });
+
+  it('match is case-insensitive', () => {
+    const css = 'BODY { font-family: "delight", sans-serif; }';
+    expect(bundleDeliversRootFontFamily(css, 'Delight')).toBe(true);
+  });
+});
+
+describe('design-contract-sync — bundle promise check', () => {
+  it('exits 1 when bundle lacks the root font-family the contract promises', () => {
+    const original = fs.readFileSync(CSS_PATH, 'utf8');
+    try {
+      // Strip the body { font-family: ... } ruleset; leave everything else.
+      const stripped = original.replace(
+        /body\s*\{\s*font-family:[^}]+\}/,
+        'body { /* stripped for test */ }',
+      );
+      // Sanity: replacement must have changed the file.
+      expect(stripped).not.toBe(original);
+      fs.writeFileSync(CSS_PATH, stripped);
+
+      let exitCode = 0;
+      let stderr = '';
+      try {
+        execSync('tsx design-contract-sync.ts', { cwd: here, encoding: 'utf8' });
+      } catch (e: unknown) {
+        exitCode = (e as { status: number }).status;
+        stderr = (e as { stderr: Buffer | string }).stderr.toString();
+      }
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain('bundle promise broken');
     } finally {
       fs.writeFileSync(CSS_PATH, original);
     }

--- a/skills/alva/scripts/design-contract-sync.ts
+++ b/skills/alva/scripts/design-contract-sync.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'node:child_process';
 import YAML from 'yaml';
+import * as csstree from 'css-tree';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REFERENCES = path.resolve(__dirname, '../references');
@@ -27,6 +28,11 @@ interface Comp {
 
 interface RawContract {
   components: Record<string, Comp>;
+  global?: {
+    typography?: {
+      'font-family-root-must-include'?: string;
+    };
+  };
 }
 
 function readContract(): RawContract {
@@ -117,25 +123,97 @@ function check(): string[] {
   return errors;
 }
 
-const errors = check();
+const ROOT_SELECTOR_RE = /^(body|html|:root|html\s*,\s*body|body\s*,\s*html)$/i;
 
-// CSS freshness check — re-run the design-system.css build and compare
-const cssCheck = spawnSync('tsx', ['build-design-system-css.ts', '--check'], {
-  cwd: __dirname,
-  stdio: 'pipe',
-  encoding: 'utf8',
-});
-if (cssCheck.status !== 0) {
-  errors.push(
-    `design-system.css drift: ${(cssCheck.stderr || '').trim() || 'build --check failed'}`
-  );
+/**
+ * Walk the bundle and look for a body/html/:root ruleset whose font-family
+ * declaration mentions the required family. The linter's `font-family-root`
+ * rule auto-passes when a playbook <link>s the canonical bundle URL on the
+ * assumption that the bundle delivers what the contract promises — this
+ * check enforces that assumption at bundle build time.
+ */
+export function bundleDeliversRootFontFamily(
+  bundle: string,
+  required: string,
+): boolean {
+  let ast: csstree.CssNode;
+  try {
+    ast = csstree.parse(bundle);
+  } catch {
+    return false;
+  }
+  if (ast.type !== 'StyleSheet') return false;
+
+  let found = false;
+  csstree.walk(ast, {
+    visit: 'Rule',
+    enter(node) {
+      if (found) return;
+      if (node.type !== 'Rule') return;
+      const sel = csstree.generate(node.prelude).trim();
+      if (!ROOT_SELECTOR_RE.test(sel)) return;
+      csstree.walk(node.block, {
+        visit: 'Declaration',
+        enter(d) {
+          if (found) return;
+          if (d.type !== 'Declaration') return;
+          if (d.property !== 'font-family') return;
+          const val = csstree.generate(d.value).toLowerCase();
+          if (val.includes(required.toLowerCase())) found = true;
+        },
+      });
+    },
+  });
+  return found;
 }
 
-if (errors.length === 0) {
-  console.log('design-contract.yaml ⇄ design docs: in sync\ndesign-system.css: in sync');
-  process.exit(0);
-} else {
-  console.error('design-contract.yaml ⇄ design docs DRIFT:');
-  for (const e of errors) console.error('  - ' + e);
-  process.exit(1);
+function checkBundlePromises(): string[] {
+  const errors: string[] = [];
+  const contract = readContract();
+  const required = contract.global?.typography?.['font-family-root-must-include'];
+  if (!required) return errors;
+
+  const bundlePath = path.join(REFERENCES, 'css/design-system.css');
+  if (!fs.existsSync(bundlePath)) return errors; // freshness check handles missing bundle
+  const bundle = fs.readFileSync(bundlePath, 'utf8');
+  if (!bundleDeliversRootFontFamily(bundle, required)) {
+    errors.push(
+      `bundle promise broken: contract requires '${required}' as root font-family ` +
+      `(font-family-root-must-include), but design-system.css has no body/html/:root rule ` +
+      `that includes it. The linter auto-passes the font-family-root rule when a playbook ` +
+      `<link>s the canonical bundle URL — that auto-pass is a lie until the bundle carries ` +
+      `the rule. Add a 'body { font-family: "${required}", ... }' block to design.md.`
+    );
+  }
+  return errors;
+}
+
+function main(): void {
+  const errors = check();
+  errors.push(...checkBundlePromises());
+
+  // CSS freshness check — re-run the design-system.css build and compare
+  const cssCheck = spawnSync('tsx', ['build-design-system-css.ts', '--check'], {
+    cwd: __dirname,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+  if (cssCheck.status !== 0) {
+    errors.push(
+      `design-system.css drift: ${(cssCheck.stderr || '').trim() || 'build --check failed'}`
+    );
+  }
+
+  if (errors.length === 0) {
+    console.log('design-contract.yaml ⇄ design docs: in sync\ndesign-system.css: in sync');
+    process.exit(0);
+  } else {
+    console.error('design-contract.yaml ⇄ design docs DRIFT:');
+    for (const e of errors) console.error('  - ' + e);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
 }


### PR DESCRIPTION
## Why

The font-family bug fixed in #439 (`body` had no `font-family` rule despite the contract requiring `Delight`) was silently live since v1 shipped (#421). The linter at `toolkit-ts/src/lint/rules/font-family-root.ts` is *correct in design* — it checks for `body|html|:root { font-family: <required> }` — but it auto-passes whenever a playbook `<link>`s the canonical bundle URL:

```ts
const canonical = contract.global.canonicalCssUrls ?? [];
if (canonical.length > 0) {
  // ... if any canonical URL is linked, return [];
}
```

The auto-pass **trusts the bundle delivers the rule**. Nothing enforced that trust. So:
- Bundle had no `body { font-family }` for months
- Every playbook linking v1 auto-passed `font-family-root`
- Real failure: bare text rendered in browser defaults
- Caught by a human noticing the wrong font, not by lint

## Fix

Move the trust into a build-time check. `pnpm design-contract-sync` now also parses the bundle and confirms a `body|html|:root` rule declares `font-family` containing the contract's `font-family-root-must-include` value. Drift fails the sync workflow on PR and the verify step on push to main; the linter's auto-pass stays valid because the bundle is enforced at build.

Selector set + case-insensitive includes-check mirror the linter's matcher 1:1 — same closed selector set, same comparison semantics. The script's top-level side-effects are wrapped in `main()` with the standard `import.meta.url` guard (matching `build-design-system-css.ts`) so `bundleDeliversRootFontFamily` can be unit-tested without firing `process.exit`.

## Tests

10 total:
- 7 unit tests for `bundleDeliversRootFontFamily` — body/html/:root positives, component-class negative, wrong-family negative, missing-font-family negative, case-insensitive positive
- 1 integration test that strips the body font-family ruleset and asserts sync exits 1 with stderr containing "bundle promise broken"
- 2 preexisting freshness tests still pass

## Why not generalize

Other contract entries could be checked the same way:
- `font-weight-allowed: [400, 500]` — bundle should not declare other weights at root
- `font-weight-restrictions` (≥24px → 400 only)
- Anti-aliasing rules

None had a months-of-silent-breakage incident. Per `alva-skill-standard` Principle 1 (earn every line), build infrastructure for one promise. Add more when one breaks.

## Test plan

- [x] `pnpm test` passes (10/10)
- [x] `pnpm design-contract-sync` passes against current main (no regression)
- [x] Subagent audit per `alva-skill-standard` editing-workflow step 5 — PASS verdict
- [ ] After merge: confirm the sync workflow runs the new check on PR
- [ ] Manual: drop the body `font-family` from `design.md`, run `pnpm design-contract-sync` locally, see it fail with "bundle promise broken"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
