### PR TITLE
[codex] Document release automation flow

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -400,6 +400,25 @@
       ]
     },
     {
+      "id": "target.automation-publish",
+      "group": "target",
+      "target": "corpus",
+      "description": "Deploy cronjob and release feed are treated as one automation publish operation without erasing lifecycle boundaries.",
+      "includes": [
+        "automation publish",
+        "deploy-plus-release block",
+        "CRONJOB_ID=$(alva deploy create",
+        "immediately run",
+        "alva release feed ... --cronjob-id <id>",
+        "Do not treat `alva deploy create` as a finished live feed",
+        "orphan producer",
+        "released feed body",
+        "each still has its own lifecycle row",
+        "Playbook release is the separate UI publication step",
+        "Without it, the push is still dispatched but arrives with an empty body"
+      ]
+    },
+    {
       "id": "target.pitfalls-stepwise-required",
       "group": "target",
       "target": "corpus",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -122,8 +122,7 @@
         "Feed SDK",
         "alva run --entry-path",
         "special:user:*",
-        "alva deploy create",
-        "alva release feed",
+        "alva release automation",
         "before-feed-release"
       ]
     },
@@ -403,13 +402,11 @@
       "id": "target.automation-publish",
       "group": "target",
       "target": "corpus",
-      "description": "Deploy cronjob and release feed are treated as one automation publish operation without erasing lifecycle boundaries.",
+      "description": "Cronjob creation and feed release are exposed as one automation publish operation without erasing lifecycle boundaries.",
       "includes": [
         "automation publish",
-        "deploy-plus-release block",
-        "CRONJOB_ID=$(alva deploy create",
-        "immediately run",
-        "alva release feed ... --cronjob-id <id>",
+        "alva release automation",
+        "creates the backing cronjob and registers the released",
         "Do not treat `alva deploy create` as a finished live feed",
         "orphan producer",
         "released feed body",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -122,8 +122,8 @@
         "Feed SDK",
         "alva run --entry-path",
         "special:user:*",
-        "alva release automation",
-        "before-feed-release"
+        "alva automation publish",
+        "before-automation-publish"
       ]
     },
     {
@@ -402,14 +402,14 @@
       "id": "target.automation-publish",
       "group": "target",
       "target": "corpus",
-      "description": "Cronjob creation and feed release are exposed as one automation publish operation without erasing lifecycle boundaries.",
+      "description": "Cronjob creation and feed release are hidden behind the automation publish operation without erasing lifecycle boundaries.",
       "includes": [
         "automation publish",
-        "alva release automation",
-        "creates the backing cronjob and registers the released",
-        "Do not treat `alva deploy create` as a finished live feed",
+        "alva automation publish",
+        "creates the backing scheduler and registers the automation output",
+        "Do not treat `alva deploy create` as a finished live automation",
         "orphan producer",
-        "released feed body",
+        "published automation output",
         "each still has its own lifecycle row",
         "Playbook release is the separate UI publication step",
         "Without it, the push is still dispatched but arrives with an empty body"

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -374,15 +374,15 @@ digest, signal, reusable dataset, or future answer.
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
 short lifecycle is: write schema and logic, upload source, `alva run`, grant
-public read if needed, then publish the automation in one block: deploy the
-producer and immediately release the feed with that cronjob id.
+public read if needed, then publish the automation with
+`alva automation publish`.
 
-Before feed release, satisfy `before-feed-release`: fresh run, expected shape,
-needed grants, public read verification, and non-empty data for HTML
-dependencies. Feed scripts fail fast on missing data; the detailed release and
-grant contract lives in the feed references. Read the matching
+Before automation publish, satisfy `before-automation-publish`: fresh run,
+expected shape, needed grants, public read verification, and non-empty data for
+HTML dependencies. Feed scripts fail fast on missing data; the detailed release
+and grant contract lives in the feed references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before
-each feed, ALFS, deploy, and release step.
+each feed, ALFS, automation publish, and release step.
 
 #### Publication Layer: Playbook Creation Tree
 
@@ -634,8 +634,8 @@ generator behind the selected element rather than the rendered DOM.
 ### Push Monitor
 
 For a recurring alert, design the feed output first: signal target or message,
-quiet-run sentinel, cadence, and subscriber. Release the feed after adding the
-sidecar, then verify a real run. A cronjob with `--push-notify` and no
+quiet-run sentinel, cadence, and subscriber. Publish the automation after
+adding the sidecar, then verify a real run. Push enablement without an explicit
 subscription is not a completed push setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
@@ -693,7 +693,7 @@ Use this index to open only the file needed for the current task.
 | [request-routing.md](references/request-routing.md) | Route choice, Skillhub, Guided Planning, capability verification, completion gate. |
 | [content-legitimacy.md](references/content-legitimacy.md) | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions. |
 | [data-skills.md](references/data-skills.md) | Data Skills discovery, endpoint calls, Arrays auth, search/data routing. |
-| [feed-lifecycle.md](references/feed-lifecycle.md) | Feed build/release lifecycle, modeling summary, push sidecars, `before-feed-release`. |
+| [feed-lifecycle.md](references/feed-lifecycle.md) | Feed data-layer lifecycle for automations, modeling summary, push sidecars, `before-automation-publish`. |
 | [playbook-creation.md](references/playbook-creation.md) | HTML build, browser-safe reads, README, draft, release, screenshot, tier flow. |
 | [push-notifications.md](references/push-notifications.md) | Push-worthy feeds, sidecars, subscriptions, delivery verification. |
 | [operational-pitfalls.md](references/operational-pitfalls.md) | Runtime, ALFS, chart, watermark, and resource pitfalls. |
@@ -756,7 +756,7 @@ Before finishing an Alva task, ask:
 - Did Financial Analysis / Ask Question pass the ask evidence gate before I answered?
 - Did I avoid WebSearch/LLM/memory/user-pasted data as factual values?
 - Did I run Data Skills `list` -> `summary` -> `endpoint` before coding calls?
-- Did feed release pass `before-feed-release`?
+- Did automation publish pass `before-automation-publish`?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)
   and pass the relevant hard gates?
 - Did design work read [design.md](references/design.md) and lint where needed?

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -374,7 +374,8 @@ digest, signal, reusable dataset, or future answer.
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
 short lifecycle is: write schema and logic, upload source, `alva run`, grant
-public read if needed, deploy, then `alva release feed`.
+public read if needed, then publish the automation in one block: deploy the
+producer and immediately release the feed with that cronjob id.
 
 Before feed release, satisfy `before-feed-release`: fresh run, expected shape,
 needed grants, public read verification, and non-empty data for HTML

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -761,10 +761,10 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 ```
 
 `signal/targets` makes the feed push-capable, but delivery still requires the
-cronjob to be created or updated with `--push-notify` and the feed release to be
+automation to be published or updated with `--push-notify` and a feed release
 bound to that cronjob. Actual delivery also requires an explicit personal or
 group subscription to the feed or to a playbook that references it. See
-`references/deployment.md` for the deploy/release flow.
+`references/deployment.md` for the automation publish flow.
 
 ---
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -3,12 +3,14 @@
 Publish automations by binding the scheduled producer to the released feed in
 one build step. This is essential for feeds that need regular updates (e.g.
 hourly price data), recurring tasks, push alerts, live playbook data, and clean
-retirement when an automation is replaced.
+retirement when an automation is replaced. Use `automation` as the normal
+product term; use feed/cronjob terms only for SDK code, diagnostics, or repair.
 
-The three lifecycle CLI groups:
+The lifecycle CLI groups:
 
 | Group           | Manages                              | Common commands                  |
 | --------------- | ------------------------------------ | -------------------------------- |
+| `alva automation` | User-facing automation publish      | `publish`                       |
 | `alva deploy`   | Cronjobs (schedule + entry script)   | `create`, `list`, `update`, `delete`, `runs` |
 | `alva feed`     | Released feed records + active majors | `list`, `delete`                |
 | `alva playbook` | Published playbook records           | `list`, `delete`                 |
@@ -21,30 +23,29 @@ For any live feed, push alert, or playbook dependency, publish the producer and
 released feed in one command:
 
 ```bash
-alva release automation \
+alva automation publish \
   --name btc-ema \
   --version 1.0.0 \
-  --cronjob-name btc-ema-update \
+  --producer-name btc-ema-update \
   --path '~/feeds/btc-ema/v1/src/index.js' \
-  --cron "0 */4 * * *" \
+  --schedule "0 */4 * * *" \
   --push-notify \
   --description "Refreshes BTC EMA data every four hours from the feed script and publishes the latest values for playbooks and alerts"
 ```
 
-`alva release automation` creates the backing cronjob and registers the released
-feed/feed major in one backend flow. Do not treat `alva deploy create` as a
-finished live feed. A standalone cronjob row only starts scheduled execution;
-the released feed body and active major are what readers, playbooks, and push
-fanout consume. Prefer the one-command publish path for new builds because it
-avoids orphan producers, removes extra list/get discovery, and keeps builds
-faster.
+`alva automation publish` creates the backing scheduler and registers the
+automation output in one backend flow. Do not treat `alva deploy create` as a
+finished live automation. A standalone scheduler only starts execution; the
+published automation output is what readers, playbooks, and push fanout
+consume. Prefer the one-command publish path for new builds because it avoids
+orphan producers, removes extra list/get discovery, and keeps builds faster.
 
 The full automation workflow:
 
 1. **Write** a script (feed or task) and upload it to the filesystem.
 2. **Test** it manually via `alva run`.
 3. **Grant** public read if playbooks or public readers need it.
-4. **Publish** the automation with `alva release automation`.
+4. **Publish** the automation with `alva automation publish`.
 5. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run).
 6. **Monitor** status via `alva deploy list` / `alva deploy get`.
 7. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`.
@@ -84,7 +85,7 @@ any group. For `notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text`
 skips the user-visible push while advancing fanout.
 
 The CLI validates that the entry path exists on the filesystem before creating
-the cronjob. For new feed-backed automations, use `alva release automation`
+the cronjob. For new feed-backed automations, use `alva automation publish`
 instead of standalone create so the feed release is bound immediately.
 
 **Response**:
@@ -204,14 +205,14 @@ on flags.
 - `alva deploy` — the **cronjob** (schedule + entry script + args). Lives
   in the `cronjobs` table.
 - `alva feed` — the **released feed record + active majors** (the row
-  written by `alva release automation` or manual `alva release feed`,
+  written by `alva automation publish` or manual `alva release feed`,
   consumed by the push-fanout path).
   Lives in `feeds` / `feed_majors`.
 - `alva playbook` — the **published playbook** (rendered HTML +
   display_name + visibility + ACL). Lives in `playbooks` and is
   surfaced at `https://alva.ai/u/<username>/playbooks/<name>`.
 
-`alva release automation` creates and binds the deploy/feed rows in one publish
+`alva automation publish` creates and binds the deploy/feed rows in one publish
 operation for build speed, but each still has its own lifecycle row. Playbook
 release is the separate UI publication step after the backing automation is
 published.
@@ -355,12 +356,12 @@ alva fs grant --path '~/feeds/btc-hourly/v1' --subject "special:user:*" --permis
 ### 4. Publish the automation
 
 ```bash
-alva release automation \
+alva automation publish \
   --name btc-hourly \
   --version 1.0.0 \
-  --cronjob-name btc-hourly-price-feed \
+  --producer-name btc-hourly-price-feed \
   --path '~/feeds/btc-hourly/v1/src/index.js' \
-  --cron "0 */4 * * *" \
+  --schedule "0 */4 * * *" \
   --description "Refreshes hourly BTC OHLCV data every four hours from crypto market data"
 ```
 
@@ -384,8 +385,8 @@ alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@las
   timestamp with `ctx.kv.put()`/`ctx.kv.load()` to avoid re-fetching all
   historical data on each run.
 - **Test thoroughly before publishing**: Run the script manually via
-  `alva run` and verify the output before `alva release automation`.
-- **Use descriptive names**: The cronjob name helps you identify jobs when
+  `alva run` and verify the output before `alva automation publish`.
+- **Use descriptive names**: The producer name helps you identify jobs when
   listing them.
 - **Pause before updating**: If you need to update the script, pause the cronjob
   first, update the script file, test it, then resume.

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -17,36 +17,34 @@ The three lifecycle CLI groups:
 
 ## Automation Publish
 
-For any live feed, push alert, or playbook dependency, deploy the producer and
-release the feed as one automation publish block:
+For any live feed, push alert, or playbook dependency, publish the producer and
+released feed in one command:
 
 ```bash
-CRONJOB_ID=$(alva deploy create \
-  --name btc-ema-update \
+alva release automation \
+  --name btc-ema \
+  --version 1.0.0 \
+  --cronjob-name btc-ema-update \
   --path '~/feeds/btc-ema/v1/src/index.js' \
   --cron "0 */4 * * *" \
   --push-notify \
-  | jq -r '.id')
-
-alva release feed \
-  --name btc-ema \
-  --version 1.0.0 \
-  --cronjob-id "$CRONJOB_ID" \
   --description "Refreshes BTC EMA data every four hours from the feed script and publishes the latest values for playbooks and alerts"
 ```
 
-Do not treat `alva deploy create` as a finished live feed. The cronjob row
-starts scheduled execution; `alva release feed` registers the released feed body
-and active major that readers, playbooks, and push fanout consume. Keeping them
-adjacent avoids an orphan producer, removes extra list/get discovery, and keeps
-builds faster.
+`alva release automation` creates the backing cronjob and registers the released
+feed/feed major in one backend flow. Do not treat `alva deploy create` as a
+finished live feed. A standalone cronjob row only starts scheduled execution;
+the released feed body and active major are what readers, playbooks, and push
+fanout consume. Prefer the one-command publish path for new builds because it
+avoids orphan producers, removes extra list/get discovery, and keeps builds
+faster.
 
 The full automation workflow:
 
 1. **Write** a script (feed or task) and upload it to the filesystem.
 2. **Test** it manually via `alva run`.
 3. **Grant** public read if playbooks or public readers need it.
-4. **Publish** the automation with the deploy-plus-release block above.
+4. **Publish** the automation with `alva release automation`.
 5. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run).
 6. **Monitor** status via `alva deploy list` / `alva deploy get`.
 7. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`.
@@ -79,14 +77,15 @@ When `--push-notify` is set, every successful cronjob execution checks the
 feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
 canonical `feed_alert_ready` event with different feed-alert sources. The push
 body is read from the *released* feed: a cronjob with `--push-notify` but no
-`alva release feed` dispatches an empty body. Delivery also requires an
+released feed binding dispatches an empty body. Delivery also requires an
 explicit personal or group subscription to the feed or to a playbook that
 references the feed; `--push-notify` does not subscribe the owner, any user, or
 any group. For `notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text`
 skips the user-visible push while advancing fanout.
 
 The CLI validates that the entry path exists on the filesystem before creating
-the cronjob.
+the cronjob. For new feed-backed automations, use `alva release automation`
+instead of standalone create so the feed release is bound immediately.
 
 **Response**:
 
@@ -205,15 +204,17 @@ on flags.
 - `alva deploy` — the **cronjob** (schedule + entry script + args). Lives
   in the `cronjobs` table.
 - `alva feed` — the **released feed record + active majors** (the row
-  written by `alva release feed`, consumed by the push-fanout path).
+  written by `alva release automation` or manual `alva release feed`,
+  consumed by the push-fanout path).
   Lives in `feeds` / `feed_majors`.
 - `alva playbook` — the **published playbook** (rendered HTML +
   display_name + visibility + ACL). Lives in `playbooks` and is
   surfaced at `https://alva.ai/u/<username>/playbooks/<name>`.
 
