### PR TITLE
docs(alva): document feedback submission flow

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -251,6 +251,17 @@ financial figures, each number must either come from a fresh SDK/BYOD fetch
 (attributed inline to its source) or be explicitly qualified as an estimate
 that the user should verify with current sources.
 
+### Platform Feedback Moments
+
+If an Alva-owned problem blocks progress, do not end with only an apology or a
+generic limitation. Read [feedback.md](references/api/feedback.md) and run the
+feedback flow when repeated attempts hit the same Alva API/runtime/data/docs/auth
+or product issue, when the final outcome fails because Alva behaved unexpectedly,
+or when the user complains about Alva quality or reliability.
+
+Before closing a failed Alva-owned task, offer the feedback flow and briefly say
+the user can also report it in Alva's Discord or Telegram community channels.
+
 ## Request Routing
 
 | Request Type | Core Objectives |
@@ -1204,7 +1215,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 | `skillhub` | Pull curated methodology blueprints (`/use-skill:` flow). |
 | `playbooks` | Discover public playbooks (`trending`) with compact agent-friendly refs for browsing examples and choosing remix sources; flip an existing playbook's visibility with `set-visibility` (public / private / paid — private and paid are Pro-gated, a free account gets `PERMISSION_DENIED`). |
 | `comments` | Create / pin / unpin playbook comments — see [creators-note.md](references/creators-note.md) for the post-release creator's-note workflow. |
-| `feedback` | Submit user-confirmed Alva platform feedback. **Must read [feedback.md](references/api/feedback.md)** before submitting — user confirmation is required and evidence must be scrubbed. |
+| `feedback` | Submit user-confirmed Alva platform feedback for Alva-owned blockers, repeated failures, or user complaints. **Must read [feedback.md](references/api/feedback.md)** before submitting — user confirmation is required and evidence must be scrubbed. |
 | `subscriptions` | Subscribe to playbooks (follow + enable all push-enabled automations) and feeds (single automation alert). |
 | `channel` | Group push subscriptions (Telegram / Discord groups). |
 | `trading` | Accounts, portfolio, orders, signals, risk. **Must read [trading.md](references/api/trading.md)** before `execute`, building a signal JSON, or picking an exchange/symbol — real `--signal` schema is `allocate`/`predict` (not the `{symbol,side,qty}` shape the help example shows), `date` is epoch seconds. |

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1113,6 +1113,7 @@ the full locate-and-edit procedure.
 | [narrative-voice.md](references/narrative-voice.md) | Voice rules for user-facing prose: banned tokens/shapes, copy-paste ADK system-prompt block with few-shots |
 | [language.md](references/language.md) | Canonical product vocabulary: automation, playbook, alert, Agent, and when feed must stay internal |
 | [udf-runtime.md](references/api/udf-runtime.md) | User-defined functions for playbooks: strict trigger rule, creator registration, browser invocation, PBSV, allowance consent, and `UdfButton` |
+| [feedback.md](references/api/feedback.md) | User-confirmed Alva platform feedback: trigger, confirmation prompt, evidence/privacy rules |
 
 **Runtime artifacts** (use, don't read as reference — the spec lives in the
 `.md` files above):
@@ -1145,6 +1146,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 | `skillhub` | Pull curated methodology blueprints (`/use-skill:` flow). |
 | `playbooks` | Discover public playbooks (`trending`) with compact agent-friendly refs for browsing examples and choosing remix sources; flip an existing playbook's visibility with `set-visibility` (public / private / paid — private and paid are Pro-gated, a free account gets `PERMISSION_DENIED`). |
 | `comments` | Create / pin / unpin playbook comments — see [creators-note.md](references/creators-note.md) for the post-release creator's-note workflow. |
+| `feedback` | Submit user-confirmed Alva platform feedback. **Must read [feedback.md](references/api/feedback.md)** before submitting — user confirmation is required and evidence must be scrubbed. |
 | `push-subscriptions` | Personal push opt-in for playbooks and feeds. |
 | `channel` | Group push subscriptions (Telegram / Discord groups). |
 | `trading` | Accounts, portfolio, orders, signals, risk. **Must read [trading.md](references/api/trading.md)** before `execute`, building a signal JSON, or picking an exchange/symbol — real `--signal` schema is `allocate`/`predict` (not the `{symbol,side,qty}` shape the help example shows), `date` is epoch seconds. |

