### PR TITLE
docs(alva): clarify visibility-agnostic feed-data reads (mono-meta#545)

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -833,6 +833,17 @@ async function readAlfsJson(path) {
 </script>
 ```
 
+**Read feed data through this helper, not a raw `fetch` — it is
+visibility-agnostic.** `readAlfsJson` carries the viewer's PBSV token, so a
+published playbook reads its own feed data whether the playbook is currently
+**public or private**: the token authorizes the bound playbook's feeds
+server-side. An unauthenticated `fetch` to `…/api/v1/fs/read` only works while
+the playbook and its feeds are public and **silently breaks the moment the
+owner flips the playbook to private** — treat it as a public-only fallback,
+never the default read path. (For an anonymous viewer of a public playbook the
+same helper works token-lessly as a guest read, so one code path covers every
+case.)
+
 `$ALVA_ENDPOINT` is available to sandbox scripts and CLI verification only. Do
 not emit it into browser HTML. Published HTML must call Alva APIs through
 `AlvaToolkit.AlvaClient` so endpoint selection, auth transport, query

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -833,16 +833,9 @@ async function readAlfsJson(path) {
 </script>
 ```
 
-**Read feed data through this helper, not a raw `fetch` — it is
-visibility-agnostic.** `readAlfsJson` carries the viewer's PBSV token, so a
-published playbook reads its own feed data whether the playbook is currently
-**public or private**: the token authorizes the bound playbook's feeds
-server-side. An unauthenticated `fetch` to `…/api/v1/fs/read` only works while
-the playbook and its feeds are public and **silently breaks the moment the
-owner flips the playbook to private** — treat it as a public-only fallback,
-never the default read path. (For an anonymous viewer of a public playbook the
-same helper works token-lessly as a guest read, so one code path covers every
-case.)
+For feed reads, use `readAlfsJson`; it calls `AlvaClient.fs.read` and carries
+PBSV when available, so one code path works for public and private playbooks.
+See [feed-sdk.md](references/feed-sdk.md#from-a-web-page) for details.
 
 `$ALVA_ENDPOINT` is available to sandbox scripts and CLI verification only. Do
 not emit it into browser HTML. Published HTML must call Alva APIs through

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -38,7 +38,7 @@ query parameters to the iframe URL:
 
 | Parameter       | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |
-| `_pbsv`         | Short-lived playbook-scoped viewer JWT. Scope is fixed to read + `udf:invoke`. |
+| `_pbsv`         | Short-lived playbook-scoped viewer JWT. Scope is fixed to read + `udf:invoke`. The `read` scope authorizes reading the **bound playbook's own feed data** (e.g. `GET /api/v1/fs/read` on the playbook's feed paths, gated server-side by the playbook binding) and invoking the playbook's UDFs — it does not grant access to arbitrary file APIs or the viewer's other files. This is why `readAlfsJson` (SKILL.md §6) works for a published playbook in both public and private modes. |
 | `parent_origin` | Origin allowed to send token refresh and consent messages.                     |
 | `api_origin`    | Alva API origin for service calls.                                             |
 

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -38,7 +38,7 @@ query parameters to the iframe URL:
 
 | Parameter       | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |
-| `_pbsv`         | Short-lived playbook-scoped viewer JWT. Scope is fixed to read + `udf:invoke`. The `read` scope authorizes reading the **bound playbook's own feed data** (e.g. `GET /api/v1/fs/read` on the playbook's feed paths, gated server-side by the playbook binding) and invoking the playbook's UDFs — it does not grant access to arbitrary file APIs or the viewer's other files. This is why `readAlfsJson` (SKILL.md §6) works for a published playbook in both public and private modes. |
+| `_pbsv`         | Short-lived playbook-scoped viewer JWT. Scope is fixed to read + `udf:invoke`: `read` authorizes the **bound playbook's own feed data** (e.g. `GET /api/v1/fs/read` on the playbook's feed paths, gated server-side by the playbook binding), while `udf:invoke` authorizes that playbook's UDFs. It does not grant access to arbitrary file APIs or the viewer's other files. This is why `readAlfsJson` (SKILL.md §6) works for a published playbook in both public and private modes. |
 | `parent_origin` | Origin allowed to send token refresh and consent messages.                     |
 | `api_origin`    | Alva API origin for service calls.                                             |
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -664,6 +664,12 @@ const points = await createAlvaClient().fs.read({
 </script>
 ```
 
+Use `createAlvaClient().fs.read(...)` (the SDK), not a raw `fetch`: it carries
+the viewer's PBSV token, so the page reads its feed data whether the playbook is
+public or private. An unauthenticated `fetch` to `/api/v1/fs/read` is a
+public-only fallback that breaks when the playbook is set private. See
+SKILL.md §6.
+
 ---
 
 ## Grouped Records (Multi-Record Per Date)


### PR DESCRIPTION
## Clarify visibility-agnostic feed-data reads in the alva skill (mono-meta#545)

Doc-only. Companion to alva-backend#1375 (merged) and alva-gateway#476 — the fix that lets a Playbook-Scoped-Viewer read its playbook's feed data via `fs/read`.

### Why
A playbook's visibility (public/private) is a runtime toggle, so its HTML must read its feeds **identically in both modes**. The SDK read path (`AlvaClient.fs.read` / the `readAlfsJson` helper) is the correct mechanism: it carries the viewer's PBSV token, which authorizes the bound playbook's feeds server-side. An unauthenticated `fetch` to `/api/v1/fs/read` only works while the playbook + feeds are public and **silently breaks when the playbook is set private** — it's a public-only fallback, not the default. (This corrects an earlier suggestion, in the mono-meta#545 thread, to default to public fetch.)

### Changes
- **SKILL.md §6** — note next to `readAlfsJson` explaining the visibility-agnostic property and warning against raw public fetch as the default.
- **references/feed-sdk.md** — same note next to the web-page read example.
- **references/api/udf-runtime.md** — clarify what the pbsv `read` scope authorizes (the bound playbook's feed data via `fs/read`, gated server-side by the playbook binding; not arbitrary file APIs), reconciling the description with the now-shipping backend behavior.

No code or example-blueprint changes. The `alva/asset-deepdive` Skillhub example still uses a raw public fetch; migrating it to the SDK helper is a separate follow-up (it lives in the Skillhub catalog, not this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