-Deploy and feed release should move together as one automation publish block
-for build speed, but each still has its own lifecycle row. Playbook release is
-the separate UI publication step after the backing automation is published.
+`alva release automation` creates and binds the deploy/feed rows in one publish
+operation for build speed, but each still has its own lifecycle row. Playbook
+release is the separate UI publication step after the backing automation is
+published.
 Deleting one row does **not** automatically delete the others — see the cascade
 notes in each `--help`.
 
@@ -354,16 +355,12 @@ alva fs grant --path '~/feeds/btc-hourly/v1' --subject "special:user:*" --permis
 ### 4. Publish the automation
 
 ```bash
-CRONJOB_ID=$(alva deploy create \
-  --name btc-hourly-price-feed \
-  --path '~/feeds/btc-hourly/v1/src/index.js' \
-  --cron "0 */4 * * *" \
-  | jq -r '.id')
-
-alva release feed \
+alva release automation \
   --name btc-hourly \
   --version 1.0.0 \
-  --cronjob-id "$CRONJOB_ID" \
+  --cronjob-name btc-hourly-price-feed \
+  --path '~/feeds/btc-hourly/v1/src/index.js' \
+  --cron "0 */4 * * *" \
   --description "Refreshes hourly BTC OHLCV data every four hours from crypto market data"
 ```
 
