### PR TITLE
contract: require requestAnimationFrame on any page using ECharts

### DIFF
--- a/skills/alva/references/design-contract.yaml
+++ b/skills/alva/references/design-contract.yaml
@@ -39,6 +39,17 @@ global:
       - "-moz-osx-font-smoothing: grayscale"
       - "text-rendering: optimizeLegibility"
 
+  # Cross-cutting script rules (not scoped to any component). Same matcher
+  # shape as a component's required-scripts.
+  required-scripts:
+    # Any page using ECharts must defer init/resize so a 0-width or
+    # display:none container at first render doesn't compress the canvas.
+    # The tab-resize requirement under components.tab covers tab-switch
+    # specifically; this covers the no-tab case.
+    - when-script-contains: ["echarts.init"]
+      must-contain: ["requestAnimationFrame"]
+      message: "Pages using ECharts must defer init/resize via requestAnimationFrame — otherwise a 0-width or display:none container at first render compresses the canvas."
+
 components:
   dropdown:
     root: "dropdown"


### PR DESCRIPTION
## Why

The current `tab.required-scripts` entry covers ECharts resize **only when a tab is present in the HTML**:

```yaml
tab:
  required-scripts:
    - when-script-contains: ['echarts.init']
      must-contain: ['[_echarts_instance_]', 'echarts.getInstanceByDom', '.resize()']
```

Playbooks with charts but no tabs slip through. In production we hit exactly that: `echarts.init` ran when its container was 0-width (or an ancestor was `display:none`), the canvas compressed to wrong dimensions, and lint never noticed because the no-tab path was unreachable from the contract.

## Fix

Add a global `required-scripts` entry — not scoped to any component, fires on `when-script-contains: ['echarts.init']` regardless of tab presence:

```yaml
global:
  required-scripts:
    - when-script-contains: ['echarts.init']
      must-contain: ['requestAnimationFrame']
      message: "Pages using ECharts must defer init/resize via requestAnimationFrame — otherwise a 0-width or display:none container at first render compresses the canvas."
```

## Paired toolkit change

toolkit-ts gains the `Contract.global.requiredScripts` field and rule processing in **alva-ai/toolkit-ts#77**. Toolkit picks this contract entry up automatically once that lands and the next CDN publish runs (live fetch).

## What this does NOT do

- Does **not** require `.resize()` — `requestAnimationFrame` around init is the most common safe pattern.
- Does **not** accept `setTimeout` or event-driven defer patterns. If real-world playbooks use those and trip false positives, extend `must-contain` to an any-of matcher in a follow-up.
- Tab-switch resize requirement under `tab` stays — it covers a different concern (resize after user interaction, not initial layout).

## Test plan

- [x] `pnpm design-contract-sync` passes (contract still in sync with docs + bundle)
- [ ] After merge + toolkit#77 merge + npm release: re-lint a no-tab ECharts playbook, confirm the new finding fires
- [ ] Walk an existing prod no-tab playbook with charts: does it already have `requestAnimationFrame`? If yes, no friction; if no, expected to surface as a new lint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
