### PR TITLE
docs(alva): include related people in playbook tags

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -788,7 +788,8 @@ hand-write bearer headers in playbook HTML; use the browser SDK.
      `before-feed-release`.
    - The draft metadata (`display_name`, description, tags, trading symbols,
      and feed list) matches the user's approved plan.
-   - `--tags` and `--trading-symbols` satisfy the overlap rule in
+   - `--tags` includes required asset overlap plus material related people
+     (investors, company figures, officials/policymakers, Twitter / X KOLs) per
      [release.md](references/api/release.md#trading-symbols-and-tags).
    - If any Skillhub skill informed this build (`/use-skill:` directive, or
      any `alva skillhub get` / `alva skillhub file` call), `--skill-id
@@ -809,8 +810,8 @@ hand-write bearer headers in playbook HTML; use the browser SDK.
    **Trading symbols and tags**: if the playbook covers specific assets,
    pass `--trading-symbols` and overlap those same entities into `--tags`
    — see [Trading symbols and tags in release.md](references/api/release.md#trading-symbols-and-tags)
-   for the casing rule, resolution behavior, and `/explore` discovery
-   semantics.
+   for the casing rule, related-person tags, resolution behavior, and
+   `/explore` discovery semantics.
 4. **Screenshot**: Take a screenshot to verify the released playbook renders
    correctly from the deployed published URL (for example,
    `https://<username>.playbook.alva.ai/<playbook_name>/v1.0.0/index.html`).

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -6,8 +6,8 @@ flags, display-name conventions, and examples. This file covers only:
 1. Feed `--description` wording rules
 2. Playbook README content shape (the big one — referenced by SKILL.md
    and the `--readme-url` flag)
-3. `--trading-symbols` and `--tags` semantics and the required overlap
-   between them
+3. `--trading-symbols` and `--tags` semantics, person-name discovery tags,
+   and the required overlap between trading symbols and tags
 4. `--skill-id` — when it is required
 
 ## Feed `--description` conventions
@@ -34,7 +34,16 @@ Bad: `"BTC EMA"`
 Omit the entities and the playbook is invisible to `/explore` searches
 for that asset — asset-routing and discovery read different fields.
 
-Example: `--trading-symbols '["BTC"]' --tags '["BTC","macro"]'`.
+**Related people.** If the playbook's thesis, screen, or catalyst logic depends
+on named people, include those names in `--tags` using the most recognizable
+public name. Cover investors, company executives / market-famous company
+figures, government-linked officials or policymakers, and Twitter / X KOLs
+whose posts or views materially affect the playbook.
+
+Examples:
+
+- `--trading-symbols '["BTC"]' --tags '["BTC","macro"]'`.
+- `--trading-symbols '["TSLA"]' --tags '["TSLA","Elon Musk","EV"]'`.
 
 ## Skill id
 


### PR DESCRIPTION
## Summary
- document that playbook discovery tags should include material related people
- cover investors, company figures, officials/policymakers, and Twitter / X KOLs in the release tagging reference
- keep SKILL.md as a compact gate/pointer to the canonical release tag policy

## Tests
- git diff --check
- bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/skill-tagging-person-names/skills/alva *(reports pre-existing broken link: references/design-components.md -> ./design.md#typography--font)*