@@ -387,7 +384,7 @@ alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@las
   timestamp with `ctx.kv.put()`/`ctx.kv.load()` to avoid re-fetching all
   historical data on each run.
 - **Test thoroughly before publishing**: Run the script manually via
-  `alva run` and verify the output before the deploy-plus-release block.
+  `alva run` and verify the output before `alva release automation`.
 - **Use descriptive names**: The cronjob name helps you identify jobs when
   listing them.
 - **Pause before updating**: If you need to update the script, pause the cronjob

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -1,9 +1,9 @@
 # Deployment Guide
 
-Deploy scripts as cronjobs for scheduled, automated execution and manage the
-downstream feed / playbook resources they produce. This is essential for feeds
-that need regular updates (e.g. hourly price data), recurring tasks, and for
-cleaning up when a deployment is retired or replaced.
+Publish automations by binding the scheduled producer to the released feed in
+one build step. This is essential for feeds that need regular updates (e.g.
+hourly price data), recurring tasks, push alerts, live playbook data, and clean
+retirement when an automation is replaced.
 
 The three lifecycle CLI groups:
 
@@ -15,16 +15,41 @@ The three lifecycle CLI groups:
 
 ---
 
-## Overview
+## Automation Publish
 
-The deployment workflow:
+For any live feed, push alert, or playbook dependency, deploy the producer and
+release the feed as one automation publish block:
 
