### PR TITLE
[jaxxjj] docs(alva): document alva run --dry-run for feed testing

### DIFF
--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -790,8 +790,11 @@ feed.def("metrics", {
 
 ### Step 2: Run the feed
 
+Iterate with `--dry-run` (runs but persists nothing) so repeated test runs
+don't append duplicate points to the published series; drop it once correct.
+
 ```bash
-alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
+alva run --entry-path '~/feeds/btc-ema/v1/src/index.js' --dry-run
 ```
 
 ### Step 3: Make it public

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -15,6 +15,10 @@ via `alva run` (inline code or filesystem entry path) or triggered by cronjobs.
   `max_heap_size_mb` in the `/api/v1/run` body / SDK
 - **No persistent state between executions**: each `alva run` call starts
   fresh (use `alfs` for persistence)
+- **Dry-run** (`--dry-run` / `dry_run: true`): runs and returns the result but
+  commits no writes. **Always test a feed producer with `--dry-run`** —
+  running it for real appends to its published series every time, so iterating
+  without it stacks near-duplicate entries (e.g. same-day briefs).
 
 If a run exceeds its heap it is killed with an explicit out-of-memory error;
 retry with a higher `max_heap_size_mb` (up to 2048 MB).


### PR DESCRIPTION
## Summary
Document the new `alva run --dry-run` (runs a script to completion but commits no writes) in the Alva skill so the agent uses it when building feeds:
- `references/jagent-runtime.md` — adds a Dry-run bullet to the Runtime Overview.
- `references/feed-sdk.md` — steers the "Run the feed" step to iterate with `--dry-run`.

## Why
A feed producer appends a data point to its **published** series every time it runs. Agents (esp. Codex) force-run a feed repeatedly while iterating, stacking near-duplicate entries (e.g. multiple same-day briefs) that the dashboard then renders. `--dry-run` lets them validate without persisting.

## Related
- alva-ai/jagent#660 (merged), alva-ai/alva-gateway#485, alva-ai/toolkit-ts#90 — the `--dry-run` implementation.

## Test Plan
- [x] Docs-only; renders as Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)