### PR TITLE
docs(alva): route UDF setup through functions CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Start with a simple prompt:
 Explain why NVDA moved last week and what changed in semis
 ```
 
-That's it. Your agent can now answer market questions, build or remix live Playbooks, set alerts, and work with connected accounts on Alva. By default, the skill builds live Playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive Playbooks use the current PBSV + UDF runtime.
+That's it. Your agent can now answer market questions, build or remix live Playbooks, set alerts, and work with connected accounts on Alva. By default, the skill builds live Playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive Playbooks register them through the functions CLI and invoke them through the PBSV + UDF runtime.
 
 ---
 
@@ -135,7 +135,7 @@ Event-driven backtesting with historical data and live paper trading. Define str
 
 ### Deploy & Share — Playbook Web Apps
 
-Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and optional UDF controls for explicitly requested user-registered functions. You can also remix published playbooks and add a creator's note after release.
+Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and optional UDF controls for explicitly requested user-registered functions registered by the functions CLI. You can also remix published playbooks and add a creator's note after release.
 
 ---
 

--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -2,11 +2,11 @@
 
 Source: `origin/main`
 
-SKILL.md lines: 1876
+SKILL.md lines: 757
 
-Cases: 16/27
+Cases: 27/28
 
-Checks: 132/196 (67.35%)
+Checks: 196/201 (97.51%)
 
 ## Scoring Diagnosis
 
@@ -15,21 +15,11 @@ Classify the gap before editing: missing capability summary, missing routing poi
 Do not expose eval scores as product copy, and do not patch demos to hide a weak result.
 Instead, fix the canonical skill text or eval case, then rerun baseline and final reports so the regression mechanism proves the gap is closed.
 
-- retained.request-routing: inspect for a skill gap before editing. Missing checks: Financial Analysis / Ask Question; Strategy / Trading Analysis
-- pr353.chat-as-artifact: inspect for a skill gap before editing. Missing checks: answer_only; Chat-as-Artifact; prompt-injected text; verdict words; EPS forecasts; YTD returns; current prices; forward-return projections
-- pr353.no-synth-verdicts: inspect for a skill gap before editing. Missing checks: Cautious; inline source attribution; not investment advice
-- pr353.no-task-list: inspect for a skill gap before editing. Missing checks: enumerated list; no verb; no question; no task description; scheduled research digest
-- pr353.no-consensus-synthesis: inspect for a skill gap before editing. Missing checks: Do not merge multiple snippet claims; agent-authored consensus; ranked list; source-labeled; synthetic takeaway; source identity is missing; ambiguous
-- target.top-level-size: inspect for a skill gap before editing. Missing checks: line count <= 850 (actual 1876)
-- target.playbook-task-offload: inspect for a skill gap before editing. Missing checks: playbook-creation.md; Playbook Creation Tree; The playbook tree has subroutes; hosted or shareable playbook surface; ordinary financial-analysis questions should answer directly
-- target.top-level-playbook-routing: inspect for a skill gap before editing. Missing checks: Playbook Creation Tree; Durable Artifacts / Playbook Tree; Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release; do not let every financial question inherit playbook gates; route through [playbook-creation.md](references/playbook-creation.md); Did playbook work read [playbook-creation.md](references/playbook-creation.md); relevant hard gates
-- target.financial-analysis-routing: inspect for a skill gap before editing. Missing checks: Shared Data And Execution Layer; Do not treat data access or `alva run` as playbook-only; A direct answer may still need Alva Cloud execution; Execution: Jagent Runtime And `alva run`; Financial Analysis / Ask Question; Financial Analysis / Ask Question Tree; It is not merely "Data Query"; data access and execution are steps inside an analysis answer; an `alva run` computation over live data; latest fact; comparison/valuation; Data Access: Data Sources; Data Access: Content Search And BYOD; comparison baselines are financial facts; peer multiple; Do not let playbook creation become the default; Do not turn every Skillhub task into a playbook
-- target.pitfalls-stepwise-required: inspect for a skill gap before editing. Missing checks: step by step; before each step; runtime, feed, ALFS, playbook HTML, deploy, release, chart, or cron work; Write or run jagent code; Touch ALFS paths; Build or edit playbook HTML/charts
-- target.mainline-updates: inspect for a skill gap before editing. Missing checks: publish publicly by default; implementation internals; Skillhub to users as a catalog of methodologies
+- retained.udf-functions-cli: inspect for a skill gap before editing. Missing checks: alva functions --help; alva functions register; alva functions invoke; alva functions allowance create; Do not hand-roll REST, GraphQL, or curl
 
 ## retained
 
-15/16 cases, 90/92 checks
+16/17 cases, 92/97 checks
 
 ### PASS retained.platform-panorama
 
@@ -52,13 +42,13 @@ Agents still run help-first preflight and session setup.
 - [x] ARRAYS_JWT
 - [x] alva fs read --path '~/memory/MEMORY.md'
 
-### FAIL retained.request-routing
+### PASS retained.request-routing
 
 Routing preserves the major user intents and Guided Planning discipline.
 
-- [ ] Financial Analysis / Ask Question
+- [x] Financial Analysis / Ask Question
 - [x] Playbook Creation
-- [ ] Strategy / Trading Analysis
+- [x] Strategy / Trading Analysis
 - [x] Remix
 - [x] /use-skill:<username>/<name>
 - [x] Exactly one blocking question
@@ -163,6 +153,16 @@ UDFs stay strict opt-in and routed to the PBSV/browser runtime reference.
 - [x] PBSV
 - [x] allowance consent
 
+### FAIL retained.udf-functions-cli
+
+Creator-side UDF setup and allowance management route through the functions CLI instead of manual service requests.
+
+- [ ] alva functions --help
+- [ ] alva functions register
+- [ ] alva functions invoke
+- [ ] alva functions allowance create
+- [ ] Do not hand-roll REST, GraphQL, or curl
+
 ### PASS retained.altra
 
 Backtesting and signal feeds still require Altra and preserve common guardrails.
@@ -205,58 +205,58 @@ Memory and secret-manager operating rules remain covered.
 
 ## pr353
 
-0/4 cases, 8/31 checks
+4/4 cases, 31/31 checks
 
-### FAIL pr353.chat-as-artifact
+### PASS pr353.chat-as-artifact
 
 The answer_only/query-mode artifact rule from alva-ai/skills#353 is present.
 
-- [ ] answer_only
-- [ ] Chat-as-Artifact
-- [ ] prompt-injected text
-- [ ] verdict words
+- [x] answer_only
+- [x] Chat-as-Artifact
+- [x] prompt-injected text
+- [x] verdict words
 - [x] price targets
-- [ ] EPS forecasts
-- [ ] YTD returns
-- [ ] current prices
-- [ ] forward-return projections
+- [x] EPS forecasts
+- [x] YTD returns
+- [x] current prices
+- [x] forward-return projections
 
-### FAIL pr353.no-synth-verdicts
+### PASS pr353.no-synth-verdicts
 
 Verdicts and forecast figures from snippets must be attributed or refused, not laundered with a disclaimer.
 
 - [x] Buy
 - [x] Sell
 - [x] Bullish
-- [ ] Cautious
+- [x] Cautious
 - [x] quote
-- [ ] inline source attribution
+- [x] inline source attribution
 - [x] refuse
-- [ ] not investment advice
+- [x] not investment advice
 
-### FAIL pr353.no-task-list
+### PASS pr353.no-task-list
 
 Pure enumerated prompt dumps are not tasks and require clarification.
 
-- [ ] enumerated list
-- [ ] no verb
-- [ ] no question
-- [ ] no task description
+- [x] enumerated list
+- [x] no verb
+- [x] no question
+- [x] no task description
 - [x] AskUserQuestion
-- [ ] scheduled research digest
+- [x] scheduled research digest
 
-### FAIL pr353.no-consensus-synthesis
+### PASS pr353.no-consensus-synthesis
 
 Snippet claims must not be merged into new agent-authored consensus, ranking, or recommendation output.
 
-- [ ] Do not merge multiple snippet claims
-- [ ] agent-authored consensus
-- [ ] ranked list
+- [x] Do not merge multiple snippet claims
+- [x] agent-authored consensus
+- [x] ranked list
 - [x] recommendation
-- [ ] source-labeled
-- [ ] synthetic takeaway
-- [ ] source identity is missing
-- [ ] ambiguous
+- [x] source-labeled
+- [x] synthetic takeaway
+- [x] source identity is missing
+- [x] ambiguous
 
 ## feedback
 
@@ -277,77 +277,77 @@ Review-discovered guardrails stay present in the skill corpus instead of only in
 
 ## target
 
-0/6 cases, 26/65 checks
+6/6 cases, 65/65 checks
 
-### FAIL target.top-level-size
+### PASS target.top-level-size
 
 Top-level SKILL.md is in the requested encyclopedia/guide size band.
 
-- [x] line count >= 650 (actual 1876)
-- [ ] line count <= 850 (actual 1876)
+- [x] line count >= 650 (actual 757)
+- [x] line count <= 850 (actual 757)
 
-### FAIL target.playbook-task-offload
+### PASS target.playbook-task-offload
 
 Playbook creation is a concrete task reference rather than the dominant top-level body.
 
-- [ ] playbook-creation.md
-- [ ] Playbook Creation Tree
-- [ ] The playbook tree has subroutes
-- [ ] hosted or shareable playbook surface
-- [ ] ordinary financial-analysis questions should answer directly
+- [x] playbook-creation.md
+- [x] Playbook Creation Tree
+- [x] The playbook tree has subroutes
+- [x] hosted or shareable playbook surface
+- [x] ordinary financial-analysis questions should answer directly
 - [x] before-playbook-release
 - [x] AlvaToolkit.AlvaClient
 - [x] Free users
 - [x] Pro users
 
-### FAIL target.top-level-playbook-routing
+### PASS target.top-level-playbook-routing
 
 Top-level routing and final checklist keep playbook work in its concrete reference without making all routing playbook-centric.
 
-- [ ] Playbook Creation Tree
-- [ ] Durable Artifacts / Playbook Tree
-- [ ] Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release
-- [ ] do not let every financial question inherit playbook gates
-- [ ] route through [playbook-creation.md](references/playbook-creation.md)
-- [ ] Did playbook work read [playbook-creation.md](references/playbook-creation.md)
-- [ ] relevant hard gates
+- [x] Playbook Creation Tree
+- [x] Durable Artifacts / Playbook Tree
+- [x] Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release
+- [x] do not let every financial question inherit playbook gates
+- [x] route through [playbook-creation.md](references/playbook-creation.md)
+- [x] Did playbook work read [playbook-creation.md](references/playbook-creation.md)
+- [x] relevant hard gates
 
-### FAIL target.financial-analysis-routing
+### PASS target.financial-analysis-routing
 
 Ask-question work is grouped as financial analysis instead of a low-level Data Query route.
 
-- [ ] Shared Data And Execution Layer
-- [ ] Do not treat data access or `alva run` as playbook-only
-- [ ] A direct answer may still need Alva Cloud execution
-- [ ] Execution: Jagent Runtime And `alva run`
-- [ ] Financial Analysis / Ask Question
-- [ ] Financial Analysis / Ask Question Tree
-- [ ] It is not merely "Data Query"
-- [ ] data access and execution are steps inside an analysis answer
-- [ ] an `alva run` computation over live data
-- [ ] latest fact
-- [ ] comparison/valuation
-- [ ] Data Access: Data Sources
-- [ ] Data Access: Content Search And BYOD
-- [ ] comparison baselines are financial facts
+- [x] Shared Data And Execution Layer
+- [x] Do not treat data access or `alva run` as playbook-only
+- [x] A direct answer may still need Alva Cloud execution
+- [x] Execution: Jagent Runtime And `alva run`
+- [x] Financial Analysis / Ask Question
+- [x] Financial Analysis / Ask Question Tree
+- [x] It is not merely "Data Query"
+- [x] data access and execution are steps inside an analysis answer
+- [x] an `alva run` computation over live data
+- [x] latest fact
+- [x] comparison/valuation
+- [x] Data Access: Data Sources
+- [x] Data Access: Content Search And BYOD
+- [x] comparison baselines are financial facts
 - [x] historical average
-- [ ] peer multiple
-- [ ] Do not let playbook creation become the default
-- [ ] Do not turn every Skillhub task into a playbook
+- [x] peer multiple
+- [x] Do not let playbook creation become the default
+- [x] Do not turn every Skillhub task into a playbook
 
-### FAIL target.pitfalls-stepwise-required
+### PASS target.pitfalls-stepwise-required
 
 Operational pitfalls are a mandatory stepwise gate, not an optional debugging appendix.
 
-- [ ] step by step
-- [ ] before each step
+- [x] step by step
+- [x] before each step
 - [x] mandatory
-- [ ] runtime, feed, ALFS, playbook HTML, deploy, release, chart, or cron work
-- [ ] Write or run jagent code
-- [ ] Touch ALFS paths
-- [ ] Build or edit playbook HTML/charts
+- [x] runtime, feed, ALFS, playbook HTML, deploy, release, chart, or cron work
+- [x] Write or run jagent code
+- [x] Touch ALFS paths
+- [x] Build or edit playbook HTML/charts
 
-### FAIL target.mainline-updates
+### PASS target.mainline-updates
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
@@ -359,10 +359,10 @@ Latest mainline Alva skill updates remain integrated after rebasing the refactor
 - [x] alva feedback --help
 - [x] subscriptions subscribe-feed
 - [x] subscriptions subscribe-playbook
-- [ ] publish publicly by default
+- [x] publish publicly by default
 - [x] registered UDFs
-- [ ] implementation internals
-- [ ] Skillhub to users as a catalog of methodologies
+- [x] implementation internals
+- [x] Skillhub to users as a catalog of methodologies
 - [x] callerUserId
 - [x] allow_charges=false
 - [x] no-charge

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -172,6 +172,19 @@
       ]
     },
     {
+      "id": "retained.udf-functions-cli",
+      "group": "retained",
+      "target": "corpus",
+      "description": "Creator-side UDF setup and allowance management route through the functions CLI instead of manual service requests.",
+      "includes": [
+        "alva functions --help",
+        "alva functions register",
+        "alva functions invoke",
+        "alva functions allowance create",
+        "Do not hand-roll REST, GraphQL, or curl"
+      ]
+    },
+    {
       "id": "retained.altra",
       "group": "retained",
       "target": "corpus",

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/shared-data-execution-layer/skills/alva`
+Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/udf-functions-cli-skill/skills/alva`
 
-SKILL.md lines: 757
+SKILL.md lines: 758
 
-Cases: 27/27
+Cases: 28/28
 
-Checks: 196/196 (100.00%)
+Checks: 201/201 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -19,7 +19,7 @@ No failed cases. Keep the eval in place as a regression mechanism.
 
 ## retained
 
-16/16 cases, 92/92 checks
+17/17 cases, 97/97 checks
 
 ### PASS retained.platform-panorama
 
@@ -153,6 +153,16 @@ UDFs stay strict opt-in and routed to the PBSV/browser runtime reference.
 - [x] PBSV
 - [x] allowance consent
 
+### PASS retained.udf-functions-cli
+
+Creator-side UDF setup and allowance management route through the functions CLI instead of manual service requests.
+
+- [x] alva functions --help
+- [x] alva functions register
+- [x] alva functions invoke
+- [x] alva functions allowance create
+- [x] Do not hand-roll REST, GraphQL, or curl
+
 ### PASS retained.altra
 
 Backtesting and signal feeds still require Altra and preserve common guardrails.
@@ -273,8 +283,8 @@ Review-discovered guardrails stay present in the skill corpus instead of only in
 
 Top-level SKILL.md is in the requested encyclopedia/guide size band.
 
-- [x] line count >= 650 (actual 757)
-- [x] line count <= 850 (actual 757)
+- [x] line count >= 650 (actual 758)
+- [x] line count <= 850 (actual 758)
 
 ### PASS target.playbook-task-offload
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -479,9 +479,9 @@ when the user asks for a registerable function or a button that calls their
 analysis function.
 
 Open [api/udf-runtime.md](references/api/udf-runtime.md). It owns PBSV browser
-authentication, creator registration, `window.alva.udf`, allowance consent,
-`UdfButton`, caller identity, `allow_charges=false` defaults, and release
-checks.
+authentication, `alva functions` creator registration and allowance tools,
+`window.alva.udf`, allowance consent, `UdfButton`, caller identity,
+`allow_charges=false` defaults, and release checks.
 
 #### Action Layer: Push Notifications
 
@@ -662,6 +662,7 @@ text does not fully cover.
 | `trading` | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md). |
 | `screenshot` | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot). |
 | `remix` | Lineage registration only. See [remix-workflow.md](references/remix-workflow.md). |
+| `functions` | Playbook UDF registration, invoke smoke tests, and allowance management. Must read [api/udf-runtime.md](references/api/udf-runtime.md). |
 | `secrets` | Secret CRUD for agent-managed setup. See [secret-manager.md](references/secret-manager.md). |
 | `feedback` | Submit user-confirmed Alva platform feedback. Must read [api/feedback.md](references/api/feedback.md). |
 
@@ -669,8 +670,8 @@ Non-CLI references:
 
 - [api/error-responses.md](references/api/error-responses.md) for programmatic
   HTTP error handling.
-- [api/udf-runtime.md](references/api/udf-runtime.md) for playbook UDF service
-  and browser calls.
+- [api/udf-runtime.md](references/api/udf-runtime.md) for PBSV browser runtime
+  behavior behind `window.alva.udf`.
 
 ## Reference Library
 
@@ -708,7 +709,7 @@ Use this index to open only the file needed for the current task.
 | [api/filesystem.md](references/api/filesystem.md) | ALFS synth suffixes and feed grant gotcha. |
 | [api/release.md](references/api/release.md) | Release extras: README, tags, trading symbols, skill id, descriptions. |
 | [api/trading.md](references/api/trading.md) | Trading signal schema, symbol naming, dry-run rules. |
-| [api/udf-runtime.md](references/api/udf-runtime.md) | Playbook UDF registration and browser invocation. |
+| [api/udf-runtime.md](references/api/udf-runtime.md) | Playbook UDF CLI setup, allowance management, and browser invocation. |
 | [api/feedback.md](references/api/feedback.md) | User-confirmed Alva platform feedback for Alva-owned blockers. |
 | [api/error-responses.md](references/api/error-responses.md) | HTTP status to error-code table. |
 

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -4,8 +4,8 @@ User-defined functions (UDFs) are functions registered by a playbook creator and
 made available for viewers to invoke from the playbook UI. A UDF flow always has
 two parts:
 
-1. **Registration**: the creator registers a named function, its entry script,
-   and its parameter schema against a playbook.
+1. **Registration**: the creator writes the entry script to ALFS, then
+   registers a named function and parameter schema with `alva functions`.
 2. **Use**: the playbook HTML lists or invokes registered functions through the
    browser SDK.
 
@@ -24,11 +24,13 @@ browser UI instead.
 
 If the trigger is met, implement both sides:
 
-- register or update the creator function with the service API
+- register or update the creator function with the `alva functions` CLI
 - load the toolkit browser SDK and invoke the function with `window.alva.udf`
 
 Do not build only the browser button without registering the function, and do
 not register a function without wiring the intended viewer-facing use.
+Do not hand-roll REST, GraphQL, or curl for function registration, invocation
+smoke tests, or allowance management when the CLI is available.
 
 ## Runtime Model
 
@@ -211,78 +213,53 @@ invocation once.
 
 Do not implement a custom credit authorization modal inside the playbook iframe.
 
-## Creator Function Registration
+## Creator Function CLI
 
-Creators register or update UDF functions through the service API:
+Creator-side UDF management is a CLI flow. Before using it in a session, run
+`alva functions --help` and treat the help output as authoritative for current
+flags, response fields, and examples.
 
-```http
-POST /api/v1/service/functions
-Content-Type: application/json
-Authorization: Bearer <creator-session-token>
+The stable flow is:
+
+```bash
+alva fs write --path '/alva/home/<username>/playbooks/<name>/udf/analyze.js' --file ./analyze.js --mkdir-parents
+alva functions register --playbook-id <playbook-id> --function-name analyze --entry-script-path '/alva/home/<username>/playbooks/<name>/udf/analyze.js' --params-schema-file ./schema.json --no-allow-charges
+alva functions invoke --playbook-id <playbook-id> --function-name analyze --params '{"ticker":"AAPL"}'
 ```
 
