### PR TITLE
docs(alva): require HTML to follow browser request rule

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -775,7 +775,7 @@ See **Step 9** below for the post-release subscription flow.
 
 <HARD-GATE id="before-build-html">
 Before writing or rewriting playbook HTML, read the applicable design guidance
-for this session.
+and confirm the data-layer contract for this session.
 
 Required evidence:
 
@@ -788,6 +788,9 @@ Required evidence:
   for strategy/backtest playbooks.
 - If a `/use-skill:` blueprint or template is active, its layout and data
   contract have been read before HTML work starts.
+- The HTML follows the [Browser request rule](#6-build-the-playbook-web-app)
+  for Alva data requests, including when cloning a `/use-skill:` blueprint,
+  template, or existing HTML.
 
 If this evidence is missing, stop and read the required design/reference file
 before creating or editing HTML. Do not rely on memory of prior sessions.


### PR DESCRIPTION
## What

Adds a required-evidence bullet to the **`before-build-html`** HARD-GATE in `skills/alva/SKILL.md`: generated playbook HTML should **follow the Browser request rule (§6)** for Alva data requests. Calls out cloned `/use-skill:` blueprints, templates, and existing HTML so reused scaffolds do not bypass the same rule.

## Why

The Browser request rule already defines the data-layer contract. `before-build-html` is the right reminder point because it fires before HTML is written or rewritten, so the agent should follow that rule while shaping the page rather than treating it as a later audit item.

## Standard compliance

- Routes to the canonical rule in §6 rather than restating it.
- Adds a gate item, not a new gate id; no gate-chain cross-refs or module-map updates needed.
- Validated with `git diff --check` and `alva-skill-standard` mechanical audit (`audit.sh`): no broken links or orphan references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
