### PR TITLE
docs(alva): document UDF caller and charge controls

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1169,7 +1169,7 @@ variables, or shell. Host-agent permissions still apply. See
 | Module          | require()                    | Description                                                             |
 | --------------- | ---------------------------- | ----------------------------------------------------------------------- |
 | alfs            | `require("alfs")`            | Filesystem (uses absolute paths `'/alva/home/<username>/...'`)            |
-| env             | `require("env")`             | `userId`, `username`, `args` from request                               |
+| env             | `require("env")`             | `userId`, `callerUserId`, `username`, `args` from request               |
 | secret-manager  | `require("secret-manager")`  | Read user-scoped third-party secrets stored in Alva Secret Manager      |
 | net/http        | `require("net/http")`        | `fetch(url, init)` for async HTTP requests                              |
 | @alva/algorithm | `require("@alva/algorithm")` | Statistics                                                              |
@@ -1694,6 +1694,13 @@ consistent read pattern (`@last`, `@range`, etc.).
 - **`require("alfs")` uses absolute paths.** Inside the V8 runtime,
   `alfs.readFile()` needs full paths like `'/alva/home/alice/...'`. Get your
   username from `require("env").username`.
+- **UDF caller identity is `require("env").callerUserId`.** `env.userId` is the
+  execution owner; `callerUserId` is the user ID of the person invoking the UDF
+  when a caller is present.
+- **UDF charging is opt-in at registration.** Register UDFs with
+  `allow_charges=false` unless they are explicitly allowed to charge credits. A
+  no-charge UDF that triggers metered credit usage during execution fails instead
+  of settling a debit; otherwise it runs as a no-charge invocation.
 - **No Node.js builtins.** `require("fs")`, `require("path")`, `require("http")`
   do not exist. Use `require("alfs")` for files, `require("net/http")` for HTTP.
 - **Altra `run()` is async.** `FeedAltra.run()` returns a `Promise<RunResult>`.

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -100,9 +100,15 @@ const entries = await alfs.readDir(home + "/data");
 ```javascript
 const env = require("env");
 env.userId; // "1" (string) -- your numeric user ID
+env.callerUserId; // "2" (string) -- invoking user's ID for UDF calls, when present
 env.username; // "alice" (string) -- your username, used in ALFS paths
 env.args; // parsed JSON from the request's "args" field
 ```
+
+For UDF executions, `env.userId` / `env.username` identify the execution owner
+whose ALFS context runs the script. `env.callerUserId` identifies the caller who
+invoked the UDF and may differ from the owner. It is absent when no caller ID is
+available.
 
 ### secret-manager -- Third-Party Secrets
 


### PR DESCRIPTION
# Pull Request

## Summary

- Documents `require(\"env\").callerUserId` as the UDF caller user ID while `env.userId` / `env.username` remain the execution owner identity.
- Adds Alva skill guidance for UDF registration `allow_charges=false`: no-charge UDFs fail if execution triggers metered credit usage instead of settling a debit.
- Keeps the main skill quick reference and jagent runtime reference in sync.

## Affected Areas

- [x] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Breaking Changes

None

## Database Migrations

None

## Merge Order

None

## Related

None

## Submission Checklist

- [ ] Validated with representative skill prompts locally
- [ ] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility

- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change

## Test Plan

- [x] `git fetch origin --prune && git rebase origin/main`
- [x] `git diff --check`
- [x] Confirmed repository has no `Makefile` or `package.json`, so no project test/lint command is available.