-```json
-{
-  "playbook_id": "<playbook-id>",
-  "function_name": "analyze",
-  "entry_script_path": "~/playbooks/my-playbook/udf/analyze.js",
-  "params_schema": {
-    "type": "object",
-    "properties": {
-      "ticker": { "type": "string" }
-    },
-    "required": ["ticker"]
-  }
-}
-```
+CLI gotchas the help text may not make obvious:
 
-Delete a function with:
+- `entry_script_path` is an absolute ALFS path under the creator's home and
+  must point at a `.js` file. Do not pass a local filesystem path or `~/...`.
+- Prefer `--params-schema-file` for nontrivial schemas so shell quoting does
+  not corrupt the JSON Schema. The schema must match both UI inputs and
+  server-side validation.
+- Registration is no-charge by default; pass `--no-allow-charges` unless the
+  user explicitly wants viewer-credit charging and the consent flow is wired.
+  Do not silently opt viewers into charges.
+- `alva functions invoke` is a creator/session smoke test. Released playbook
+  HTML still invokes through `window.alva.udf`, not through the CLI.
+- Use `alva functions list` and `alva functions delete` for maintenance; do
+  not recreate those operations with raw service requests.
 
-```http
-DELETE /api/v1/service/functions?playbook_id=<playbook-id>&function_name=<name>
-```
-
-Function entry scripts should live in creator-controlled ALFS paths and should
-validate `parameters_json` before doing expensive work.
-
-Registration is no-charge by default: keep `allow_charges=false` unless the
-user explicitly wants viewer-credit charging and the consent flow is wired. Do
-not silently opt viewers into charges.
+The service REST routes for register/list/delete/invoke are toolkit and gateway
+implementation details. Do not put raw HTTP request examples into playbook
+build instructions.
 
 ## Allowance Management
 
