### PR TITLE
docs(alva): document `playbooks set-visibility` command

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -870,6 +870,10 @@ validation rules and the canonical content shape.
    - **Keep private** → done. Remind the user that only they can access the
      draft URL.
 
+   To change a *published* playbook's visibility later, use
+   `alva playbooks set-visibility` (run `alva playbooks --help` first;
+   private/paid require Pro).
+
 #### Free users (`subscription_tier = "free"`)
 
 1. **Publish directly**: Call `alva release playbook` — free users can create
@@ -1122,7 +1126,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 | `sdk` | Runtime libraries (50+ technical indicators, search, widgets). |
 | `data-skills` | Discover the 250+ Arrays financial-data endpoints. |
 | `skillhub` | Pull curated methodology blueprints (`/use-skill:` flow). |
-| `playbooks` | Discover public playbooks (`trending`) with compact agent-friendly refs for browsing examples and choosing remix sources. |
+| `playbooks` | Discover public playbooks (`trending`) with compact agent-friendly refs for browsing examples and choosing remix sources; flip an existing playbook's visibility with `set-visibility` (public / private / paid — private and paid are Pro-gated, a free account gets `PERMISSION_DENIED`). |
 | `comments` | Create / pin / unpin playbook comments — see [creators-note.md](references/creators-note.md) for the post-release creator's-note workflow. |
 | `push-subscriptions` | Personal push opt-in for playbooks and feeds. |
 | `channel` | Group push subscriptions (Telegram / Discord groups). |


### PR DESCRIPTION
## What

Documents the new `alva playbooks set-visibility` CLI command (see alva-ai/toolkit-ts#84) in the agent-facing Alva skill.

## Changes

- **CLI routing index** (`playbooks` row): adds `set-visibility` alongside `trending`, noting the `public`/`private`/`paid` values, the Pro gate, and the `PERMISSION_DENIED` error a free account receives.
- **Pro publish flow**: a one-line pointer that a *published* playbook's visibility can be changed later via `alva playbooks set-visibility`.

## Standard compliance

Follows the alva-skill-standard: routes to `alva playbooks --help` rather than mirroring the flag surface (Rule 0), uses the canonical `PERMISSION_DENIED` error code (consistent with `error-responses.md`), and keeps the fact in the routing index with only a short procedural pointer in the flow. Verified by a cold-read audit subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)