### PR TITLE
[codex] Allow official-source fallback for stale Alva feeds

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -317,6 +317,19 @@
       ]
     },
     {
+      "id": "issue591.official-source-web-fallback",
+      "group": "issue591",
+      "target": "corpus",
+      "description": "When structured data lags a known official release, web is an official-source fallback and corroboration path rather than an automatic refusal.",
+      "includes": [
+        "Structured Feed Lag",
+        "domain-scoped search",
+        "Alva's structured feed is not yet synced",
+        "official-source stale-feed fallback",
+        "Do not claim the value came from Data Skills"
+      ]
+    },
+    {
       "id": "target.top-level-size",
       "group": "target",
       "target": "skill",
@@ -478,7 +491,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.11.2",
+        "version: v1.12.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -125,8 +125,9 @@ make it this one.
    `~/memory/MEMORY.md` if not already read. Memory is a *claim*, not truth.
 3. **Pipeline, not oracle.** Financial values must come from Data Skills,
    published Alva feeds, or validated BYOD sources. WebSearch, LLM output,
-   agent memory, synthetic data, and user-pasted examples are not factual data
-   sources. Read [content-legitimacy.md](references/content-legitimacy.md).
+   agent memory, synthetic data, and user-pasted examples are not standalone
+   factual data sources. Read
+   [content-legitimacy.md](references/content-legitimacy.md).
 4. **No stale surface assumptions.** Fetch Data Skills endpoint docs, Skillhub
    blueprints, CLI help, and runtime docs in the current session. Do not act
    from remembered field names.
@@ -594,10 +595,12 @@ or qualify any comparison baseline, read
 [user-facing-prose.md](references/user-facing-prose.md), apply the answer gate
 in the Financial Analysis tree, classify complex asks with
 [request-routing.md](references/request-routing.md), and answer with inline
-provenance. If the data source fails, report the failure instead of
-substituting a web snippet or model memory. If the user then asks to track,
-alert, share, or publish, upgrade the route to a feed, signal, alert, or
-playbook.
+provenance. If a structured source returns stale or missing latest data, use
+[data-skills.md](references/data-skills.md#structured-feed-lag) before refusing
+when a known official release may be ahead of the feed; otherwise report the
+failure instead of substituting a web snippet or model memory. If the user then
+asks to track, alert, share, or publish, upgrade the route to a feed, signal,
+alert, or playbook.
 
 ### Durable Artifacts / Playbook Tree
 

--- a/skills/alva/references/content-legitimacy.md
+++ b/skills/alva/references/content-legitimacy.md
@@ -44,8 +44,10 @@ good unless you actually rendered or screenshotted it. Copy `published_url`,
 ## Prohibited Sources
 
 - WebSearch / WebFetch values must not be quoted as financial answers or
-  embedded as data. Search can find docs, requirements, or BYOD endpoints, but
-  discovered values must flow through a legitimate data source.
+  embedded as data, except for the official-source stale-feed fallback in
+  [data-skills.md](data-skills.md#structured-feed-lag). Search can find docs,
+  requirements, or BYOD endpoints, but discovered values must flow through a
+  legitimate data source.
 - LLM / alpi output must not be presented as factual sourced data. alpi can
   classify, summarize, and reason over real data; if it produces quantitative
   output, label it as AI-generated analysis.

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -99,6 +99,23 @@ alva sdk doc --name <module>
 
 ## Failure And Fallback
 
+### Structured Feed Lag
+
+If an in-catalog series appears stale against its cadence, release calendar, or
+the user's claim that an official release has happened:
+
+1. Re-check Data Skills, including observation-date and release-date endpoints
+   when available.
+2. Verify the release calendar or latest release on the official primary source
+   through domain-scoped search or direct page fetch.
+3. If confirmed, answer with inline source attribution and state that Alva's
+   structured feed is not yet synced. Do not claim the value came from Data
+   Skills.
+4. If the official source does not confirm the release, say the structured feed
+   latest value and the official-release status you checked.
+5. Treat news, blogs, screenshots, memory, and LLM output only as hints to
+   verify, not as fallback value sources.
+
 When an endpoint returns 403, 404, empty, or irrelevant data:
 
 1. Re-check `summary` for a semantically equivalent endpoint in the same skill.


### PR DESCRIPTION
## Summary

- add a narrow Data Skills stale-feed fallback: re-check structured data, verify the official primary source, and label the answer as not yet synced in Alva's feed
- keep the WebSearch prohibition intact, with only this official-source stale-feed exception
- add a compact issue591 regression case and refresh the mainline version sentinel to v1.12.1

## Why

mono-meta issue 591 showed the skill text could be read as a full refusal path when Arrays lagged an official macro release. The intended behavior is simple: web is not the Alva data pipeline, but an official primary source can be used as a one-off fallback/corroboration path when the structured feed is stale.

Related: alva-ai/mono-meta#591

## Validation

- `node evals/alva-skill-docs/skill-doc-eval.mjs --out /tmp/alva-skill-doc-eval-official-source-web-fallback.md` -> 32/32 cases, 258/258 checks
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/official-source-web-fallback/skills/alva` -> no broken links, no orphan references
- `git diff --check`
