### PR TITLE
[codex] Bump Alva skill to v1.10.0

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.9.1
+  version: v1.10.0
 ---
 
 # Alva


### PR DESCRIPTION
## What changed

- Bumped the Alva skill metadata version from `v1.9.1` to `v1.10.0`.

## Validation

- `git diff --check`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`

Note: the audit still reports the existing `design.md#typography--font` heading check issue; this PR only changes the version metadata.
