### PR TITLE
[yimingchen] docs(alva): document slack as an IM channel (identity + push)

### DIFF
--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -54,9 +54,10 @@ Capture these session variables:
 
 - `username`: public URLs and ALFS paths.
 - `subscription_tier`: `pro` or `free`; controls private/paid playbook flow.
-- `active_channel`: `telegram`, `discord`, or null; web notifications always
-  work, external delivery depends on this field.
-- `telegram_username` / `discord_username`: external IM display fields.
+- `active_channel`: `telegram`, `discord`, `slack`, or null; web notifications
+  always work, external delivery depends on this field.
+- `telegram_username` / `discord_username` / `slack_username`: external IM
+  display fields.
 
 All write, deploy, draft, release, and visibility operations must target the
 requesting user from `alva whoami`. Do not write to or release under another

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -18,11 +18,11 @@ on material changes and emit `<|SKIP_NOTIFICATION|>` otherwise.
 ## Delivery Channel
 
 Web notifications are always available. External DM delivery depends on
-`active_channel` plus a matching `telegram_username` or `discord_username`
-from `alva whoami`.
+`active_channel` plus a matching `telegram_username`, `discord_username`, or
+`slack_username` from `alva whoami`.
 
 If no active IM channel exists, say web notifications will work immediately and
-the user can connect Telegram or Discord at <https://alva.ai/settings>.
+the user can connect Telegram, Discord, or Slack at <https://alva.ai/settings>.
 
 ## Configure And Verify
 


### PR DESCRIPTION
Closes the SKILL.md side of the Slack identity gap (alongside backend prefill/bind + toolkit-ts type work).

`active_channel` can now be `slack` and `alva whoami` returns `slack_username`, but the agent docs only listed telegram/discord — so the agent treated Slack as an unknown/invalid channel.

- `references/preflight.md`: add `slack` to `active_channel` values + `slack_username` to the IM display fields.
- `references/push-notifications.md`: add Slack to the delivery-channel + connect copy.

Docs-only.