### PR TITLE
chore(alva): bump version to v1.12.0

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.11.2
+  version: v1.12.0
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.11.2` → `v1.12.0` ahead of cutting the `v1.12.0` release. `rel/v1.12` and the `v1.12.0` tag will point at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)