### PR TITLE
docs(alva): add capability help prompts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "support@alva.ai"
   },
   "metadata": {
-    "description": "Official Alva plugin for Claude Code - agentic finance applications",
+    "description": "Official Alva plugin for Claude Code - Alva Agent investing workflows",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "alva",
       "source": "./",
-      "description": "Build and deploy agentic finance applications on the Alva platform. Access 250+ financial data sources, run cloud-side analytics, backtest trading strategies, and publish interactive playbooks.",
+      "description": "Use Alva Agent for investing workflows: ask market questions with live financial context, set alerts, build or remix Playbooks, connect accounts, and backtest strategies on Alva Cloud.",
       "version": "1.0.0",
       "author": {
         "name": "Alva",
@@ -21,7 +21,7 @@
       "homepage": "https://alva.ai",
       "repository": "https://github.com/alva-ai/skills",
       "license": "MIT",
-      "keywords": ["finance", "crypto", "equities", "trading", "data", "analytics", "playbooks", "backtesting"],
+      "keywords": ["finance", "crypto", "equities", "trading", "alerts", "accounts", "analytics", "playbooks", "backtesting"],
       "category": "external-integrations",
       "tags": ["finance", "data-analytics", "trading", "agents", "playbooks"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "alva",
   "version": "1.0.0",
-  "description": "Build and deploy agentic finance applications on the Alva platform. Access 250+ financial data sources, run cloud-side analytics, backtest trading strategies, and publish interactive playbooks.",
+  "description": "Use Alva Agent for investing workflows: ask market questions with live financial context, set alerts, build or remix Playbooks, connect accounts, and backtest strategies on Alva Cloud.",
   "author": {
     "name": "Alva",
     "email": "support@alva.ai",
@@ -10,6 +10,6 @@
   "homepage": "https://alva.ai",
   "repository": "https://github.com/alva-ai/skills",
   "license": "MIT",
-  "keywords": ["finance", "crypto", "equities", "trading", "data", "analytics", "playbooks", "backtesting"],
+  "keywords": ["finance", "crypto", "equities", "trading", "alerts", "accounts", "analytics", "playbooks", "backtesting"],
   "skills": "./skills/alva/"
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Agent Skills](https://alva-ai-static.b-cdn.net/images/alva-skill-github-cover.png)
 
-> Turn your AI agent into a finance powerhouse — access 250+ financial skills, build cloud-side analytics, backtest strategies, and ship live investing playbooks.
+> Turn your AI agent into Alva Agent — research market theses with live financial context, build or remix Playbooks, set alerts, connect accounts, and backtest strategies on Alva Cloud.
 
 ## Quick Start
 
@@ -83,23 +83,24 @@ The check is silent when your skill is up to date. It runs at most once every 8 
 Start with a simple prompt:
 
 ```
-Build me an NVDA dashboard with insider trading data and financial metrics
+Explain why NVDA moved last week and what changed in semis
 ```
 
-That's it. Your agent now has full access to the Alva platform. By default, the skill builds live playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive playbooks use the current PBSV + UDF runtime.
+That's it. Your agent can now answer market questions, build or remix live Playbooks, set alerts, and work with connected accounts on Alva. By default, the skill builds live Playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive Playbooks use the current PBSV + UDF runtime.
 
 ---
 
 ## Example Prompts
 
-| Use Case         | Example Prompt                                                                            |
-| ---------------- | ----------------------------------------------------------------------------------------- |
-| Stock Dashboard  | *"Build a playbook tracking AAPL with price charts, analyst targets, and insider trades"* |
-| Crypto Monitor   | *"Create a BTC/ETH dashboard with funding rates, exchange flows, and on-chain metrics"*   |
-| Trading Strategy | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing"*                 |
-| Macro Overview   | *"Build a macro dashboard with CPI, GDP, Treasury rates, and recession probability"*      |
-| Screening Tool   | *"Screen for stocks with PE < 15, ROE > 20%, and positive insider buying"*                |
-| Interactive Tool | *"Register a playbook UDF and expose it through a Run analysis button for the selected ticker"* |
+| Use Case                    | Example Prompt                                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Ask Market Questions        | *"Explain why NVDA moved last week and what changed in semis."*                                        |
+| Set Alerts                  | *"Create a weekday 8:30am ET alert for SPY, QQQ, NVDA, MSFT, and TSLA meaningful changes."*            |
+| Build Playbooks             | *"Build a Playbook tracking AAPL with price charts, analyst targets, and insider trades."*             |
+| Discover & Remix Playbooks  | *"Find a semiconductor Playbook tracking AI infrastructure and subscribe me to its alerts."*            |
+| Backtest Strategies         | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing."*                             |
+| Connect Accounts & Trading  | *"Show my connected portfolio holdings and summarize recent activity."*                                |
+| Interactive Playbook Tools  | *"Register a Playbook UDF and expose it through a Run analysis button for the selected ticker."*        |
 
 ---
 
@@ -166,7 +167,7 @@ Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/
 
 | Skill                            | Description                                                                                                                                                                 |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[alva](skills/alva/SKILL.md)** | Full Alva platform access — data skills, cloud runtime, feeds, backtesting, and playbook deployment. See the [skill reference](skills/alva/SKILL.md) for detailed API docs. |
+| **[alva](skills/alva/SKILL.md)** | Alva Agent for investing workflows — ask market questions, set alerts, build/remix Playbooks, connect accounts, backtest strategies, and use Alva Cloud data/runtime capabilities. See the [skill reference](skills/alva/SKILL.md) for detailed instructions. |
 
 ---
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -27,29 +27,87 @@ DeFi metrics, news feeds, social media and more!
 
 ## What Alva Skills Enables
 
-The Alva skill connects any AI agent or IDE to the full Alva platform. With it
-you can:
+The Alva skill connects Alva Agent to the full Alva platform. With it you can:
 
-- **Access financial data** -- query any of Alva's 250+ data SDKs
-  programmatically, or bring your own data via HTTP API or direct upload.
-- **Run cloud-side analytics** -- write JavaScript that executes on Alva Cloud
-  in a secure runtime. No local compute, no dependencies, no infrastructure to
-  manage.
-- **Build agentic playbooks** -- create data pipelines, trading strategies, and
-  scheduled automations that run continuously on Alva Cloud.
-- **Deploy trading strategies** -- backtest with the Altra trading engine and
-  run continuous live paper trading.
-- **Release and share** -- turn your work into a hosted playbook web app at
-  `https://alva.ai/u/<username>/playbooks/<playbook_name>`, and share it with
-  the world.
-- **Discover public playbooks** -- find examples and remix candidates with the
-  agent-friendly `alva playbooks trending` command.
-- **Remix existing playbooks** -- take any published playbook as a template,
-  read its feed scripts and HTML source, customize parameters/logic/UI, and
-  deploy as your own new playbook.
+- **Ask market questions** -- research a thesis or monitor a narrative with
+  Alva's institutional-grade financial data and live market context, including
+  company fundamentals, earnings estimates, price targets, insider and senator
+  trades, macro data, ETFs, news, positioning, and sentiment.
+- **Build and remix Playbooks** -- turn a thesis, narrative, backtest idea, or
+  strategy into a live Playbook on Alva Cloud. Use SkillHub skills for Asset
+  Deepdive, Theme Tracker, Smart Screener, Backtest, Earnings, trading
+  strategies, and custom data workflows. Remix public Playbooks by inspecting
+  their data logic and UI, then customizing them for your thesis. Share
+  Playbooks by sending a hosted Playbook link to others.
+- **Discover and manage Playbooks** -- find public Playbooks by keyword or tag,
+  use them as examples or remix candidates, subscribe to useful Playbooks,
+  manage the Playbooks you build or subscribe to, and learn from a growing
+  library of community skills and Playbooks.
+- **Set alerts** -- set personal alerts, subscribe to Playbook alerts, and
+  manage alerts from one place. Examples include AI digests, threshold alerts,
+  earnings alerts, narrative trackers, and Playbook updates. Alva keeps watching
+  the market and alerts you the moment it matters.
+- **Connect accounts** -- connect portfolios or trading accounts, then read
+  balances, holdings, and activity. If trading is enabled, inspect orders,
+  strategy signals, backtest strategies with the Altra trading engine, and
+  manage live paper-trading.
 
 In short: turn your ideas into a forever-running finance agent that gets things
 done for you.
+
+### Capability Help
+
+When the user asks who Alva is, what Alva can do, how to use Alva, or asks for
+starter prompts, answer from [What Alva Skills Enables](#what-alva-skills-enables).
+
+Use this framing:
+"I'm Alva, your AI investing agent. In this chat, I can help you research a
+thesis, monitor a narrative, backtest an idea, build or remix live Playbooks,
+set alerts, connect accounts, and read balances, holdings, and activity. This
+can stay as your Alva Agent channel, so you can message me anytime to continue
+research, start a new market idea, or manage alerts and Playbooks. You can also
+invite Alva Agent to your favorite group chat and @Alva anytime."
+
+When summarizing capabilities in channel replies, use these user-facing groups:
+
+- Ask
+- Set alerts
+- Build and remix Playbooks
+- Discover and manage Playbooks
+- Connect accounts
+
+Pick 3 to 5 groups based on the user question and recent context. Because this
+is user-initiated, the reply can be longer than the binding welcome: briefly
+explain the selected groups before listing starter prompts.
+
+Default starter prompts:
+
+1. "Explain why NVDA moved last week and what changed in semis."
+2. "Create a weekday 8:30am ET alert that digests SPY, QQQ, NVDA, MSFT, and
+   TSLA, and only pushes meaningful changes here."
+3. "Find a semiconductor Playbook tracking AI infrastructure and subscribe me
+   to its alerts."
+
+Before choosing starter prompts, quickly inspect visible session history for
+explicit tickers, assets, sectors, themes, macro topics, or strategy keywords.
+If there is a stable recent interest, adapt one or two starter prompts to that
+context. If there is no clear signal, use the default prompts. Do not invent
+user preferences.
+
+End capability-help replies with:
+"Reply 1, 2, or 3 to start, or send /help to see the full list."
+
+If the user replies only "1", "2", or "3", treat it as selecting the
+corresponding starter prompt from the latest capability-help or onboarding
+message.
+
+After a starter prompt is selected, route through the existing workflow:
+market questions follow **Data Query** and [Data Sourcing](#data-sourcing);
+Playbook/SkillHub prompts follow [Choose Skill](#choose-skill-mandatory-when-use-skillusernamename-is-present)
+and [Guided Planning](#guided-planning); alert prompts follow the push guidance
+in [Request Routing](#request-routing) and [Post-release push notification flow](#9-post-release-push-notification-flow);
+connected account or trading prompts follow the `trading` row in
+[CLI Reference](#cli-reference).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Capability Help guidance to the Alva skill so user questions like "who is Alva?", "what can Alva do?", "how do I use Alva?", and starter-prompt requests get a consistent Alva Agent response.

This also updates `What Alva Skills Enables` from builder-oriented platform bullets to the user-facing Alva Agent capability groups: Ask, alerts, Playbooks, discovery/management, and connected accounts.

Follow-up alignment in this branch connects the new Capability Help flow back to the existing project docs and routes:

- selected starter prompts now route to the existing Data Query/Data Sourcing, Choose Skill/Guided Planning, post-release push notification, and trading CLI sections
- README entry copy and examples now match the same Alva Agent capability groups
- Claude plugin and marketplace descriptions now use the same user-facing capability model

## Affected Areas

- [x] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Validation

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] JSON parse check for `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- [x] `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/capability-help/skills/alva`
- [x] Judgment pass: kept Capability Help top-level because it governs immediate capability-help replies and numbered selection behavior, then added concise route links to existing canonical workflow sections instead of duplicating workflow depth.
- [x] Cross-doc phrase scan for the new Alva Agent capability language across `README.md`, `.claude-plugin`, and `skills/alva/SKILL.md`.

Note: the local subagent tool in this Codex session only allows delegation when explicitly requested by the user, so the standard's preferred subagent cold audit was not available. I ran the mechanical audit and a focused cold-pass style review instead.

## Submission Checklist

- [x] Validated with representative skill prompts locally
- [x] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility

- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change
