### PR TITLE
[yimingchen] docs(alva): subscription inventory/unsubscribe guidance + taxonomy (#584 W4)

### DIFF
--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -328,7 +328,10 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - Real delivery requires an explicit subscription: personal
   `alva subscriptions subscribe-feed --username <owner> --name <feed>`
   or `subscribe-playbook`, or group `/alva subscribe feed <feed_id>` /
-  `/alva subscribe playbook <playbook_id>`.
+  `/alva subscribe playbook <playbook_id>`. For inventory and
+  unsubscribe (including ghost rows of deleted targets), see
+  [push-notifications.md](push-notifications.md) § Inventory And
+  Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and
   signal-style notifications.
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -53,13 +53,6 @@ Confirm to the user with specifics: which feed/playbook is subscribed, what the
 next push will say, and when it will fire. For monitors, say quiet runs skip
 notifications.
 
-## Subscribe Disambiguation
-
-"Subscribe" means three different things — confirm which one before acting:
-**follow** (social, `alva subscriptions follows`), **alerts** (push,
-`alva subscriptions list`), **purchase** (paid — not this command, confirm
-before touching anything billing-related).
-
 ## Inventory And Unsubscribe
 
 - `alva subscriptions list --first 200` — rows carry `kind`, playbook

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -53,48 +53,23 @@ Confirm to the user with specifics: which feed/playbook is subscribed, what the
 next push will say, and when it will fire. For monitors, say quiet runs skip
 notifications.
 
-## Three Concepts Named "Subscribe"
+## Subscribe Disambiguation
 
-Disambiguate before acting on "subscribe"/"unsubscribe" requests — three
-distinct relations share the word:
-
-| Concept | What it is | Surface |
-|---|---|---|
-| **follow** | Social relation (the UI's "Subscribed Playbooks") | `alva subscriptions follows` |
-| **alerts** | Push/notification opt-ins | `alva subscriptions list` |
-| **purchase** | Paid playbook access / SaaS plan | NOT the subscriptions command |
-
-`subscribe-playbook` touches the first two (follow + playbook-level alert,
-one call) and reports both on unsubscribe (`{unfollowed,
-wildcard_disabled}`). Never route an "unsubscribe" request to anything
-billing-related without explicit confirmation.
+"Subscribe" means three different things — confirm which one before acting:
+**follow** (social, `alva subscriptions follows`), **alerts** (push,
+`alva subscriptions list`), **purchase** (paid — not this command, confirm
+before touching anything billing-related).
 
 ## Inventory And Unsubscribe
 
-To answer "what am I subscribed to" or "unsubscribe me from X":
-
-1. `alva subscriptions list --first 200` — every row is self-describing:
-   - `kind`: `PLAYBOOK_ALERTS` (playbook-level wildcard) or `FEED_ALERT`;
-   - `playbook {owner_username, name, display_name}` for playbook rows —
-     never guess names from bare ids;
-   - `following`: whether the playbook is also followed;
-   - `target_status`: `ACTIVE` | `TARGET_DELETED` (ghost row — the target
-     was deleted) | `PAUSED`;
-   - `total_count`: when `items` length is below it, keep paginating with
-     `--cursor` — never report a truncated page as the full inventory.
-2. `alva subscriptions follows` — the follow list, with identity per row.
-3. Unsubscribe:
-   - by name (live targets):
-     `alva subscriptions unsubscribe-playbook|unsubscribe-feed --username
-     <owner> --name <name>`;
-   - by TARGET ID (bulk, idempotent, and the ONLY way to clear
-     `TARGET_DELETED` ghosts — name-addressed unsubscribe 404s on deleted
-     targets):
-     `alva subscriptions unsubscribe --playbook-ids <a,b> --feed-ids <c>`.
-4. Resolve unknown ids with `alva playbooks get --ids <a,b>` (or
-   `--ref <owner/name>`), and enumerate a user's playbooks with
-   `alva playbooks list --owner <username>`.
-
-Never probe with mutating calls (subscribe-then-unsubscribe to learn an id,
-unsubscribe as an existence check) — the read surface above answers every
-identity question.
+- `alva subscriptions list --first 200` — rows carry `kind`, playbook
+  identity, `following`, `target_status`. If `items` < `total_count`, keep
+  paginating; never report a truncated page as the full inventory.
+- `alva subscriptions follows` — the follow list.
+- Unsubscribe by name (`unsubscribe-playbook|unsubscribe-feed`) for live
+  targets; by id (`unsubscribe --playbook-ids a,b --feed-ids c`) for bulk
+  and for `TARGET_DELETED` ghosts (name-addressed 404s on deleted targets).
+- Resolve ids with `alva playbooks get --ids a,b` / `--ref owner/name`;
+  list a user's playbooks with `alva playbooks list --owner <username>`.
+- Never probe with mutating calls — the read surface answers all identity
+  questions.

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -52,3 +52,49 @@ claim push is set up. Diagnose and fix first.
 Confirm to the user with specifics: which feed/playbook is subscribed, what the
 next push will say, and when it will fire. For monitors, say quiet runs skip
 notifications.
+
+## Three Concepts Named "Subscribe"
+
+Disambiguate before acting on "subscribe"/"unsubscribe" requests — three
+distinct relations share the word:
+
+| Concept | What it is | Surface |
+|---|---|---|
+| **follow** | Social relation (the UI's "Subscribed Playbooks") | `alva subscriptions follows` |
+| **alerts** | Push/notification opt-ins | `alva subscriptions list` |
+| **purchase** | Paid playbook access / SaaS plan | NOT the subscriptions command |
+
+`subscribe-playbook` touches the first two (follow + playbook-level alert,
+one call) and reports both on unsubscribe (`{unfollowed,
+wildcard_disabled}`). Never route an "unsubscribe" request to anything
+billing-related without explicit confirmation.
+
+## Inventory And Unsubscribe
+
+To answer "what am I subscribed to" or "unsubscribe me from X":
+
+1. `alva subscriptions list --first 200` — every row is self-describing:
+   - `kind`: `PLAYBOOK_ALERTS` (playbook-level wildcard) or `FEED_ALERT`;
+   - `playbook {owner_username, name, display_name}` for playbook rows —
+     never guess names from bare ids;
+   - `following`: whether the playbook is also followed;
+   - `target_status`: `ACTIVE` | `TARGET_DELETED` (ghost row — the target
+     was deleted) | `PAUSED`;
+   - `total_count`: when `items` length is below it, keep paginating with
+     `--cursor` — never report a truncated page as the full inventory.
+2. `alva subscriptions follows` — the follow list, with identity per row.
+3. Unsubscribe:
+   - by name (live targets):
+     `alva subscriptions unsubscribe-playbook|unsubscribe-feed --username
+     <owner> --name <name>`;
+   - by TARGET ID (bulk, idempotent, and the ONLY way to clear
+     `TARGET_DELETED` ghosts — name-addressed unsubscribe 404s on deleted
+     targets):
+     `alva subscriptions unsubscribe --playbook-ids <a,b> --feed-ids <c>`.
+4. Resolve unknown ids with `alva playbooks get --ids <a,b>` (or
+   `--ref <owner/name>`), and enumerate a user's playbooks with
+   `alva playbooks list --owner <username>`.
+
+Never probe with mutating calls (subscribe-then-unsubscribe to learn an id,
+unsubscribe as an existence check) — the read surface above answers every
+identity question.


### PR DESCRIPTION
## What

**Wave 4 (skills docs)** of the mono-meta#584 fix program — teaches agents the surface shipped in W1-W3 (alva-backend#1460, alva-gateway#513, toolkit-ts#98) so the dogfood failure modes stop recurring:

- **push-notifications.md**
  - *Three Concepts Named "Subscribe"* (B5): follow (social) / alerts (push) / purchase (paid) — disambiguate before acting; never route "unsubscribe" to billing without confirmation.
  - *Inventory And Unsubscribe*: `subscriptions list` rows are self-describing (`kind`, `playbook{owner_username,name,display_name}`, `following`, `target_status`); `total_count` is the truncation signal (never report a truncated page as the full inventory — the exact B7 failure); `subscriptions follows` for the follow relation (A4); unsubscribe by name vs **by target id** (`subscriptions unsubscribe --playbook-ids/--feed-ids` — the only path that clears `TARGET_DELETED` ghosts, A3); `playbooks get --ids/--ref` + `playbooks list --owner` for id resolution (A2/C10); and an explicit **"never probe with mutating calls"** rule (B9).
- **feed-sdk.md**: pointer from the delivery notes.

## Companions

alva-backend#1460 (W1, merged) · alva-gateway#513 (W2, merged) · toolkit-ts#98 (W3, merged). Primary changelog: alva-backend `docs/changelogs/2026-06-10-subscriptions-surface-agent-fix.md`.