### PR TITLE
docs(alva): default playbook publish to public

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -886,8 +886,10 @@ hand-write bearer headers in playbook HTML; use the browser SDK.
    `/explore` discovery semantics.
 4. **Publish publicly**: After `playbook-draft` succeeds and
    `before-playbook-release` passes, call `alva release playbook` without
-   asking whether to keep it private. The default published visibility is Public.
-   Output the canonical public URL:
+   asking whether to stop at the draft version. Draft is a separate version
+   state; visibility (`public` / `private` / `paid`) applies after a playbook is
+   published. The default published visibility is Public. Output the canonical
+   public URL:
    `https://alva.ai/u/<username>/playbooks/<playbook_name>`.
 5. **Screenshot**: Take a screenshot to verify the released playbook renders
    correctly from the deployed published URL (for example,
@@ -941,8 +943,8 @@ validation rules and the canonical content shape.
 After publishing, tell Pro users they can change the published playbook's
 visibility with `alva playbooks set-visibility` (run
 `alva playbooks --help` first; private/paid require Pro), or ask next time to
-stop after `playbook-draft` before public release. If the user states a durable
-publish preference, update memory per [memory.md](references/memory.md).
+stop after creating the draft version before publishing. If the user states a
+durable publish preference, update memory per [memory.md](references/memory.md).
 
 #### Free users (`subscription_tier = "free"`)
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -884,7 +884,12 @@ hand-write bearer headers in playbook HTML; use the browser SDK.
    — see [Trading symbols and tags in release.md](references/api/release.md#trading-symbols-and-tags)
    for the casing rule, related-person tags, resolution behavior, and
    `/explore` discovery semantics.
-4. **Screenshot**: Take a screenshot to verify the released playbook renders
+4. **Publish publicly**: After `playbook-draft` succeeds and
+   `before-playbook-release` passes, call `alva release playbook` without
+   asking whether to keep it private. The default published visibility is Public.
+   Output the canonical public URL:
+   `https://alva.ai/u/<username>/playbooks/<playbook_name>`.
+5. **Screenshot**: Take a screenshot to verify the released playbook renders
    correctly from the deployed published URL (for example,
    `https://<username>.playbook.alva.ai/<playbook_name>/v1.0.0/index.html`).
    Always pass `--compress` (with `--compress-quality` / `--compress-max-width`
@@ -933,24 +938,16 @@ validation rules and the canonical content shape.
 
 #### Pro users (`subscription_tier = "pro"`)
 
-1. **Show draft link**: Output the playbook URL —
-   `https://alva.ai/u/<username>/playbooks/<playbook_name>`. The draft is
-   accessible only to the creator.
-2. **Ask**: "Your playbook is ready. Would you like to publish it publicly, or
-   keep it private for now?"
-   - **Publish** → call `alva release playbook` → output the public URL.
-   - **Keep private** → done. Remind the user that only they can access the
-     draft URL.
-
-   To change a *published* playbook's visibility later, use
-   `alva playbooks set-visibility` (run `alva playbooks --help` first;
-   private/paid require Pro).
+After publishing, tell Pro users they can change the published playbook's
+visibility with `alva playbooks set-visibility` (run
+`alva playbooks --help` first; private/paid require Pro), or ask next time to
+stop after `playbook-draft` before public release. If the user states a durable
+publish preference, update memory per [memory.md](references/memory.md).
 
 #### Free users (`subscription_tier = "free"`)
 
-1. **Publish directly**: Call `alva release playbook` — free users can create
-   and publish unlimited public playbooks. Free playbooks are always public. Output the public URL:
-   `https://alva.ai/u/<username>/playbooks/<playbook_name>`
+1. Free users can create and publish unlimited public playbooks. Free playbooks
+   are always public.
 2. **Upsell only on friction**: Do **not** proactively suggest upgrading.
    But when the user's experience is degraded because of free-tier
    limitations — wanting private or paid playbooks, hitting the cronjob cap,
@@ -1048,9 +1045,8 @@ read any playbook's files, use `alva fs read`.
 
 ### 9. Post-release push notification flow
 
-After a playbook is **released or kept as draft** (Step 7 complete), proactively
-evaluate whether any deployed feeds produce push-worthy content. Do not wait for
-the user to ask.
+After a playbook is released (Step 7 complete), proactively evaluate whether
+any deployed feeds produce push-worthy content. Do not wait for the user to ask.
 
 #### Identify push-worthy feeds
 

--- a/skills/alva/references/memory.md
+++ b/skills/alva/references/memory.md
@@ -66,7 +66,7 @@ Persistent facts about the user. Update when you learn something new.
 
 - Communication style: <!-- e.g. terse / detailed / visual -->
 - Notification channel:
-- Playbook publishing: <!-- e.g. default public release / draft-first review -->
+- Playbook publishing: <!-- e.g. default public release / draft-only before publishing -->
 ```
 
 **When to update:** User shares personal info, corrects a preference, reveals

--- a/skills/alva/references/memory.md
+++ b/skills/alva/references/memory.md
@@ -66,6 +66,7 @@ Persistent facts about the user. Update when you learn something new.
 
 - Communication style: <!-- e.g. terse / detailed / visual -->
 - Notification channel:
+- Playbook publishing: <!-- e.g. default public release / draft-first review -->
 ```
 
 **When to update:** User shares personal info, corrects a preference, reveals


### PR DESCRIPTION
# Pull Request

## Summary

Updates the Alva playbook release flow so agents default to creating the draft version and then immediately publishing it with Public visibility, instead of pausing to ask Pro users whether to stop at the draft version before publishing. Pro users are now told after publish that they can change the published playbook's visibility later or ask future runs to stop after draft creation. Draft is called out as a separate version state, not the same thing as private visibility. The memory template also has a dedicated playbook publishing preference slot.

## Affected Areas

- [x] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [ ] Local evaluation or validation flow
- [x] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Submission Checklist

- [x] Validated with representative skill prompts locally
- [x] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility

- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change

## Validation

- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`
- `git diff --check`
