### PR TITLE
fix(alva): stop design sync commits from skipping ci

### DIFF
--- a/.github/workflows/sync-design-system-css.yml
+++ b/.github/workflows/sync-design-system-css.yml
@@ -58,7 +58,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add skills/alva/references/css/design-system.css
-            git commit -m "build(alva): regenerate design-system.css [skip ci]"
+            git commit -m "build(alva): regenerate design-system.css"
             if ! git push; then
               echo "::warning::Push failed — likely a race with a concurrent push. Will retry on next CI run."
               exit 0


### PR DESCRIPTION
## Summary

- remove `[skip ci]` from the auto-generated design-system.css sync commit message
- prevent squash merges from carrying the skip token into `main` and suppressing the publish workflow

## Why

PR #468 included a bot commit titled `build(alva): regenerate design-system.css [skip ci]`. When GitHub squash-merged the PR, that line was preserved in the final merge commit body, so GitHub Actions skipped the `push` workflows on `main`, including `Publish design tokens to GCS`.

## Validation

- `git diff --check`
- `rg -n "\\[skip ci\\]|ci skip|skip-checks|skip actions|actions skip|no ci" .github/workflows/sync-design-system-css.yml` returned no matches