-1. **Write** a script (feed or task) and upload it to the filesystem
-2. **Test** it manually via `alva run`
-3. **Deploy** it as a cronjob via `alva deploy create`
-4. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run)
-5. **Monitor** the cronjob status via `alva deploy list` / `alva deploy get`
-6. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`
+```bash
+CRONJOB_ID=$(alva deploy create \
+  --name btc-ema-update \
+  --path '~/feeds/btc-ema/v1/src/index.js' \
+  --cron "0 */4 * * *" \
+  --push-notify \
+  | jq -r '.id')
+
+alva release feed \
+  --name btc-ema \
+  --version 1.0.0 \
+  --cronjob-id "$CRONJOB_ID" \
+  --description "Refreshes BTC EMA data every four hours from the feed script and publishes the latest values for playbooks and alerts"
+```
+
+Do not treat `alva deploy create` as a finished live feed. The cronjob row
+starts scheduled execution; `alva release feed` registers the released feed body
+and active major that readers, playbooks, and push fanout consume. Keeping them
+adjacent avoids an orphan producer, removes extra list/get discovery, and keeps
+builds faster.
+
+The full automation workflow:
+
+1. **Write** a script (feed or task) and upload it to the filesystem.
+2. **Test** it manually via `alva run`.
+3. **Grant** public read if playbooks or public readers need it.
+4. **Publish** the automation with the deploy-plus-release block above.
+5. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run).
+6. **Monitor** status via `alva deploy list` / `alva deploy get`.
+7. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`.
 
 Cronjobs execute the script through the same jagent runtime as `alva run`.
 The script receives the same environment (`require("env").args` contains the
@@ -168,7 +193,7 @@ alva deploy run-logs --id 42 --run-id 123
 
 ---
 
-## Feed / Playbook lifecycle — extras not in CLI help
+## Feed / Playbook Lifecycle
 
 Run `alva feed --help` and `alva playbook --help` for subcommands,
 flags, and response shapes. This section only covers the conceptual
@@ -186,10 +211,11 @@ on flags.
   display_name + visibility + ACL). Lives in `playbooks` and is
   surfaced at `https://alva.ai/u/<username>/playbooks/<name>`.
 