--- a/skills/alva/references/api/feedback.md
+++ b/skills/alva/references/api/feedback.md
@@ -1,0 +1,54 @@
+# Feedback — agent-discovered Alva issues
+
+Run `alva feedback --help` first. This file covers the behavior guardrails the
+CLI help cannot enforce.
+
+## Trigger
+
+Use feedback only for likely Alva platform issues: API/runtime failures,
+missing or wrong Alva data, confusing docs, auth problems, or product behavior
+that blocked the task. Do not use it for user preferences, feature ideas that
+did not block the task, or bugs in local code you wrote.
+
+## Required confirmation
+
+When you discover a likely Alva issue yourself, ask exactly:
+
+> 哇，你遇到问题了，看起来好像Alva有些不太对的地方，要不要我们直接帮你反馈给Alva？
+
+Submit only after the user clearly agrees. If they decline or ignore the prompt,
+continue the task without submitting.
+
+## Payload
+
+Keep the report small and actionable:
+
+- `summary`: one sentence naming the failure.
+- `details`: what the agent was doing, expected behavior, actual behavior, and
+  the most relevant error text.
+- `category`: `api_error`, `data_quality`, `docs`, `runtime`, `auth`,
+  `billing`, or `other`.
+- `severity`: `low`, `medium`, `high`, or `critical`.
+- `evidence`: compact JSON with command, endpoint, status code, error code,
+  correlation/request id, and sanitized snippets.
+- `context`: compact JSON with CLI version, profile/environment, session or
+  task id, and any non-secret repro notes.
+- `dedupe_key`: stable per-user key for repeated reports from the same failure
+  shape, such as `runtime/<command>/<error_code>`.
+
+Never include API keys, bearer tokens, cookies, private user data, raw
+portfolio holdings, or full proprietary source files. The server also redacts
+obvious secrets, but you must scrub before sending.
+
+## Example
+
+```bash
+alva feedback submit \
+  --summary "runtime command returned INTERNAL" \
+  --category runtime \
+  --severity high \
+  --details "While running alva run for a BTC automation, the runtime returned INTERNAL before user code started." \
+  --evidence-json '{"command":"alva run --entry-path ~/tasks/btc/src/index.js","error_code":"INTERNAL"}' \
+  --context-json '{"toolkit_version":"0.9.5","profile":"default"}' \
+  --dedupe-key "runtime/run/internal-before-user-code"
+```

--- a/skills/alva/references/api/feedback.md
+++ b/skills/alva/references/api/feedback.md
@@ -34,6 +34,5 @@ obvious secrets, but you must scrub before sending.
 
 When an Alva-owned issue caused the task to fail or stay blocked, do not close
 with only the feedback prompt. Also briefly tell the user they can report the
-issue in Alva's Discord or Telegram community channels. If you need a Discord
-link, use <https://discord.com/invite/d8FxDTvsf6>; do not invent a Telegram
-link.
+issue in Alva's Discord or Telegram community channels:
+<https://discord.com/invite/d8FxDTvsf6> or <https://t.me/alvans_bot>.

--- a/skills/alva/references/api/feedback.md
+++ b/skills/alva/references/api/feedback.md
@@ -5,10 +5,16 @@ adds the guardrails the CLI cannot enforce.
 
 ## Trigger
 
-Use feedback only for likely Alva platform issues that blocked the task, such
-as API/runtime failures, bad Alva data, docs gaps, auth problems, or confusing
-product behavior. Do not use it for user preferences, non-blocking feature
-ideas, or bugs in local code you wrote.
+Use feedback only for likely Alva platform issues that blocked or materially
+degraded the task, such as API/runtime failures, bad Alva data, docs gaps, auth
+problems, or confusing product behavior.
+
+Enter this flow when the agent repeatedly hits the same Alva-owned blocker, the
+task ends in failure because Alva did not behave as expected, or the user
+complains about Alva quality or reliability.
+
+Do not use it for user preferences, non-blocking feature ideas, or bugs in
+local code you wrote.
 
 ## Required confirmation
 
