### PR TITLE
docs(alva): design doc audit fixes — cyan1-main token, l9 docs, TOC, css banner

### DIFF
--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -33,6 +33,7 @@
     --chart-green2-main: #8fc13a;
     --chart-green2-1: #5b8513;
     --chart-green2-2: #c0d40f;
+    --chart-cyan1-main: #49a3a6; /* same as --main-m1 */
     --chart-cyan1-1: #117a7d;
     --chart-cyan1-2: #77c9c2;
     --chart-cyan2-main: #7cafad;
@@ -139,7 +140,7 @@
     --line-l12: rgba(0, 0, 0, 0.12); /* Card Border */
     --line-l2: rgba(0, 0, 0, 0.2); /* Popup/Dropdown Border */
     --line-l3: rgba(0, 0, 0, 0.3); /* Button/Input/Select Border */
-    --line-l9: rgba(0, 0, 0, 0.9); 
+    --line-l9: rgba(0, 0, 0, 0.9); /* Hover/Active Border */
 
     /* Shadow */
     --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.05);

--- a/skills/alva/references/design-playbook-trading-strategy.md
+++ b/skills/alva/references/design-playbook-trading-strategy.md
@@ -3,6 +3,18 @@
 > Follow this spec strictly for all trading strategy playbooks. Do not invent
 > alternative layouts. Global tokens and rules: [design.md](./design.md).
 
+## Table of Contents
+
+- [0. Page Layout](#0-page-layout)
+- [1. Shared Structure](#1-shared-structure)
+- [2. Tab: Overview](#2-tab-overview)
+- [3. Tab: Analytics](#3-tab-analytics)
+- [4. Tab: Strategy](#4-tab-strategy)
+- [5. Tab: Feed](#5-tab-feed)
+- [6. Responsive Breakpoints](#6-responsive-breakpoints)
+- [7. Data Schema (JSON)](#7-data-schema-json)
+- [8. Generation Checklist](#8-generation-checklist)
+
 ---
 
 ## 0. Page Layout

--- a/skills/alva/references/design-tokens.css
+++ b/skills/alva/references/design-tokens.css
@@ -31,6 +31,7 @@
     --chart-green2-main: #8fc13a;
     --chart-green2-1: #5b8513;
     --chart-green2-2: #c0d40f;
+    --chart-cyan1-main: #49a3a6; /* same as --main-m1 */
     --chart-cyan1-1: #117a7d;
     --chart-cyan1-2: #77c9c2;
     --chart-cyan2-main: #7cafad;
@@ -137,7 +138,7 @@
     --line-l12: rgba(0, 0, 0, 0.12); /* Card Border */
     --line-l2: rgba(0, 0, 0, 0.2); /* Popup/Dropdown Border */
     --line-l3: rgba(0, 0, 0, 0.3); /* Button/Input/Select Border */
-    --line-l9: rgba(0, 0, 0, 0.9); 
+    --line-l9: rgba(0, 0, 0, 0.9); /* Hover/Active Border */
 
     /* Shadow */
     --shadow-xs: 0 4px 15px 0 rgba(0, 0, 0, 0.05);

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -1,5 +1,10 @@
 # Alva Design System
 
+> ⚠️ **The ```css blocks in this file are the source of truth for
+> [css/design-system.css](./css/design-system.css) (published to CDN).**
+> When you edit any ```css block, commit the matching regenerated
+> `design-system.css` alongside your `.md` edit. CI doc-sync catches drift.
+
 This file is the global entry point for Alva design rules — tokens, typography,
 theme, and page-level layout. Read this first, then follow the reading path at
 the bottom for widget and component specs.
@@ -32,7 +37,7 @@ values. Below is a quick reference:
 | Chart colors | `--chart-{color}-main/1/2`                     | Grey only when ≥ 3 series               |
 | Text         | `--text-n9/n7/n5/n3/n2`                        | n9=primary, n7=secondary, n5=supporting |
 | Background   | `--b0-page`, `--grey-g01`~`g7`, `--b-r02`~`r1` | g01 for card backgrounds                |
-| Line         | `--line-l05/l07/l12/l2/l3`                     | l07=default                             |
+| Line         | `--line-l05/l07/l12/l2/l3/l9`                  | l07=default, l9=hover/active            |
 | Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only (dropdown/tooltip) |
 | Spacing      | `--spacing-xxxs`(2) ~ `--spacing-xxxxxxl`(56)  | Common: xs=8, m=16, xl=24               |
 | Radius       | `--radius-ct-min`(2) ~ `--radius-ct-max`(960)  | min=Tag, s=Card, l=Page                 |


### PR DESCRIPTION
Fixes from a quality audit of the design reference docs:

- **Missing token**: add `--chart-cyan1-main: #49a3a6` (same as `--main-m1`) to `design-tokens.css` and the generated bundle — every other chart color has the `main/1/2` triple, cyan1 was the only one missing `main`, so anything following the documented pattern emitted an undefined variable.
- **Undocumented token**: `--line-l9` is used by btn-secondary hover/loading states but had no comment and was absent from the design.md quick-reference table — documented as Hover/Active Border in both CSS files and the table.
- **Navigation**: add a table of contents to `design-playbook-trading-strategy.md` (889 lines, 9 numbered sections, previously no TOC).
- **Contributor guardrail**: design.md's own fenced css blocks also feed `css/design-system.css`, but unlike design-components.md / design-widgets.md it carried no regenerate-bundle warning banner — added the same banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)