-These three move in lockstep at create time (`alva deploy create` →
-`alva release feed` → `alva release playbook`) but each has its own
-lifecycle row. Deleting one does **not** automatically delete the
-others — see the cascade notes in each `--help`.
+Deploy and feed release should move together as one automation publish block
+for build speed, but each still has its own lifecycle row. Playbook release is
+the separate UI publication step after the backing automation is published.
+Deleting one row does **not** automatically delete the others — see the cascade
+notes in each `--help`.
 
 **Don't use `alva fs remove` to delete a feed or playbook.** It clears
 the ALFS files (the rendered HTML, the data mount), but the
@@ -325,13 +351,23 @@ alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 alva fs grant --path '~/feeds/btc-hourly/v1' --subject "special:user:*" --permission read
 ```
 
-### 4. Deploy as a cronjob
+### 4. Publish the automation
 
 ```bash
-alva deploy create --name btc-hourly-price-feed --path '~/feeds/btc-hourly/v1/src/index.js' --cron "0 */4 * * *"
+CRONJOB_ID=$(alva deploy create \
+  --name btc-hourly-price-feed \
+  --path '~/feeds/btc-hourly/v1/src/index.js' \
+  --cron "0 */4 * * *" \
+  | jq -r '.id')
+
+alva release feed \
+  --name btc-hourly \
+  --version 1.0.0 \
+  --cronjob-id "$CRONJOB_ID" \
+  --description "Refreshes hourly BTC OHLCV data every four hours from crypto market data"
 ```
 
-### 5. Verify the cronjob
+### 5. Verify the automation
 
 ```bash
 alva deploy list
@@ -350,8 +386,8 @@ alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@las
 - **Use `ctx.kv` for incremental processing**: Track the last processed
   timestamp with `ctx.kv.put()`/`ctx.kv.load()` to avoid re-fetching all
   historical data on each run.
-- **Test thoroughly before deploying**: Run the script manually via
-  `alva run` and verify the output before creating a cronjob.
+- **Test thoroughly before publishing**: Run the script manually via
+  `alva run` and verify the output before the deploy-plus-release block.
 - **Use descriptive names**: The cronjob name helps you identify jobs when
   listing them.
 - **Pause before updating**: If you need to update the script, pause the cronjob

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -3,8 +3,8 @@
 Feeds are persistent data pipelines. Use them whenever data needs freshness,
 history, public reads, charts, playbook backing, push sidecars, or release.
 
-For API detail and examples, read [feed-sdk.md](feed-sdk.md). For scheduled
-jobs, read [deployment.md](deployment.md). For runtime constraints, read
+For API detail and examples, read [feed-sdk.md](feed-sdk.md). For automation
+publish, read [deployment.md](deployment.md). For runtime constraints, read
 [jagent-runtime.md](jagent-runtime.md).
 
 ## Lifecycle
@@ -17,8 +17,15 @@ Every feed follows the same path:
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
 4. Grant the feed root for public reads when a playbook or public user needs it:
    `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
-5. Deploy the script with `alva deploy create`.
-6. Release the feed with `alva release feed` using the cronjob id from deploy.
+5. Publish the automation in one CLI block: `alva deploy create`, capture the
+   returned cronjob id, then immediately run
+   `alva release feed ... --cronjob-id <id>`.
+
+Treat deploy and feed release as one automation publish operation. Do not stop
+after deploy, run an extra discovery loop, or leave an unreleased producer when
+the intent is a live feed, push alert, or playbook dependency. The CLI currently
+uses two commands, but the agent workflow is one block because the released feed
+body and the scheduler must be bound for downstream reads and push fanout.
 
 `alva run` is a test step. It does not replace deploy or release and does not
 guarantee public `@last` data for a playbook.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -1,7 +1,9 @@
 # Feed Lifecycle
 
-Feeds are persistent data pipelines. Use them whenever data needs freshness,
-history, public reads, charts, playbook backing, push sidecars, or release.
+Feeds are the data layer for automations and playbooks. Use the Feed SDK when
+data needs freshness, history, public reads, charts, playbook backing, push
+sidecars, or release; call the user-facing product an automation unless you
+are discussing SDK code, paths, or diagnostics.
 
 For API detail and examples, read [feed-sdk.md](feed-sdk.md). For automation
 publish, read [deployment.md](deployment.md). For runtime constraints, read
@@ -9,7 +11,7 @@ publish, read [deployment.md](deployment.md). For runtime constraints, read
 
 ## Lifecycle
 
-Every feed follows the same path:
+Every automation-backed feed follows the same path:
 
 1. Write schema and incremental logic with `feed.def()` and
    `ctx.self.ts().append()`.
@@ -17,15 +19,15 @@ Every feed follows the same path:
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
 4. Grant the feed root for public reads when a playbook or public user needs it:
    `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
-5. Publish the automation with `alva release automation`.
+5. Publish the automation with `alva automation publish`.
 
 Treat scheduler creation and feed release as one automation publish operation.
 Do not stop after deploy, run an extra discovery loop, or leave an unreleased
 producer when the intent is a live feed, push alert, or playbook dependency.
-The released feed body and scheduler must be bound for downstream reads and
-push fanout.
+The published automation output and scheduler must be bound for downstream
+reads and push fanout.
 
-`alva run` is a test step. It does not replace deploy or release and does not
+`alva run` is a test step. It does not replace automation publish and does not
 guarantee public `@last` data for a playbook.
 
 ## Modeling
