### PR TITLE
docs(alva): repoint design release lint link

### DIFF
--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -58,7 +58,8 @@ alva lint playbook ./index.html
 ```
 
 `alva release playbook` runs the same lint internally and refuses to release
-if any error-severity finding fires. See SKILL.md §7 Release.
+if any error-severity finding fires. See
+[playbook-creation.md - Release](./playbook-creation.md#release).
 
 ## Typography & Font
 


### PR DESCRIPTION
## Summary

- Repoint the design contract lint release note away from stale `SKILL.md §7 Release` wording.
- Link directly to `playbook-creation.md#release`, where the current playbook release gate and lint requirement live.

## Validation

- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/repoint-design-release-lint/skills/alva`
- `git diff --check`