-Consumer allowance is managed by the Alva app. For product UI or session-user
-tools, prefer GraphQL because timestamps are normalized:
+Consumer allowance is normally managed by the Alva app through the consent
+modal. For agent-side session-user tools and smoke tests, use the functions
+CLI instead of GraphQL or raw gateway requests:
 
-```graphql
-query {
-  allowance(playbookId: "...")
-  myAllowances
-}
-
-mutation {
-  createAllowance(input: { playbookId: "...", amount: 25 }) {
-    allowance {
-      id
-      playbookId
-      amount
-      used
-      remaining
-      createdAtMs
-      updatedAtMs
-    }
-  }
-}
-
-mutation {
-  revokeAllowance(playbookId: "...") {
-    ok
-  }
-}
-```
+The CLI surface is `alva functions allowance get|list|create|revoke`; for
+example, use `alva functions allowance create --playbook-id <playbook-id>
+--amount 25` to set a cap.
 
 PBSV is explicitly rejected from allowance-management APIs. Only signed-in
-session users can create, edit, or revoke allowances.
+session users can create, edit, or revoke allowances. Viewer-facing playbook
+HTML must rely on the product consent modal and `window.alva.udf` retry path,
+not custom allowance forms inside the iframe.
 
 ## Pre-Release Checklist
 

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -91,9 +91,9 @@ Do not introduce UDFs for ordinary dashboards, scheduled refresh, filters, or
 feed-backed charts.
 
 When triggered, read [api/udf-runtime.md](api/udf-runtime.md). The reference