@@ -61,10 +63,10 @@ if (!equityRecords.length) {
 If a run fails with out-of-memory, retry with a larger `--max-heap-size-mb`
 (up to 2048) before editing logic.
 
-## HARD-GATE: before-feed-release
+## HARD-GATE: before-automation-publish
 
-<HARD-GATE id="before-feed-release">
-Before `alva release automation`, verify:
+<HARD-GATE id="before-automation-publish">
+Before `alva automation publish`, verify:
 
 1. The exact feed script ran successfully in this session after the latest
    source write.
@@ -92,7 +94,7 @@ Push-capable feeds write one of these streams:
 Both dispatch `feed_alert_ready`. Do not use legacy names such as
 `playbook_data_ready` or `feed_run_complete` in new docs.
 
-`--push-notify` marks the cronjob publisher as capable of emitting alerts. It
+`--push-notify` marks the automation publisher as capable of emitting alerts. It
 does not subscribe any user or group and does not bypass notification
 preferences. For `notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
 without sending a visible push.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -17,15 +17,13 @@ Every feed follows the same path:
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
 4. Grant the feed root for public reads when a playbook or public user needs it:
    `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
-5. Publish the automation in one CLI block: `alva deploy create`, capture the
-   returned cronjob id, then immediately run
-   `alva release feed ... --cronjob-id <id>`.
+5. Publish the automation with `alva release automation`.
 
-Treat deploy and feed release as one automation publish operation. Do not stop
-after deploy, run an extra discovery loop, or leave an unreleased producer when
-the intent is a live feed, push alert, or playbook dependency. The CLI currently
-uses two commands, but the agent workflow is one block because the released feed
-body and the scheduler must be bound for downstream reads and push fanout.
+Treat scheduler creation and feed release as one automation publish operation.
+Do not stop after deploy, run an extra discovery loop, or leave an unreleased
+producer when the intent is a live feed, push alert, or playbook dependency.
+The released feed body and scheduler must be bound for downstream reads and
+push fanout.
 
 `alva run` is a test step. It does not replace deploy or release and does not
 guarantee public `@last` data for a playbook.
@@ -66,7 +64,7 @@ If a run fails with out-of-memory, retry with a larger `--max-heap-size-mb`
 ## HARD-GATE: before-feed-release
 
 <HARD-GATE id="before-feed-release">
-Before `alva release feed`, verify:
+Before `alva release automation`, verify:
 
 1. The exact feed script ran successfully in this session after the latest
    source write.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -292,18 +292,16 @@ If there is no material update worth notifying about, output only
 })();
 ```
 
-Deploy requires **two steps** — cronjob + feed registration:
+Publish the automation as one deploy-plus-release block:
 
 ```bash
-# 1. Create the cronjob with push notification enabled
-alva deploy create --name daily-briefing \
+CRONJOB_ID=$(alva deploy create --name daily-briefing \
   --path '~/feeds/daily-briefing/v1/src/index.js' \
-  --cron "0 8 * * *" --push-notify
+  --cron "0 8 * * *" --push-notify \
+  | jq -r '.id')
 
-# 2. Register the feed (REQUIRED for push content to work)
-# Without this, notifications arrive without title/text content.
 alva release feed --name daily-briefing --version 1.0.0 \
-  --cronjob-id <ID_FROM_STEP_1> \
+  --cronjob-id "$CRONJOB_ID" \
   --description "Generates a morning briefing each day at 08:00 summarizing overnight crypto market moves and pushes it as a notification"
 ```
 
@@ -321,8 +319,8 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - If `body`/`text` contains `<|SKIP_NOTIFICATION|>`, fanout state advances but
   no user-visible notification is sent. Teach AlvaAsk to output this sentinel
   when there is no material update.
-- **`alva release feed` is required** — without it, the push is still
-  dispatched but arrives with an empty body (no `title`/`body`).
+- The release command is part of the publish block. Without it, the push is
+  still dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal or group subscriptions.
 - Real delivery requires an explicit subscription: personal
@@ -807,10 +805,20 @@ alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permissio
 alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100'
 ```
 
-### Step 5: Deploy as a cronjob (required for live playbooks)
+### Step 5: Publish the automation (required for live playbooks)
 
 ```bash
-alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
+CRONJOB_ID=$(alva deploy create \
+  --name btc-ema-update \
+  --path '~/feeds/btc-ema/v1/src/index.js' \
+  --cron "0 */4 * * *" \
+  | jq -r '.id')
+
+alva release feed \
+  --name btc-ema \
+  --version 1.0.0 \
+  --cronjob-id "$CRONJOB_ID" \
+  --description "Refreshes BTC EMA metrics every four hours"
 ```
 
 ---

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -227,9 +227,8 @@ require a 500-character summary.
 
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
-- `--push-notify` and `alva release feed --cronjob-id ...` only make the feed
-  publisher capable of emitting alerts. They do **not** subscribe any user or
-  group.
+- `--push-notify` on `alva release automation` only makes the feed publisher
+  capable of emitting alerts. It does **not** subscribe any user or group.
 - Real delivery requires an explicit subscription: personal
   `alva subscriptions subscribe-feed` / `subscribe-playbook`, or group
   `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
@@ -292,16 +291,13 @@ If there is no material update worth notifying about, output only
 })();
 ```
 
