### PR TITLE
Tighten playbook visual data verification

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -967,6 +967,12 @@ transport details.
    head -c4 /tmp/screenshot.png | grep -q PNG || echo "SCREENSHOT_FAILED"
    ```
 
+   A PNG/page shell is not enough: pass only when the screenshot or targeted
+   capture shows real feed-backed chart marks, table rows, or KPI values; blank
+   frames, headers-only tables, loading/error fallbacks, and fetch failures are
+   data-rendering failures that must be fixed before claiming the playbook is
+   done.
+
 `alva release playbook` **requires** `--readme-url`, and it must be the
 absolute ALFS path `/alva/home/<username>/playbooks/<name>/README.md`
 (the relative `<name>/README.md` shorthand is **no longer accepted**).


### PR DESCRIPTION
## What changed

- Kept the visual-data rule in one place: the release screenshot step.
- Clarified that a PNG/page shell is not enough; the capture must show real feed-backed chart marks, table rows, or KPI values.
- Names blank frames, headers-only tables, loading/error fallbacks, and fetch failures as data-rendering failures, not screenshot-file failures.

## Why

Agents were treating screenshot file generation or a visible page framework as visual verification. Empty shells, data fetch failures, and loading/error fallbacks mean the released page did not render data.

## Validation

- `git diff --check`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/alva-skill-visual-data-hard-gate/skills/alva`