-covers PBSV browser authentication, creator registration, `window.alva.udf`,
-allowance consent, and release checks. Never hand-write bearer headers in
-playbook HTML.
+covers PBSV browser authentication, `alva functions` creator registration,
+`window.alva.udf`, allowance consent, and release checks. Never hand-write
+bearer headers in playbook HTML or raw service requests for UDF setup.
 
 ## README
 
@@ -165,7 +165,8 @@ Before `alva release playbook`, verify:
 3. Cronjobs for referenced feeds are active.
 4. HTML fetches quantitative data from feeds, not inline literals.
 5. If UDFs exist, [api/udf-runtime.md](api/udf-runtime.md) has been read, the
-   function is registered, and HTML uses `window.alva.udf`.
+   function is registered with `alva functions`, and HTML uses
+   `window.alva.udf`.
 6. Latest data from each referenced feed is fresh; if older than 2x cron
    interval, warn the user or fix the feed.
 7. Description and README source/frequency claims match actual scripts and

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -82,7 +82,7 @@ inspect — each entry carries both `feed_name` (for ALFS paths) and
 
 If the source playbook has registered UDFs, collect each function's
 `function_name`, `entry_script_path`, and `params_schema` before editing. Read
-[udf-runtime.md](api/udf-runtime.md) for the registration contract. A remix
+[udf-runtime.md](api/udf-runtime.md) for the `alva functions` registration flow. A remix
 must preserve source UDF methods unless the user explicitly asks to remove or
 replace them: copy every source UDF entry script into the new playbook's ALFS
 tree, rewrite its path to the new playbook namespace, and later register the