-Publish the automation as one deploy-plus-release block:
+Publish the automation in one command:
 
 ```bash
-CRONJOB_ID=$(alva deploy create --name daily-briefing \
+alva release automation --name daily-briefing --version 1.0.0 \
+  --cronjob-name daily-briefing \
   --path '~/feeds/daily-briefing/v1/src/index.js' \
   --cron "0 8 * * *" --push-notify \
-  | jq -r '.id')
-
-alva release feed --name daily-briefing --version 1.0.0 \
-  --cronjob-id "$CRONJOB_ID" \
   --description "Generates a morning briefing each day at 08:00 summarizing overnight crypto market moves and pushes it as a notification"
 ```
 
@@ -808,16 +804,12 @@ alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last
 ### Step 5: Publish the automation (required for live playbooks)
 
 ```bash
-CRONJOB_ID=$(alva deploy create \
-  --name btc-ema-update \
-  --path '~/feeds/btc-ema/v1/src/index.js' \
-  --cron "0 */4 * * *" \
-  | jq -r '.id')
-
-alva release feed \
+alva release automation \
   --name btc-ema \
   --version 1.0.0 \
-  --cronjob-id "$CRONJOB_ID" \
+  --cronjob-name btc-ema-update \
+  --path '~/feeds/btc-ema/v1/src/index.js' \
+  --cron "0 */4 * * *" \
   --description "Refreshes BTC EMA metrics every four hours"
 ```
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -5,6 +5,10 @@ time series data on the Alva filesystem. Feed outputs are readable via standard
 filesystem paths, making them accessible to other scripts, dashboards, and
 public consumers.
 
+In normal user-facing workflows, this SDK is the data layer for an automation.
+Use `feed` for SDK code, paths, and diagnostics; publish and explain the
+finished product as an automation.
+
 ---
 
 ## Overview
@@ -227,7 +231,7 @@ require a 500-character summary.
 
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
-- `--push-notify` on `alva release automation` only makes the feed publisher
+- `--push-notify` on `alva automation publish` only makes the feed publisher
   capable of emitting alerts. It does **not** subscribe any user or group.
 - Real delivery requires an explicit subscription: personal
   `alva subscriptions subscribe-feed` / `subscribe-playbook`, or group
@@ -294,10 +298,10 @@ If there is no material update worth notifying about, output only
 Publish the automation in one command:
 
 ```bash
-alva release automation --name daily-briefing --version 1.0.0 \
-  --cronjob-name daily-briefing \
+alva automation publish --name daily-briefing --version 1.0.0 \
+  --producer-name daily-briefing \
   --path '~/feeds/daily-briefing/v1/src/index.js' \
-  --cron "0 8 * * *" --push-notify \
+  --schedule "0 8 * * *" --push-notify \
   --description "Generates a morning briefing each day at 08:00 summarizing overnight crypto market moves and pushes it as a notification"
 ```
 
@@ -804,12 +808,12 @@ alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last
 ### Step 5: Publish the automation (required for live playbooks)
 
 ```bash
-alva release automation \
+alva automation publish \
   --name btc-ema \
   --version 1.0.0 \
-  --cronjob-name btc-ema-update \
+  --producer-name btc-ema-update \
   --path '~/feeds/btc-ema/v1/src/index.js' \
-  --cron "0 */4 * * *" \
+  --schedule "0 */4 * * *" \
   --description "Refreshes BTC EMA metrics every four hours"
 ```
 

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -123,7 +123,7 @@ Before `alva release playbook-draft`, verify:
 - HTML exists at `~/playbooks/{name}/index.html`.
 - README exists at `~/playbooks/{name}/README.md`.
 - Target name and owner namespace match `alva whoami`.
-- Every feed in `--feeds` has passed `before-feed-release`.
+- Every feed in `--feeds` has passed `before-automation-publish`.
 - Draft metadata matches the approved plan.
 - `--tags` includes required asset overlap plus material related people:
   investors, company figures, officials/policymakers, Twitter/X KOLs.
@@ -159,7 +159,7 @@ alva release playbook ... \
 <HARD-GATE id="before-playbook-release">
 Before `alva release playbook`, verify:
 
-1. Every backing feed passed `before-feed-release`.
+1. Every backing feed passed `before-automation-publish`.
 2. Every feed the HTML reads at runtime has a successful deploy and appears in
    `--feeds`.
 3. Cronjobs for referenced feeds are active.
@@ -174,7 +174,7 @@ Before `alva release playbook`, verify:
 8. Target user namespace is correct.
 9. README exists, is current, and is passed via absolute `--readme-url`.
 10. Push-only feeds with `push_notify: true` have a current
-    `alva release automation` publish after the push sidecar was added.
+    `alva automation publish` after the push sidecar was added.
 11. `alva lint playbook ./index.html` passes, or an intentional
     `--bypass-lint` is documented.
 

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -173,8 +173,8 @@ Before `alva release playbook`, verify:
    cronjobs.
 8. Target user namespace is correct.
 9. README exists, is current, and is passed via absolute `--readme-url`.
