### PR TITLE
[jaxxjj] docs(alva): rename push-subscriptions CLI group to subscriptions

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -695,8 +695,8 @@ alva release feed --name <feed> --version 1.0.0 \
   advances fanout without sending a user-visible push. Use it for quiet
   AlvaAsk, heartbeat, and monitor runs.
 - Real delivery always requires an explicit subscription:
-  `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`,
-  `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`,
+  `alva subscriptions subscribe-feed --username <owner> --name <feed>`,
+  `alva subscriptions subscribe-playbook --username <owner> --name <playbook>`,
   or a group `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
 
 Keep schema examples in [feed-sdk.md](references/feed-sdk.md) Patterns D/E.
@@ -1060,8 +1060,8 @@ verification.
    included.
 3. **Enable the flag on the cronjob:** `alva deploy update --id <ID> --push-notify`.
 4. **Subscribe the delivery target:** for personal push use
-   `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`
-   or `alva push-subscriptions subscribe-playbook --username <owner> --name <playbook>`;
+   `alva subscriptions subscribe-feed --username <owner> --name <feed>`
+   or `alva subscriptions subscribe-playbook --username <owner> --name <playbook>`;
    for group push, run `/alva subscribe feed <id>` or
    `/alva subscribe playbook <id>` in that group.
 5. **Verify the release and a real run:** confirm `alva release feed
@@ -1145,7 +1145,7 @@ a routing index — and, for the rows in bold, the linked sub-doc is a
 | `skillhub` | Pull curated methodology blueprints (`/use-skill:` flow). |
 | `playbooks` | Discover public playbooks (`trending`) with compact agent-friendly refs for browsing examples and choosing remix sources; flip an existing playbook's visibility with `set-visibility` (public / private / paid — private and paid are Pro-gated, a free account gets `PERMISSION_DENIED`). |
 | `comments` | Create / pin / unpin playbook comments — see [creators-note.md](references/creators-note.md) for the post-release creator's-note workflow. |
-| `push-subscriptions` | Personal push opt-in for playbooks and feeds. |
+| `subscriptions` | Subscribe to playbooks (follow + enable all push-enabled automations) and feeds (single automation alert). |
 | `channel` | Group push subscriptions (Telegram / Discord groups). |
 | `trading` | Accounts, portfolio, orders, signals, risk. **Must read [trading.md](references/api/trading.md)** before `execute`, building a signal JSON, or picking an exchange/symbol — real `--signal` schema is `allocate`/`predict` (not the `{symbol,side,qty}` shape the help example shows), `date` is epoch seconds. |
 | `screenshot` | PNG capture used to verify a released playbook. |

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -231,7 +231,7 @@ require a 500-character summary.
   publisher capable of emitting alerts. They do **not** subscribe any user or
   group.
 - Real delivery requires an explicit subscription: personal
-  `alva push-subscriptions subscribe-feed` / `subscribe-playbook`, or group
+  `alva subscriptions subscribe-feed` / `subscribe-playbook`, or group
   `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
 - Use `meta.reason` to provide the push-notification body -- this is what
   recipients see when the signal is delivered.
@@ -325,7 +325,7 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal or group subscriptions.
 - Real delivery requires an explicit subscription: personal
-  `alva push-subscriptions subscribe-feed --username <owner> --name <feed>`
+  `alva subscriptions subscribe-feed --username <owner> --name <feed>`
   or `subscribe-playbook`, or group `/alva subscribe feed <feed_id>` /
   `/alva subscribe playbook <playbook_id>`.
 - Combine with Pattern D if you want both feed completion notifications and


### PR DESCRIPTION
## What

Aligns the `alva` skill with the toolkit CLI rename (`push-subscriptions` → `subscriptions`, toolkit-ts#87) and the unified subscribe semantics.

- All `alva push-subscriptions subscribe-*` examples → `alva subscriptions subscribe-*` (SKILL.md ×4, references/feed-sdk.md ×3).
- Capability table row: `subscriptions | Subscribe to playbooks (follow + enable all push-enabled automations) and feeds (single automation alert).` (was "Personal push opt-in …", which predated the cascade).

Prose-only change — no skill parses any API response, so nothing functional breaks. The group `/alva subscribe feed|playbook` slash-command references (a different surface) are untouched.

## Related
- toolkit-ts alva-ai/toolkit-ts#87 (SDK/CLI rename)
- gateway alva-ai/alva-gateway#458, backend alva-ai/alva-backend#1329, #1333.