@@ -216,10 +216,11 @@ only on explicit request). Do not write fresh files from scratch.
    See [release.md → Playbook README](api/release.md#playbook-readme).
 9. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
 10. **Register inherited UDFs when present**: after the draft command returns
-   the remixed playbook ID, register each copied method on that playbook using
-   the same `function_name` and `params_schema`, with `entry_script_path`
-   pointing at the new ALFS path. Do not leave inherited `window.alva.udf` UI
-   controls pointing at an unregistered function.
+   the remixed playbook ID, use `alva functions register` for each copied
+   method with the same `function_name` and `params_schema`, with
+   `entry_script_path` pointing at the new absolute ALFS path. Do not leave
+   inherited `window.alva.udf` UI controls pointing at an unregistered
+   function.
 11. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'` (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative shorthand is no longer accepted)
 
 **Important**: The new playbook must use a unique name in your user space. The


### PR DESCRIPTION
## Summary

- Route creator-side Playbook UDF setup through `alva functions` instead of hand-written service requests.
- Replace allowance GraphQL guidance with `alva functions allowance get|list|create|revoke`.
- Keep browser runtime guidance on `window.alva.udf` and product consent, and sync README/playbook/remix references.
- Add a skill-doc regression case for the functions CLI route and refresh baseline/final reports.

## Affected Areas

- [x] Prompt instructions or agent-facing behavior
- [ ] Setup or configuration flow
- [x] Local evaluation or validation flow
- [ ] Release or rollout behavior
- [x] Compatibility for downstream agents or users

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Security fix
- [ ] Breaking change

## Validation

- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/udf-functions-cli-skill/skills/alva`
- `node evals/alva-skill-docs/skill-doc-eval.mjs --out evals/alva-skill-docs/final-report.md`
- `git diff --check`

## Submission Checklist

- [x] Validated with representative skill prompts locally
- [x] Expected behavior and observed behavior were compared
- [x] Relevant references, examples, and instructions were kept in sync
- [x] Edge cases or failure paths were checked where relevant
- [x] Prompt or workflow changes were checked for instruction conflicts
- [x] Backward compatibility was considered

## Release and Compatibility

- [x] No release impact
- [ ] Requires dev release
- [ ] Requires version bump
- [ ] Introduces a breaking change