### PR TITLE
docs(alva): document alva.subscribe.propose() for playbooks

### DIFF
--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -213,6 +213,48 @@ invocation once.
 
 Do not implement a custom credit authorization modal inside the playbook iframe.
 
+## Feed Subscribe Proposal
+
+A playbook can offer the viewer a one-click "subscribe to alerts" for one of
+its feeds, but it must **not** subscribe the viewer directly. A playbook iframe
+cannot be trusted to represent real user intent — author code could silently
+`fetch()` a subscribe on load and force-subscribe the viewer. So feed subscribe
+goes through a parent-confirmed **proposal**:
+
+`window.alva.subscribe.propose({ feedOwner, feedName })` posts an
+`alva:subscribe:propose` message to the parent Alva page. The parent validates
+that the feed belongs to this playbook, shows a confirm prompt, and — only on
+user confirmation — subscribes with the viewer's own session. It replies
+`alva:subscribe:result`, and the promise resolves with the outcome.
+
+```html
+<button id="sub">Subscribe to alerts</button>
+<script>
+  document.getElementById("sub").addEventListener("click", async () => {
+    const status = await window.alva.subscribe.propose({
+      feedOwner: "alice",
+      feedName: "eth-price-push",
+    });
+    // 'subscribed' | 'declined' | 'timeout' | 'error'
+    if (status === "subscribed") {
+      document.getElementById("sub").textContent = "Subscribed ✓";
+    }
+  });
+</script>
+```
+
+Hard rules:
+
+- Do **not** call any subscribe API from playbook HTML — no
+  `fetch('/api/v1/subscriptions/...')`, no `AlvaClient` subscribe call. The
+  PBSV token does not authorize writing subscriptions; `propose()` is the only
+  allowed path.
+- The proposed feed must be one of the playbook's own feeds. Proposals for
+  any other feed are rejected by the parent (resolve `'error'`) and never
+  prompt the viewer.
+- The subscription is always written to the viewer's own account; a playbook
+  can never subscribe anyone else.
+
 ## Creator Function CLI
 
 Creator-side UDF management is a CLI flow. Before using it in a session, run

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -231,8 +231,11 @@ require a 500-character summary.
   publisher capable of emitting alerts. They do **not** subscribe any user or
   group.
 - Real delivery requires an explicit subscription: personal
-  `alva subscriptions subscribe-feed` / `subscribe-playbook`, or group
-  `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`.
+  `alva subscriptions subscribe-feed` / `subscribe-playbook`, group
+  `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`, or — from
+  inside a playbook iframe — a parent-confirmed `window.alva.subscribe.propose()`
+  (see `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook
+  must never call a subscribe API directly.
 - Use `meta.reason` to provide the push-notification body -- this is what
   recipients see when the signal is delivered.
 - `meta.reason` is **Markdown**. Write it as the push body itself, using


### PR DESCRIPTION
## What

Documents the new **parent-confirmed feed subscribe** flow for playbook authors.

A playbook iframe must never subscribe the viewer directly — author code could silently force-subscribe. Instead it calls `window.alva.subscribe.propose({ feedOwner, feedName })`, which asks the trusted parent to confirm with the viewer and subscribe with their session.

- `references/api/udf-runtime.md`: new **Feed Subscribe Proposal** section (usage + hard rules: no direct subscribe API, feed must be in the playbook, subscribes only the viewer).
- `references/feed-sdk.md`: pointer from the delivery/subscription notes.

## Companions

toolkit-ts #96 (`alva.subscribe.propose()` SDK), frontend-monorepo #3951 (parent bridge + confirm modal), alva-gateway #509 / alva-backend #1454 (revert direct pbsv subscribe).