-10. Push-only feeds with `push_notify: true` have a current `alva release feed`
-    after the push sidecar was added.
+10. Push-only feeds with `push_notify: true` have a current
+    `alva release automation` publish after the push sidecar was added.
 11. `alva lint playbook ./index.html` passes, or an intentional
     `--bypass-lint` is documented.
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -33,9 +33,9 @@ A push is set up only after all of these succeed:
    - `notify/message` for feed completion, AlvaAsk reports, heartbeat checks,
      and proactive alerts.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
-   `before-feed-release`.
+   `before-automation-publish`.
 3. Publish or update the automation with publisher push enabled: use
-   `alva release automation --push-notify` from [deployment.md](deployment.md),
+   `alva automation publish --push-notify` from [deployment.md](deployment.md),
    or update an existing cronjob with `alva deploy update --id <ID>
    --push-notify` and republish the feed after sidecar changes.
 4. Subscribe the target:

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -34,8 +34,10 @@ A push is set up only after all of these succeed:
      and proactive alerts.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-feed-release`.
-3. Enable publisher push on the cronjob:
-   `alva deploy update --id <ID> --push-notify`.
+3. Publish or update the automation with publisher push enabled: use the
+   deploy-plus-release block in [deployment.md](deployment.md) with
+   `--push-notify`, or `alva deploy update --id <ID> --push-notify` followed by
+   a current `alva release feed --cronjob-id <ID>` after sidecar changes.
 4. Subscribe the target:
    `alva subscriptions subscribe-feed --username <owner> --name <feed>`
    or

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -34,10 +34,10 @@ A push is set up only after all of these succeed:
      and proactive alerts.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-feed-release`.
-3. Publish or update the automation with publisher push enabled: use the
-   deploy-plus-release block in [deployment.md](deployment.md) with
-   `--push-notify`, or `alva deploy update --id <ID> --push-notify` followed by
-   a current `alva release feed --cronjob-id <ID>` after sidecar changes.
+3. Publish or update the automation with publisher push enabled: use
+   `alva release automation --push-notify` from [deployment.md](deployment.md),
+   or update an existing cronjob with `alva deploy update --id <ID>
+   --push-notify` and republish the feed after sidecar changes.
 4. Subscribe the target:
    `alva subscriptions subscribe-feed --username <owner> --name <feed>`
    or

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -203,11 +203,11 @@ only on explicit request). Do not write fresh files from scratch.
 3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
 4. **Publish automation**:
    ```bash
-   alva release automation \
+   alva automation publish \
      --name {new-name} \
      --version 1.0.0 \
      --path '~/feeds/{new-name}/v1/src/index.js' \
-     --cron "..." \
+     --schedule "..." \
      --description "..."
    ```
 6. **Edit local HTML** (the `./index.html` from Step 2 — update data

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -203,16 +203,11 @@ only on explicit request). Do not write fresh files from scratch.
 3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
 4. **Publish automation**:
    ```bash
-   CRONJOB_ID=$(alva deploy create \
-     --name {new-name} \
-     --path '~/feeds/{new-name}/v1/src/index.js' \
-     --cron "..." \
-     | jq -r '.id')
-
-   alva release feed \
+   alva release automation \
      --name {new-name} \
      --version 1.0.0 \
-     --cronjob-id "$CRONJOB_ID" \
+     --path '~/feeds/{new-name}/v1/src/index.js' \
+     --cron "..." \
      --description "..."
    ```
 6. **Edit local HTML** (the `./index.html` from Step 2 — update data

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -201,8 +201,20 @@ only on explicit request). Do not write fresh files from scratch.
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
 3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
-4. **Deploy cronjob**: `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
-5. **Release feed**: `alva release feed --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
+4. **Publish automation**:
+   ```bash
+   CRONJOB_ID=$(alva deploy create \
+     --name {new-name} \
+     --path '~/feeds/{new-name}/v1/src/index.js' \
+     --cron "..." \
+     | jq -r '.id')
+
+   alva release feed \
+     --name {new-name} \
+     --version 1.0.0 \
+     --cronjob-id "$CRONJOB_ID" \
+     --description "..."
+   ```
 6. **Edit local HTML** (the `./index.html` from Step 2 — update data
    paths to point to your own feed) and upload:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`


### PR DESCRIPTION
## Summary

- Update the Alva skill docs to make `alva automation publish` the agent-facing path for cronjob-backed feed publishing.
- Keep Feed SDK terminology where agents write code and inspect paths, while hiding feed/cronjob composition from the normal publish flow.
- Rename the publish gate to `before-automation-publish` and route playbook, push, remix, and feed lifecycle references through that gate.
- Keep lower-level `alva deploy` / `alva release feed` language available only for diagnostics, repair, and lifecycle-boundary explanations.

## Stack

1. Backend: https://github.com/alva-ai/alva-backend/pull/1445
2. Gateway: https://github.com/alva-ai/alva-gateway/pull/504
3. Toolkit: https://github.com/alva-ai/toolkit-ts/pull/95
4. Skill docs: this PR

## Validation

- `node evals/alva-skill-docs/skill-doc-eval.mjs --out /tmp/alva-skill-automation-alias-final.md` -> `30/30` cases, `219/219` checks.
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/unify-automation-publish/skills/alva` -> no broken links, no orphan references.
- `git diff --check`.
