### PR TITLE
docs(alva): add agent feedback routing

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -201,6 +201,7 @@ that the user should verify with current sources.
 | **Backtest / Strategy** | Use Altra, run the backtest correctly, and always produce a visual playbook (equity curve, trade log, metrics) alongside the text summary. Optionally deploy as live paper trading. |
 | **Data Query** | Fetch the requested data accurately and return it directly unless the user asks for a richer artifact |
 | **Remix** | Reuse the source artifact, apply the requested changes, and return an updated result that matches the requested customization |
+| **Platform Feedback** | Help the user report Alva bugs, product gaps, or suggestions to the Alva team. Read [agent-feedback.md](references/agent-feedback.md); if no dedicated team-feedback CLI/API is available, prepare a feedback packet and say the send path is not available. |
 
 ### Choose Skill (mandatory when `/use-skill:<username>/<name>` is present)
 
@@ -220,6 +221,14 @@ The directive gives the full catalog id (`<username>/<name>`). Skills are curate
 **Push-driven requests** — if the user's primary outcome is a recurring push (digest, threshold tracker, stream watch, periodic alert), the `alva/ai-digest` skill is purpose-built for that shape and worth offering during Guided Planning. Push can also be added to any other playbook via Step 9 — the skill is one good option, not a requirement.
 
 No `/use-skill:` directive → skip this step and proceed to Guided Planning normally.
+
+### Platform Feedback
+
+When the user asks the Agent to send feedback, bugs, product gaps, or
+suggestions to the Alva team, read [agent-feedback.md](references/agent-feedback.md).
+First verify that a dedicated team-feedback CLI/API exists in `alva --help`.
+If none exists, do not use playbook comments, `notify/message`, notification
+history/preferences, or channel subscriptions as a substitute.
 
 ### Guided Planning
 
@@ -1089,6 +1098,7 @@ the full locate-and-edit procedure.
 | [search.md](references/search.md) | Content search SDKs: per-source usage, enrichment patterns, and gotchas for Twitter/X, news, Reddit, YouTube, podcasts, and web |
 | [secret-manager.md](references/secret-manager.md) | Secret upload, CRUD API, and runtime usage via `require("secret-manager")` |
 | [memory.md](references/memory.md) | Per-user memory: storage layout, `user.md` template, what to save, read/write rules |
+| [agent-feedback.md](references/agent-feedback.md) | Agent-to-Alva-team feedback: current send-surface check, safe packet shape, and fallback behavior |
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
 | [language.md](references/language.md) | Canonical product vocabulary: automation, playbook, alert, Agent, and when feed must stay internal |
 | [udf-runtime.md](references/api/udf-runtime.md) | User-defined functions for playbooks: strict trigger rule, creator registration, browser invocation, PBSV, allowance consent, and `UdfButton` |

--- a/skills/alva/references/agent-feedback.md
+++ b/skills/alva/references/agent-feedback.md
@@ -1,0 +1,76 @@
+# Agent Feedback
+
+Use this when the user asks the Alva Agent to send product feedback, bug
+reports, data coverage gaps, broken-doc reports, or feature ideas to the Alva
+team.
+
+## Current send surface
+
+Before claiming feedback can be sent, verify the current CLI surface:
+
+```bash
+alva --help
+```
+
+If the help output does not list a dedicated command for feedback, support,
+contact, or team messages, the skill has no supported team-feedback send path.
+Do not substitute nearby surfaces:
+
+- `comments` posts public or threaded playbook comments.
+- `notify/message` is feed alert content delivered to subscribed users or
+  groups.
+- `notification-history` and `notification-preferences` only inspect or manage a
+  user's own notifications.
+- `channel` manages group subscriptions.
+
+Those are not an Alva team inbox. Do not use raw HTTP endpoints, Slack, email,
+or private contact channels from inside the skill unless the user explicitly
+provides that channel and asks you to use it.
+
+## Workflow
+
+1. Classify the request. Feedback to Alva team includes platform bugs, missing
+   data coverage, confusing product behavior, broken Alva docs/skills, or
+   feature requests. It is not a creator's note, playbook comment, alert setup,
+   or group subscription.
+2. Verify the send surface with `alva --help`. If a dedicated command exists,
+   run that command's `--help` and follow it. Use the command only if the help
+   clearly says it submits feedback or support messages to Alva.
+3. If no send surface exists, prepare the feedback packet below and tell the
+   user the current CLI cannot send it to the team yet. Do not say it was sent.
+4. If a send surface exists, redact secrets and private financial details that
+   are not needed for triage. Show a compact preview and ask for confirmation
+   unless the user already gave exact content plus an explicit send request.
+5. After sending, report success only when the command succeeds. Include any
+   returned id, status, or URL. If sending fails, report the error and leave the
+   packet ready to retry.
+
+## Feedback packet
+
+Use a compact, triage-ready shape:
+
+```text
+Summary:
+Category: bug | feature_request | data_gap | docs_gap | product_confusion | other
+Impact:
+Steps to reproduce:
+Expected:
+Actual:
+Evidence:
+Environment:
+Suggested owner:
+User contact preference:
+```
+
+Keep it short. Link to relevant playbooks, feed names, CLI command output, or
+screenshots when they are material, but avoid dumping logs unless the team needs
+them. Never include API keys, JWTs, private keys, raw account tokens, or
+unrequested portfolio details.
+
+## Product implementation gap
+
+Skill documentation alone cannot create delivery. A real agent-to-team feedback
+feature needs the full user-facing chain: backend storage or routing, gateway
+REST exposure, toolkit CLI support, then this skill's send workflow. Until that
+chain exists, the skill can only verify the absence of a send path and prepare a
+packet for another channel.

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -47,7 +47,7 @@ the **design linter** that runs inside `alva release playbook`:
   components (root class, variants, sizes, states, bindings).
 - [css/design-system.css](./css/design-system.css) — the canonical CSS bundle
   (tokens + globals + components + widgets) generated from this doc's
-  ```css blocks plus design-components.md / design-widgets.md. Published
+  `css` code blocks plus design-components.md / design-widgets.md. Published
   to the CDN; new playbooks `<link>` it to get all canonical styling.
 
 The linter is shipped in the `alva` CLI and runs as a hard gate. To pre-check


### PR DESCRIPTION
## Summary
- add a Platform Feedback route in the Alva skill that points agents to a dedicated reference
- document the current send-surface check: agents must verify `alva --help` and must not use comments, notify/message, notification history/preferences, or channel subscriptions as a fake Alva team inbox
- add a compact feedback-packet fallback and note the backend -> gateway REST -> toolkit CLI -> Skill chain required for real delivery
- fix a design doc inline-code wording issue that made the skill audit misread later headings as fenced content

## Current CLI finding
`alva --help` currently lists no dedicated feedback/support/contact/team/inbox/ticket/issue command, so the skill documents that agents can prepare feedback but cannot claim it was sent through the CLI yet.

## Tests
- `git diff --cached --check`
- `npx prettier --check skills/alva/references/agent-feedback.md`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/agent-feedback-team/skills/alva`
- `alva --help | rg -i "feedback|support|contact|team|inbox|ticket|issue" || true`