### PR TITLE
chore(alva): bump version to v1.11.1

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.11.0
+  version: v1.11.1
 ---
 
 # Alva


### PR DESCRIPTION
Bump the Alva skill version in `SKILL.md` frontmatter from `v1.11.0` to `v1.11.1` ahead of cutting the `v1.11.1` release.

This is the bump commit that `rel/v1.11` and the `v1.11.1` tag will point at, capturing the docs changes merged to main since `v1.11.0` (#460, #455, #459, #456).

🤖 Generated with [Claude Code](https://claude.com/claude-code)