### PR TITLE
chore(alva): bump version to v1.12.1

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.12.0
+  version: v1.12.1
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.12.0` → `v1.12.1` ahead of cutting the `v1.12.1` release. `rel/v1.12` and the `v1.12.1` tag will point at this commit.

Made with [Cursor](https://cursor.com)