@@ -23,3 +29,11 @@ continue the task without submitting.
 Never include API keys, bearer tokens, cookies, private user data, raw
 portfolio holdings, or full proprietary source files. The server also redacts
 obvious secrets, but you must scrub before sending.
+
+## Failed-task closeout
+
+When an Alva-owned issue caused the task to fail or stay blocked, do not close
+with only the feedback prompt. Also briefly tell the user they can report the
+issue in Alva's Discord or Telegram community channels. If you need a Discord
+link, use <https://discord.com/invite/d8FxDTvsf6>; do not invent a Telegram
+link.

--- a/skills/alva/references/api/feedback.md
+++ b/skills/alva/references/api/feedback.md
@@ -1,14 +1,14 @@
 # Feedback — agent-discovered Alva issues
 
-Run `alva feedback --help` first. This file covers the behavior guardrails the
-CLI help cannot enforce.
+Run `alva feedback --help` first; it is the command contract. This file only
+adds the guardrails the CLI cannot enforce.
 
 ## Trigger
 
-Use feedback only for likely Alva platform issues: API/runtime failures,
-missing or wrong Alva data, confusing docs, auth problems, or product behavior
-that blocked the task. Do not use it for user preferences, feature ideas that
-did not block the task, or bugs in local code you wrote.
+Use feedback only for likely Alva platform issues that blocked the task, such
+as API/runtime failures, bad Alva data, docs gaps, auth problems, or confusing
+product behavior. Do not use it for user preferences, non-blocking feature
+ideas, or bugs in local code you wrote.
 
 ## Required confirmation
 
@@ -20,33 +20,6 @@ the user controls whether anything is submitted.
 Submit only after the user clearly agrees. If they decline or ignore the prompt,
 continue the task without submitting.
 
-## Payload
-
-Keep the report small and actionable:
-
-- `summary`: one sentence naming the failure.
-- `details`: what the agent was doing, expected behavior, actual behavior, and
-  the most relevant error text.
-- `category`: `api_error`, `data_quality`, `docs`, `runtime`, `auth`,
-  `billing`, or `other`.
-- `severity`: `low`, `medium`, `high`, or `critical`.
-- `evidence`: compact JSON with command, endpoint, status code, error code,
-  correlation/request id, and sanitized snippets.
-- `context`: compact JSON with CLI version, profile/environment, session or
-  task id, and any non-secret repro notes.
-
 Never include API keys, bearer tokens, cookies, private user data, raw
 portfolio holdings, or full proprietary source files. The server also redacts
 obvious secrets, but you must scrub before sending.
-
-## Example
-
-```bash
-alva feedback submit \
-  --summary "runtime command returned INTERNAL" \
-  --category runtime \
-  --severity high \
-  --details "While running alva run for a BTC automation, the runtime returned INTERNAL before user code started." \
-  --evidence-json '{"command":"alva run --entry-path ~/tasks/btc/src/index.js","error_code":"INTERNAL"}' \
-  --context-json '{"toolkit_version":"0.11.0","profile":"default"}'
-```


### PR DESCRIPTION
## Summary

Documents the agent behavior for the new Alva feedback command.

- adds `references/api/feedback.md` as a short guardrail reference, not a duplicate command manual
- adds top-level `SKILL.md` routing for feedback moments: repeated Alva-owned blockers, failed Alva-owned outcomes, and user complaints about Alva quality or reliability
- keeps confirmation in English and Alva voice instead of a fixed quoted script
- adds failed-task closeout guidance so users are also pointed to Discord / Telegram community feedback channels (`https://discord.com/invite/d8FxDTvsf6`, `https://t.me/alvans_bot`)
- removes stale dedupe guidance and keeps CLI details in `alva feedback --help`
- adds lean `SKILL.md` routing entries in the reference catalog and CLI table

## Cross-repo chain

Depends on the toolkit PR for `alva feedback submit`, which depends on the Gateway REST endpoint and merged backend feedback service.

## Validation

- `git diff --check`
- `alva-skill-standard` audit script: no broken links and no orphan references
