### PR TITLE
docs(alva): add semiconductor spot prices to data coverage

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -38,7 +38,7 @@ The main objects are:
 
 | Concept | Meaning | Read when |
 | --- | --- | --- |
-| Data Skills | 250+ structured Arrays endpoints for equities, crypto, macro, on-chain, news, prediction markets, and indexed Twitter/X. | You need factual financial data. |
+| Data Skills | 250+ structured Arrays endpoints for equities, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data. |
 | Runtime script | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs. | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK. |
 | Feed | A persistent data pipeline that writes time-series or grouped outputs to ALFS and can back playbooks or alerts. | Data needs freshness, history, public reads, charts, release, or push. |
 | Playbook | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`. | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface. |
@@ -263,8 +263,8 @@ or sector baskets, verify ticker fit with live company-detail data such as
 
 Source routing:
 
-- Structured US-equity, crypto, on-chain, macro, prediction-market, and
-  fundamentals data: Data Skills.
+- Structured US-equity, crypto, on-chain, macro, semiconductor spot price,
+  prediction-market, and fundamentals data: Data Skills.
 - Twitter/X handle history, URL lookup, or full-text over tracked investing
   accounts: Data Skills.
 - Global X search beyond Arrays' index, news/web search, non-US finance, or

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -44,8 +44,8 @@ If a call returns 401, rerun `alva arrays token ensure`. Do not use
 
 Data Skills cover spot and derivatives markets across stocks, ETFs, options,
 and crypto; equity fundamentals, estimates, events, ownership flows; on-chain
-metrics and exchange flows; macro indicators; prediction markets; news; and
-Twitter/X feeds.
+metrics and exchange flows; macro indicators; semiconductor spot prices;
+prediction markets; news; and Twitter/X feeds.
 
 Twitter/X routing:
 


### PR DESCRIPTION
Surfaces the **semiconductor price** domain (DRAM/NAND/Memory Card spot, via Arrays `arrays-data-api-semiconductor-price`) so the agent knows it exists and discovers it through the `alva data-skills` pipeline.

- `references/data-skills.md` — add `semiconductor spot prices` to the Coverage list.
- `SKILL.md` — add it to the Data Skills mental-model row and Source-routing list.

No version bump.

(Non-US / forex / index / commodity routing moved to #492.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)