### PR TITLE
docs(alva): bind comparison baselines to direct-answer data provenance

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -249,7 +249,13 @@ update at each milestone so the user knows work is progressing.
 **Data provenance in direct answers.** When a direct answer cites specific
 financial figures, each number must either come from a fresh SDK/BYOD fetch
 (attributed inline to its source) or be explicitly qualified as an estimate
-that the user should verify with current sources.
+that the user should verify with current sources. This binds **comparison
+baselines** too — a historical average, peer/sector value, or macro reference a
+judgement leans on (e.g. a stock's "5-year P/E mean", a peer P/E) is itself a
+specific figure: fetch it in-session like the current value it anchors, or flag
+it as unsourced and keep the conclusion qualitative ("未实拉，仅供定性参考").
+NEVER state a baseline from training memory as fact beside fetched numbers — an
+unsourced yardstick next to sourced data reads as sourced.
 
 ### Platform Feedback Moments
 


### PR DESCRIPTION
Source: Notion Issue Tracker uid 97 (no GitHub issue)

## Problem
First-pass valuation answers stated the comparison baseline (a stock's historical P/E mean, peer P/E, macro reference) from training memory as fact, beside sourced current figures. The agent only admitted it was unfetched when the user pushed later.

## Fix
Content Legitimacy Rules -> 'Data provenance in direct answers': bind comparison baselines to the same fetch-or-flag rule as the figures they anchor. (+7 lines, one section.)

## Why this works
The old rule covered 'specific financial figures' but the agent didn't classify a comparison baseline as one. Naming the category closes the gap at the root.

## Verification (local, skill ce89ef7)
`b22cfe3` → `ce89ef7`

- Fixed: **1**  |  Regressed (good→bad): **0**
- 2/3 evals unchanged (hidden)  |  mean cost/item $1.1228 → $2.8893

| eval | from | to | Δ |
|---|---|---|---|
| `#3` | 0.50 | 1.00 | +0.50 ✅ |

> Auto-prepared by alva-skill-iterator (no CI gate). Reviewer: confirm the
> problem framing, the fix, and that the baseline went RED→green with no
> regression above, then merge.
