### PR TITLE
docs(alva): inherit UDFs during playbook remix

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -968,8 +968,11 @@ prompt arrives as a `<remix>` tag — e.g.
 `<remix url="/u/alice/playbooks/btc-momentum" type="playbook" ...>...</remix>`
 — from which the agent extracts the source `owner` and `name` via the
 `url` attribute. The agent then reads the source playbook's feed scripts
-(strategy logic) and HTML (dashboard UI), customizes them per the user's
-request, and deploys a new playbook under their own namespace. The tag's
+(strategy logic), HTML (dashboard UI), and any registered UDF entry scripts,
+customizes them per the user's request, and deploys a new playbook under their
+own namespace. If the source playbook has registered UDFs, copy each original
+UDF method into the new playbook's ALFS tree and register it on the remixed
+playbook before release. The tag's
 inner text is a fixed instruction, not the user's customization request —
 if the user typed nothing meaningful outside the tag, ask what to
 customize before proceeding.

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -80,6 +80,14 @@ release. From `releases[0].feeds`, collect the feed refs you need to
 inspect — each entry carries both `feed_name` (for ALFS paths) and
 `feed_id` (for API calls).
 
+If the source playbook has registered UDFs, collect each function's
+`function_name`, `entry_script_path`, and `params_schema` before editing. Read
+[udf-runtime.md](api/udf-runtime.md) for the registration contract. A remix
+must preserve source UDF methods unless the user explicitly asks to remove or
+replace them: copy every source UDF entry script into the new playbook's ALFS
+tree, rewrite its path to the new playbook namespace, and later register the
+same `function_name` and `params_schema` on the remixed playbook.
+
 ---
 
 ## Step 2 — Download UI Layer (HTML Source)
@@ -112,6 +120,17 @@ alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js' > ./{
 This contains the strategy logic, data fetching, and indicator
 computations. As with the HTML, **modify the downloaded file in place**
 rather than re-typing the script from your reading of it.
+
+If Step 1 found registered UDFs, download each UDF entry script from its
+`entry_script_path` into a local file as well:
+
+```bash
+alva fs read --path '{source_entry_script_path}' > ./udf-{function_name}.js
+```
+
+Treat these as inherited source code. Edit only the path-sensitive or
+topic-specific pieces required by the remix; do not recreate the methods from
+memory.
 
 Optionally, read sample feed output to understand the data schema (this
 one stays in stdout — it's reference, not a file you'll edit):
@@ -187,12 +206,21 @@ only on explicit request). Do not write fresh files from scratch.
 6. **Edit local HTML** (the `./index.html` from Step 2 — update data
    paths to point to your own feed) and upload:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
-7. **Write README** (mandatory) — adapt the source playbook's README to
+7. **Copy inherited UDF entry scripts when present**: for each source UDF,
+   upload the edited local entry script to a path under the new playbook, for
+   example
+   `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
+8. **Write README** (mandatory) — adapt the source playbook's README to
    your data sources and methodology, then upload:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
-8. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
-9. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'` (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative shorthand is no longer accepted)
+9. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
+10. **Register inherited UDFs when present**: after the draft command returns
+   the remixed playbook ID, register each copied method on that playbook using
+   the same `function_name` and `params_schema`, with `entry_script_path`
+   pointing at the new ALFS path. Do not leave inherited `window.alva.udf` UI
+   controls pointing at an unregistered function.
+11. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'` (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative shorthand is no longer accepted)
 
 **Important**: The new playbook must use a unique name in your user space. The
 feed scripts must use **your own** ALFS paths (not the original owner's) for


### PR DESCRIPTION
# Pull Request

## Summary

<!-- What changed, why it changed, and which skill workflows or docs are affected? -->

## Affected Areas

- [ ] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [ ] Compatibility for downstream agents or users

## Type of Change

- [ ] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [ ] Relevant references, examples, and instructions were kept in sync
- [ ] Edge cases or failure paths were checked where relevant
- [ ] Prompt or workflow changes were checked for instruction conflicts
- [ ] Backward compatibility was considered

## Release and Compatibility

- [ ] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
