### PR TITLE
docs(alva): add scoped behavior evals

### DIFF
--- a/.github/workflows/alva-skill-doc-evals.yml
+++ b/.github/workflows/alva-skill-doc-evals.yml
@@ -1,0 +1,36 @@
+name: Alva skill doc evals
+
+on:
+  pull_request:
+    paths:
+      - "skills/alva/**"
+      - "evals/alva-skill-docs/**"
+      - ".github/workflows/alva-skill-doc-evals.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/alva/**"
+      - "evals/alva-skill-docs/**"
+      - ".github/workflows/alva-skill-doc-evals.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run doc regression eval
+        run: node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva
+
+      - name: Run mutation smoke
+        run: node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva

--- a/.github/workflows/alva-skill-llm-trace.yml
+++ b/.github/workflows/alva-skill-llm-trace.yml
@@ -1,0 +1,64 @@
+name: Alva skill LLM trace eval
+
+on:
+  schedule:
+    # Weekly Monday 10:00 Asia/Shanghai. This is periodic diagnostics, not PR CI.
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "OpenAI model override"
+        required: false
+        type: string
+      scenario:
+        description: "Optional scenario id"
+        required: false
+        type: string
+      limit:
+        description: "Optional scenario limit"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  trace:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ALVA_SKILL_LLM_EVAL_MODEL: ${{ inputs.model || vars.ALVA_SKILL_LLM_EVAL_MODEL }}
+      ALVA_SKILL_LLM_EVAL_SCENARIO: ${{ inputs.scenario || '' }}
+      ALVA_SKILL_LLM_EVAL_LIMIT: ${{ inputs.limit || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run periodic LLM trace eval
+        run: |
+          mkdir -p artifacts/alva-skill-llm-trace
+          args=(
+            --out artifacts/alva-skill-llm-trace/report.md
+            --json-out artifacts/alva-skill-llm-trace/traces.json
+          )
+          if [[ -n "${ALVA_SKILL_LLM_EVAL_SCENARIO}" ]]; then
+            args+=(--scenario "${ALVA_SKILL_LLM_EVAL_SCENARIO}")
+          fi
+          if [[ -n "${ALVA_SKILL_LLM_EVAL_LIMIT}" ]]; then
+            args+=(--limit "${ALVA_SKILL_LLM_EVAL_LIMIT}")
+          fi
+          node evals/alva-skill-docs/llm-scenario-trace.mjs "${args[@]}"
+
+      - name: Upload trace report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: alva-skill-llm-trace
+          path: artifacts/alva-skill-llm-trace/
+          if-no-files-found: ignore

--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -6,7 +6,7 @@ SKILL.md lines: 780
 
 Cases: 47/47
 
-Checks: 403/403 (100.00%)
+Checks: 416/416 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -292,7 +292,7 @@ When structured data lags a known official release, web is an official-source fa
 
 ## issue592
 
-5/5 cases, 52/52 checks
+5/5 cases, 65/65 checks
 
 ### PASS issue592.scoped-eval-checks
 
@@ -302,16 +302,29 @@ The eval runner can verify scoped behavior and scenario contracts instead of onl
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes section_includes
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes hard_gate_includes
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenariosPath
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes mutation-smoke.mjs
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes evaluateScenario
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenarioAsCase
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes requirements.sections
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes expected route
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractMarkdownSection
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractHardGate
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes getFileText
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes prompt
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes "route"
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes "sections"
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes Capability Verification
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes before-playbook-release
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes MUTATIONS
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes simple-latest-one-hop
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes scenario.simple-latest-price
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes capability-before-refusal
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes issue592.capability-verification-before-refusal
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes playbook-release-readme
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes before-playbook-release
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes udf-strict-opt-in
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes scenario.udf-strict-opt-in
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes expectFailedCases
 
 ### PASS issue592.financial-ask-contract
 
@@ -584,12 +597,12 @@ Prompt: `Does Alva have darkpool L2 realtime data?`
 
 - [x] data-skills.md
 - [x] search.md
-- [x] Before saying Alva lacks a capability
-- [x] alva data-skills list | grep -i <topic>
-- [x] Decompose compound asks
-- [x] Never reject the whole as one unit from memory
 - [x] custom data source URL / BYOD source
 - [x] expected route: references/request-routing.md#Routes includes Capability Verification
+- [x] before refusal: references/request-routing.md#Capability Verification includes Before saying Alva lacks a capability
+- [x] before refusal: references/request-routing.md#Capability Verification includes alva data-skills list | grep -i <topic>
+- [x] before refusal: references/request-routing.md#Capability Verification includes Decompose compound asks
+- [x] before refusal: references/request-routing.md#Capability Verification includes Never reject the whole as one unit from memory
 
 ## scenarios.playbook
 

--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -2,11 +2,11 @@
 
 Source: `origin/main`
 
-SKILL.md lines: 771
+SKILL.md lines: 780
 
-Cases: 29/31
+Cases: 47/47
 
-Checks: 215/253 (84.98%)
+Checks: 403/403 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -15,8 +15,7 @@ Classify the gap before editing: missing capability summary, missing routing poi
 Do not expose eval scores as product copy, and do not patch demos to hide a weak result.
 Instead, fix the canonical skill text or eval case, then rerun baseline and final reports so the regression mechanism proves the gap is closed.
 
-- target.ask-evidence-gate: inspect for a skill gap before editing. Missing checks: Do not answer until; Simple latest-fact asks stop there after one sourced hop; Simple/latest-fact asks stop there; cap confidence when required evidence; KPI coverage; computation is missing
-- target.financial-ask-quality-gates: inspect for a skill gap before editing. Missing checks: Complex Ask Router; Only complex judgment asks also pass the Complex Ask Router; treat complex judgments as high-risk financial analysis; Simple/latest-fact asks stop there; Complex Ask Router only for complex judgment asks; thesis/fundamental; earnings/catalyst; event-study/backtest; screener/ranking; macro/cross-asset; news/social sentiment; portfolio/scenario; valuation/accounting; event definition; sample count; non-overlap rule; look-ahead control; benchmark/sector ETF; missing-field handling; evidence table with source; authority/relevance; duplicate status; synchronized as-of time; implied-probability source/proxy; weights/exposure assumption; beta/correlation/proxy method; drawdown table; current multiple/FCF/EPS; multiple/earnings sensitivity; attempted/found/missing/impact; required calculation not done caps at B-/C; hard cap
+No failed cases. Keep the eval in place as a regression mechanism.
 
 ## retained
 
@@ -277,16 +276,110 @@ Review-discovered guardrails stay present in the skill corpus instead of only in
 - [x] 20%
 - [x] ~/library
 
+## issue591
+
+1/1 cases, 5/5 checks
+
+### PASS issue591.official-source-web-fallback
+
+When structured data lags a known official release, web is an official-source fallback and corroboration path rather than an automatic refusal.
+
+- [x] Structured Feed Lag
+- [x] domain-scoped search
+- [x] Alva's structured feed is not yet synced
+- [x] official-source stale-feed fallback
+- [x] Do not claim the value came from Data Skills
+
+## issue592
+
+5/5 cases, 52/52 checks
+
+### PASS issue592.scoped-eval-checks
+
+The eval runner can verify scoped behavior and scenario contracts instead of only corpus-wide string presence.
+
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes file_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes section_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes hard_gate_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenariosPath
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes evaluateScenario
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenarioAsCase
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes expected route
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractMarkdownSection
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractHardGate
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes getFileText
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes prompt
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes "route"
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes Capability Verification
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes before-playbook-release
+
+### PASS issue592.financial-ask-contract
+
+Financial Analysis / Ask Question remains a small answer route with fresh evidence, prose, and confidence gates instead of inheriting playbook workflow.
+
+- [x] answer route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+- [x] answer route: references/request-routing.md#Routes includes fresh data/search/`alva run` evidence
+- [x] answer route: references/request-routing.md#Routes includes Every answer must read [user-facing-prose.md](user-facing-prose.md)
+- [x] answer route: references/request-routing.md#Routes includes ask evidence gate
+- [x] answer gate: references/request-routing.md#Guided Planning includes decomposition
+- [x] answer gate: references/request-routing.md#Guided Planning includes source path
+- [x] answer gate: references/request-routing.md#Guided Planning includes coverage gaps
+- [x] answer gate: references/request-routing.md#Guided Planning includes sourced-vs-inference boundary
+- [x] answer gate: references/request-routing.md#Guided Planning includes Simple asks can satisfy the gate with one hop
+- [x] answer gate: references/request-routing.md#Guided Planning includes Only complex judgment asks also pass the Complex Ask Router
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes It is not merely "Data Query"
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes data access and execution are steps inside an analysis answer
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes Simple latest-fact asks stop there after one sourced hop
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes Do not answer until you can name the decomposition
+
+### PASS issue592.capability-verification-before-refusal
+
+Capability gaps are verified against live Alva surfaces and reduced-scope/BYOD fallbacks before the agent refuses.
+
+- [x] before refusal: references/request-routing.md#Capability Verification includes Before saying Alva lacks a capability
+- [x] before refusal: references/request-routing.md#Capability Verification includes alva data-skills list | grep -i <topic>
+- [x] before refusal: references/request-routing.md#Capability Verification includes Decompose compound asks
+- [x] before refusal: references/request-routing.md#Capability Verification includes Never reject the whole as one unit from memory
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes same-domain Alva endpoints cannot answer the task
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes custom data source URL / BYOD source
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never stop with zero useful output
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never replace a missing data source with LLM-fabricated values
+
+### PASS issue592.playbook-release-behavior
+
+Playbook release remains protected by behavior-level gates for feed freshness, live data reads, README, lint, and screenshot verification.
+
+- [x] visual verification: references/playbook-creation.md#Screenshot includes A PNG or page shell is not enough
+- [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
+- [x] visual verification: references/playbook-creation.md#Screenshot includes headers-only tables
+- [x] visual verification: references/playbook-creation.md#Screenshot includes fetch failures are data-rendering failures
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes HTML fetches quantitative data from feeds, not inline literals
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Latest data from each referenced feed is fresh
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
+
+### PASS issue592.push-delivery-behavior
+
+Push setup is evaluated as a full delivery path instead of a single publisher flag.
+
+- [x] push setup: references/push-notifications.md#Configure And Verify includes A push is set up only after all of these succeed
+- [x] push setup: references/push-notifications.md#Configure And Verify includes before-feed-release
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva deploy update --id <ID> --push-notify
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-feed
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-playbook
+- [x] push setup: references/push-notifications.md#Configure And Verify includes read `@last/1` of the sidecar
+- [x] push setup: references/push-notifications.md#Configure And Verify includes do not claim push is set up
+
 ## target
 
-7/9 cases, 78/116 checks
+9/9 cases, 115/115 checks
 
 ### PASS target.top-level-size
 
-Top-level SKILL.md is in the requested encyclopedia/guide size band.
+Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count >= 650 (actual 771)
-- [x] line count <= 850 (actual 771)
+- [x] line count <= 850 (actual 780)
 
 ### PASS target.playbook-task-offload
 
@@ -337,58 +430,58 @@ Ask-question work is grouped as financial analysis instead of a low-level Data Q
 - [x] Do not let playbook creation become the default
 - [x] Do not turn every Skillhub task into a playbook
 
-### FAIL target.ask-evidence-gate
+### PASS target.ask-evidence-gate
 
 Direct financial asks have compact evidence gates instead of a free-form memo contract.
 
 - [x] ask evidence gate
-- [ ] Do not answer until
+- [x] Do not answer until
 - [x] decomposition
 - [x] data/source path for each hop
 - [x] fetched vs missing coverage
 - [x] sourced facts, computed values, or inference
-- [ ] Simple latest-fact asks stop there after one sourced hop
-- [ ] Simple/latest-fact asks stop there
-- [ ] cap confidence when required evidence
-- [ ] KPI coverage
-- [ ] computation is missing
+- [x] Simple latest-fact asks stop there after one sourced hop
+- [x] Simple/latest-fact asks stop there
+- [x] cap confidence when required evidence
+- [x] KPI coverage
+- [x] computation is missing
 
-### FAIL target.financial-ask-quality-gates
+### PASS target.financial-ask-quality-gates
 
 Complex financial asks classify the problem type and apply source, methodology, KPI, and confidence gates.
 
-- [ ] Complex Ask Router
-- [ ] Only complex judgment asks also pass the Complex Ask Router
-- [ ] treat complex judgments as high-risk financial analysis
-- [ ] Simple/latest-fact asks stop there
-- [ ] Complex Ask Router only for complex judgment asks
-- [ ] thesis/fundamental
-- [ ] earnings/catalyst
-- [ ] event-study/backtest
-- [ ] screener/ranking
-- [ ] macro/cross-asset
-- [ ] news/social sentiment
-- [ ] portfolio/scenario
-- [ ] valuation/accounting
-- [ ] event definition
-- [ ] sample count
-- [ ] non-overlap rule
-- [ ] look-ahead control
-- [ ] benchmark/sector ETF
-- [ ] missing-field handling
-- [ ] evidence table with source
-- [ ] authority/relevance
-- [ ] duplicate status
-- [ ] synchronized as-of time
-- [ ] implied-probability source/proxy
-- [ ] weights/exposure assumption
-- [ ] beta/correlation/proxy method
-- [ ] drawdown table
-- [ ] current multiple/FCF/EPS
-- [ ] multiple/earnings sensitivity
-- [ ] attempted/found/missing/impact
-- [ ] required calculation not done caps at B-/C
-- [ ] hard cap
+- [x] Complex Ask Router
+- [x] Only complex judgment asks also pass the Complex Ask Router
+- [x] treat complex judgments as high-risk financial analysis
+- [x] Simple/latest-fact asks stop there
+- [x] Complex Ask Router only for complex judgment asks
+- [x] thesis/fundamental
+- [x] earnings/catalyst
+- [x] event-study/backtest
+- [x] screener/ranking
+- [x] macro/cross-asset
+- [x] news/social sentiment
+- [x] portfolio/scenario
+- [x] valuation/accounting
+- [x] event definition
+- [x] sample count
+- [x] non-overlap rule
+- [x] look-ahead control
+- [x] benchmark/sector ETF
+- [x] missing-field handling
+- [x] evidence table with source
+- [x] authority/relevance
+- [x] duplicate status
+- [x] synchronized as-of time
+- [x] implied-probability source/proxy
+- [x] weights/exposure assumption
+- [x] beta/correlation/proxy method
+- [x] drawdown table
+- [x] current multiple/FCF/EPS
+- [x] multiple/earnings sensitivity
+- [x] attempted/found/missing/impact
+- [x] required calculation not done caps at B-/C
+- [x] hard cap
 
 ### PASS target.financial-analysis-prose-gate
 
@@ -419,7 +512,7 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.11.2
+- [x] version: v1.12.1
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
@@ -441,3 +534,195 @@ Latest mainline Alva skill updates remain integrated after rebasing the refactor
 - [x] real feed-backed chart marks
 - [x] headers-only tables
 - [x] fetch failures
+
+## scenarios.ask
+
+2/2 cases, 19/19 checks
+
+### PASS scenario.simple-latest-price
+
+A simple latest-fact ask stays in Financial Analysis, uses fresh sourced evidence, and does not inherit playbook gates.
+
+Prompt: `What is BTC doing right now?`
+
+- [x] Simple latest-fact asks stop there after one sourced hop
+- [x] user-facing-prose.md
+- [x] content-legitimacy.md
+- [x] Direct latest price for covered US equities and crypto: intraday klines, not daily close
+- [x] Do not answer until you can name the decomposition
+- [x] Do not let playbook creation become the default
+- [x] not automatically to a playbook
+- [x] expected route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+
+### PASS scenario.complex-valuation-ask
+
+A complex valuation ask uses the ask evidence gate plus Complex Ask Router without becoming a playbook by default.
+
+Prompt: `Is NVDA cheap versus peers after the latest earnings revision?`
+
+- [x] request-routing.md
+- [x] user-facing-prose.md
+- [x] fundamentals-periods.md
+- [x] Complex Ask Router
+- [x] valuation/accounting
+- [x] comparison baselines are financial facts
+- [x] current multiple/FCF/EPS
+- [x] multiple/earnings sensitivity
+- [x] cap confidence when required evidence
+- [x] not automatically to a playbook
+- [x] expected route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+
+## scenarios.capability
+
+1/1 cases, 8/8 checks
+
+### PASS scenario.capability-gap-before-refusal
+
+A capability-gap question verifies live coverage before saying no or moving to BYOD.
+
+Prompt: `Does Alva have darkpool L2 realtime data?`
+
+- [x] data-skills.md
+- [x] search.md
+- [x] Before saying Alva lacks a capability
+- [x] alva data-skills list | grep -i <topic>
+- [x] Decompose compound asks
+- [x] Never reject the whole as one unit from memory
+- [x] custom data source URL / BYOD source
+- [x] expected route: references/request-routing.md#Routes includes Capability Verification
+
+## scenarios.playbook
+
+3/3 cases, 31/31 checks
+
+### PASS scenario.dashboard-playbook-build
+
+A hosted dashboard enters the Playbook Creation route and preserves feed-first, live-read, README, lint, release, and screenshot gates.
+
+Prompt: `Build and publish a live dashboard for BTC dominance breakouts.`
+
+- [x] Publication Layer: Playbook Creation Tree
+- [x] playbook-creation.md
+- [x] feed-lifecycle.md
+- [x] design.md
+- [x] api/release.md
+- [x] AlvaToolkit.AlvaClient
+- [x] Build live feeds first
+- [x] HTML fetches quantitative data from feeds, not inline literals
+- [x] Every release needs a current README
+- [x] screenshot verification must show real feed-backed marks
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
+
+### PASS scenario.remix-existing-playbook
+
+A remix reads source artifacts and preserves lineage instead of regenerating from memory.
+
+Prompt: `<remix https://alva.ai/u/alva/playbooks/screener> make my own version`
+
+- [x] Playbook Subroute: Remix
+- [x] remix-workflow.md
+- [x] playbook-creation.md
+- [x] Extract source owner/name from the tag URL
+- [x] read the source feed scripts, HTML, README, and playbook metadata
+- [x] preserve them unless the user explicitly asks otherwise
+- [x] Do not regenerate from memory
+- [x] expected route: references/request-routing.md#Routes includes Debug / Edit
+
+### PASS scenario.annotation-edit
+
+An annotation edit changes the generator behind the element and re-enters HTML gates.
+
+Prompt: `<annotation id="hero-title">make this chart title shorter</annotation>`
+
+- [x] Playbook Subroute: Annotation Edits
+- [x] annotation-edits.md
+- [x] playbook-creation.md
+- [x] change the generator behind the selected element
+- [x] Never freeze rendered feed values into static text
+- [x] HTML edits re-enter `before-build-html`
+- [x] expected route: references/request-routing.md#Routes includes Debug / Edit
+- [x] html gate: references/playbook-creation.md<HARD-GATE:before-build-html> includes The HTML follows the Browser request rule
+- [x] html gate: references/playbook-creation.md<HARD-GATE:before-build-html> includes Do not rely on memory of prior sessions
+
+## scenarios.push
+
+1/1 cases, 9/9 checks
+
+### PASS scenario.alert-push-monitor
+
+A monitoring request routes to Automation / Push and validates sidecar, release, subscription, and real-run delivery.
+
+Prompt: `Track BTC dominance and notify me when it breaks out.`
+
+- [x] push-notifications.md
+- [x] feed-lifecycle.md
+- [x] Build or modify a feed that emits actionable `signal/targets` or `notify/message`
+- [x] A push is set up only after all of these succeed
+- [x] alva deploy update --id <ID> --push-notify
+- [x] alva subscriptions subscribe-feed
+- [x] read `@last/1` of the sidecar
+- [x] do not claim push is set up
+- [x] expected route: references/request-routing.md#Routes includes Automation / Push
+
+## scenarios.strategy
+
+1/1 cases, 8/8 checks
+
+### PASS scenario.backtest-strategy
+
+A backtest routes through Strategy / Trading Analysis and requires Altra instead of hand-rolled loops.
+
+Prompt: `Backtest a weekly NVDA momentum strategy and show drawdowns.`
+
+- [x] altra-trading.md
+- [x] api/trading.md
+- [x] Always use Altra for backtesting
+- [x] FeedAltra
+- [x] look-ahead bias
+- [x] drawdown
+- [x] package results as a concise answer, feed, signal, or visual playbook depending on the request
+- [x] expected route: references/request-routing.md#Routes includes Strategy / Trading Analysis
+
+## scenarios.skillhub
+
+1/1 cases, 10/10 checks
+
+### PASS scenario.skillhub-method
+
+A Skillhub directive fetches the blueprint fresh, avoids bulk download, and only becomes a playbook if the user or blueprint asks.
+
+Prompt: `/use-skill:alva/thesis NVDA AI capex read-through`
+
+- [x] request-routing.md
+- [x] playbook-creation.md
+- [x] api/release.md
+- [x] If the user's message contains `/use-skill:<username>/<name>`, the Skillhub path is mandatory
+- [x] alva skillhub get
+- [x] alva skillhub file
+- [x] Do not bulk-download
+- [x] Do not turn every Skillhub task into a playbook
+- [x] --skill-id <username>/<name>
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+
+## scenarios.udf
+
+1/1 cases, 9/9 checks
+
+### PASS scenario.udf-strict-opt-in
+
+A UDF request is explicit opt-in and routes to the PBSV/browser runtime and functions CLI checks.
+
+Prompt: `Add a button so viewers can run my custom analysis function.`
+
+- [x] api/udf-runtime.md
+- [x] playbook-creation.md
+- [x] User-Defined Functions are strict opt-in
+- [x] registerable/shareable interactive function
+- [x] window.alva.udf
+- [x] alva functions
+- [x] allowance consent
+- [x] Never hand-write bearer headers
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -538,15 +538,40 @@
       "id": "target.top-level-playbook-routing",
       "group": "target",
       "target": "skill",
-      "description": "Top-level routing and final checklist keep playbook work in its concrete reference without making all routing playbook-centric.",
-      "includes": [
-        "Playbook Creation Tree",
-        "Durable Artifacts / Playbook Tree",
-        "Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release",
-        "do not let every financial question inherit playbook gates",
-        "route through [playbook-creation.md](references/playbook-creation.md)",
-        "Did playbook work read [playbook-creation.md](references/playbook-creation.md)",
-        "relevant hard gates"
+      "description": "Top-level routing keeps playbook work as route-plus-boundary-plus-pointer instead of duplicating the manual.",
+      "section_includes": [
+        {
+          "file": "SKILL.md",
+          "heading": "Publication Layer: Playbook Creation Tree",
+          "label": "playbook route",
+          "includes": [
+            "Enter this branch only when the user wants a hosted/shareable surface",
+            "Read [playbook-creation.md](references/playbook-creation.md)",
+            "owns the build order, Browser-safe feed reads, README, draft/release gates, screenshot verification, tier/visibility flow, and push-after-release handoff",
+            "feed-first and live-read",
+            "Keep procedure, release, screenshot, and tier details in the owning references",
+            "Do not let every financial question inherit playbook gates"
+          ]
+        },
+        {
+          "file": "SKILL.md",
+          "heading": "Hosted Playbook Workflow",
+          "label": "common workflow",
+          "includes": [
+            "First choose the artifact shape",
+            "turn the request into a data contract before UI work",
+            "they own the procedure"
+          ]
+        },
+        {
+          "file": "SKILL.md",
+          "heading": "Final Sanity Checklist",
+          "label": "final checklist",
+          "includes": [
+            "Did playbook work read [playbook-creation.md](references/playbook-creation.md)",
+            "relevant hard gates"
+          ]
+        }
       ]
     },
     {

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -343,8 +343,10 @@
             "section_includes",
             "hard_gate_includes",
             "scenariosPath",
+            "mutation-smoke.mjs",
             "evaluateScenario",
             "scenarioAsCase",
+            "requirements.sections",
             "expected route",
             "extractMarkdownSection",
             "extractHardGate",
@@ -357,8 +359,25 @@
           "includes": [
             "prompt",
             "\"route\"",
+            "\"sections\"",
             "Capability Verification",
             "before-playbook-release"
+          ]
+        },
+        {
+          "file": "evals/alva-skill-docs/mutation-smoke.mjs",
+          "label": "mutation smoke",
+          "includes": [
+            "MUTATIONS",
+            "simple-latest-one-hop",
+            "scenario.simple-latest-price",
+            "capability-before-refusal",
+            "issue592.capability-verification-before-refusal",
+            "playbook-release-readme",
+            "before-playbook-release",
+            "udf-strict-opt-in",
+            "scenario.udf-strict-opt-in",
+            "expectFailedCases"
           ]
         }
       ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -333,7 +333,7 @@
       "id": "issue592.scoped-eval-checks",
       "group": "issue592",
       "target": "eval",
-      "description": "The eval runner can verify scoped behavior contracts instead of only corpus-wide string presence.",
+      "description": "The eval runner can verify scoped behavior and scenario contracts instead of only corpus-wide string presence.",
       "file_includes": [
         {
           "file": "evals/alva-skill-docs/skill-doc-eval.mjs",
@@ -342,9 +342,23 @@
             "file_includes",
             "section_includes",
             "hard_gate_includes",
+            "scenariosPath",
+            "evaluateScenario",
+            "scenarioAsCase",
+            "expected route",
             "extractMarkdownSection",
             "extractHardGate",
             "getFileText"
+          ]
+        },
+        {
+          "file": "evals/alva-skill-docs/scenarios.json",
+          "label": "scenarios",
+          "includes": [
+            "prompt",
+            "\"route\"",
+            "Capability Verification",
+            "before-playbook-release"
           ]
         }
       ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -330,12 +330,159 @@
       ]
     },
     {
+      "id": "issue592.scoped-eval-checks",
+      "group": "issue592",
+      "target": "eval",
+      "description": "The eval runner can verify scoped behavior contracts instead of only corpus-wide string presence.",
+      "file_includes": [
+        {
+          "file": "evals/alva-skill-docs/skill-doc-eval.mjs",
+          "label": "runner",
+          "includes": [
+            "file_includes",
+            "section_includes",
+            "hard_gate_includes",
+            "extractMarkdownSection",
+            "extractHardGate",
+            "getFileText"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "issue592.financial-ask-contract",
+      "group": "issue592",
+      "target": "corpus",
+      "description": "Financial Analysis / Ask Question remains a small answer route with fresh evidence, prose, and confidence gates instead of inheriting playbook workflow.",
+      "section_includes": [
+        {
+          "file": "references/request-routing.md",
+          "heading": "Routes",
+          "label": "answer route",
+          "includes": [
+            "Financial Analysis / Ask Question",
+            "fresh data/search/`alva run` evidence",
+            "Every answer must read [user-facing-prose.md](user-facing-prose.md)",
+            "ask evidence gate"
+          ]
+        },
+        {
+          "file": "references/request-routing.md",
+          "heading": "Guided Planning",
+          "label": "answer gate",
+          "includes": [
+            "decomposition",
+            "source path",
+            "coverage gaps",
+            "sourced-vs-inference boundary",
+            "Simple asks can satisfy the gate with one hop",
+            "Only complex judgment asks also pass the Complex Ask Router"
+          ]
+        },
+        {
+          "file": "SKILL.md",
+          "heading": "Financial Analysis / Ask Question Tree",
+          "label": "top-level route",
+          "includes": [
+            "It is not merely \"Data Query\"",
+            "data access and execution are steps inside an analysis answer",
+            "Simple latest-fact asks stop there after one sourced hop",
+            "Do not answer until you can name the decomposition"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "issue592.capability-verification-before-refusal",
+      "group": "issue592",
+      "target": "corpus",
+      "description": "Capability gaps are verified against live Alva surfaces and reduced-scope/BYOD fallbacks before the agent refuses.",
+      "section_includes": [
+        {
+          "file": "references/request-routing.md",
+          "heading": "Capability Verification",
+          "label": "before refusal",
+          "includes": [
+            "Before saying Alva lacks a capability",
+            "alva data-skills list | grep -i <topic>",
+            "Decompose compound asks",
+            "Never reject the whole as one unit from memory"
+          ]
+        },
+        {
+          "file": "references/data-skills.md",
+          "heading": "Failure And Fallback",
+          "label": "fallback behavior",
+          "includes": [
+            "same-domain Alva endpoints cannot answer the task",
+            "custom data source URL / BYOD source",
+            "Never stop with zero useful output",
+            "Never replace a missing data source with LLM-fabricated values"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "issue592.playbook-release-behavior",
+      "group": "issue592",
+      "target": "corpus",
+      "description": "Playbook release remains protected by behavior-level gates for feed freshness, live data reads, README, lint, and screenshot verification.",
+      "hard_gate_includes": [
+        {
+          "file": "references/playbook-creation.md",
+          "id": "before-playbook-release",
+          "label": "release gate",
+          "includes": [
+            "Every backing feed passed `before-feed-release`",
+            "HTML fetches quantitative data from feeds, not inline literals",
+            "Latest data from each referenced feed is fresh",
+            "README exists, is current, and is passed via absolute `--readme-url`",
+            "alva lint playbook ./index.html"
+          ]
+        }
+      ],
+      "section_includes": [
+        {
+          "file": "references/playbook-creation.md",
+          "heading": "Screenshot",
+          "label": "visual verification",
+          "includes": [
+            "A PNG or page shell is not enough",
+            "real feed-backed chart marks",
+            "headers-only tables",
+            "fetch failures are data-rendering failures"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "issue592.push-delivery-behavior",
+      "group": "issue592",
+      "target": "corpus",
+      "description": "Push setup is evaluated as a full delivery path instead of a single publisher flag.",
+      "section_includes": [
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Configure And Verify",
+          "label": "push setup",
+          "includes": [
+            "A push is set up only after all of these succeed",
+            "before-feed-release",
+            "alva deploy update --id <ID> --push-notify",
+            "alva subscriptions subscribe-feed",
+            "alva subscriptions subscribe-playbook",
+            "read `@last/1` of the sidecar",
+            "do not claim push is set up"
+          ]
+        }
+      ]
+    },
+    {
       "id": "target.top-level-size",
       "group": "target",
       "target": "skill",
-      "description": "Top-level SKILL.md is in the requested encyclopedia/guide size band.",
-      "max_lines": 850,
-      "min_lines": 650
+      "description": "Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.",
+      "max_lines": 850
     },
     {
       "id": "target.playbook-task-offload",

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/financial-ask-quality-gates/skills/alva`
+Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/behavioral-doc-eval/skills/alva`
 
-SKILL.md lines: 776
+SKILL.md lines: 780
 
-Cases: 31/31
+Cases: 47/47
 
-Checks: 253/253 (100.00%)
+Checks: 403/403 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -276,16 +276,110 @@ Review-discovered guardrails stay present in the skill corpus instead of only in
 - [x] 20%
 - [x] ~/library
 
+## issue591
+
+1/1 cases, 5/5 checks
+
+### PASS issue591.official-source-web-fallback
+
+When structured data lags a known official release, web is an official-source fallback and corroboration path rather than an automatic refusal.
+
+- [x] Structured Feed Lag
+- [x] domain-scoped search
+- [x] Alva's structured feed is not yet synced
+- [x] official-source stale-feed fallback
+- [x] Do not claim the value came from Data Skills
+
+## issue592
+
+5/5 cases, 52/52 checks
+
+### PASS issue592.scoped-eval-checks
+
+The eval runner can verify scoped behavior and scenario contracts instead of only corpus-wide string presence.
+
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes file_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes section_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes hard_gate_includes
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenariosPath
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes evaluateScenario
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenarioAsCase
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes expected route
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractMarkdownSection
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractHardGate
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes getFileText
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes prompt
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes "route"
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes Capability Verification
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes before-playbook-release
+
+### PASS issue592.financial-ask-contract
+
+Financial Analysis / Ask Question remains a small answer route with fresh evidence, prose, and confidence gates instead of inheriting playbook workflow.
+
+- [x] answer route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+- [x] answer route: references/request-routing.md#Routes includes fresh data/search/`alva run` evidence
+- [x] answer route: references/request-routing.md#Routes includes Every answer must read [user-facing-prose.md](user-facing-prose.md)
+- [x] answer route: references/request-routing.md#Routes includes ask evidence gate
+- [x] answer gate: references/request-routing.md#Guided Planning includes decomposition
+- [x] answer gate: references/request-routing.md#Guided Planning includes source path
+- [x] answer gate: references/request-routing.md#Guided Planning includes coverage gaps
+- [x] answer gate: references/request-routing.md#Guided Planning includes sourced-vs-inference boundary
+- [x] answer gate: references/request-routing.md#Guided Planning includes Simple asks can satisfy the gate with one hop
+- [x] answer gate: references/request-routing.md#Guided Planning includes Only complex judgment asks also pass the Complex Ask Router
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes It is not merely "Data Query"
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes data access and execution are steps inside an analysis answer
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes Simple latest-fact asks stop there after one sourced hop
+- [x] top-level route: SKILL.md#Financial Analysis / Ask Question Tree includes Do not answer until you can name the decomposition
+
+### PASS issue592.capability-verification-before-refusal
+
+Capability gaps are verified against live Alva surfaces and reduced-scope/BYOD fallbacks before the agent refuses.
+
+- [x] before refusal: references/request-routing.md#Capability Verification includes Before saying Alva lacks a capability
+- [x] before refusal: references/request-routing.md#Capability Verification includes alva data-skills list | grep -i <topic>
+- [x] before refusal: references/request-routing.md#Capability Verification includes Decompose compound asks
+- [x] before refusal: references/request-routing.md#Capability Verification includes Never reject the whole as one unit from memory
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes same-domain Alva endpoints cannot answer the task
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes custom data source URL / BYOD source
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never stop with zero useful output
+- [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never replace a missing data source with LLM-fabricated values
+
+### PASS issue592.playbook-release-behavior
+
+Playbook release remains protected by behavior-level gates for feed freshness, live data reads, README, lint, and screenshot verification.
+
+- [x] visual verification: references/playbook-creation.md#Screenshot includes A PNG or page shell is not enough
+- [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
+- [x] visual verification: references/playbook-creation.md#Screenshot includes headers-only tables
+- [x] visual verification: references/playbook-creation.md#Screenshot includes fetch failures are data-rendering failures
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes HTML fetches quantitative data from feeds, not inline literals
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Latest data from each referenced feed is fresh
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
+
+### PASS issue592.push-delivery-behavior
+
+Push setup is evaluated as a full delivery path instead of a single publisher flag.
+
+- [x] push setup: references/push-notifications.md#Configure And Verify includes A push is set up only after all of these succeed
+- [x] push setup: references/push-notifications.md#Configure And Verify includes before-feed-release
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva deploy update --id <ID> --push-notify
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-feed
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-playbook
+- [x] push setup: references/push-notifications.md#Configure And Verify includes read `@last/1` of the sidecar
+- [x] push setup: references/push-notifications.md#Configure And Verify includes do not claim push is set up
+
 ## target
 
-9/9 cases, 116/116 checks
+9/9 cases, 115/115 checks
 
 ### PASS target.top-level-size
 
-Top-level SKILL.md is in the requested encyclopedia/guide size band.
+Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count >= 650 (actual 776)
-- [x] line count <= 850 (actual 776)
+- [x] line count <= 850 (actual 780)
 
 ### PASS target.playbook-task-offload
 
@@ -418,7 +512,7 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.11.2
+- [x] version: v1.12.1
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
@@ -440,3 +534,195 @@ Latest mainline Alva skill updates remain integrated after rebasing the refactor
 - [x] real feed-backed chart marks
 - [x] headers-only tables
 - [x] fetch failures
+
+## scenarios.ask
+
+2/2 cases, 19/19 checks
+
+### PASS scenario.simple-latest-price
+
+A simple latest-fact ask stays in Financial Analysis, uses fresh sourced evidence, and does not inherit playbook gates.
+
+Prompt: `What is BTC doing right now?`
+
+- [x] Simple latest-fact asks stop there after one sourced hop
+- [x] user-facing-prose.md
+- [x] content-legitimacy.md
+- [x] Direct latest price for covered US equities and crypto: intraday klines, not daily close
+- [x] Do not answer until you can name the decomposition
+- [x] Do not let playbook creation become the default
+- [x] not automatically to a playbook
+- [x] expected route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+
+### PASS scenario.complex-valuation-ask
+
+A complex valuation ask uses the ask evidence gate plus Complex Ask Router without becoming a playbook by default.
+
+Prompt: `Is NVDA cheap versus peers after the latest earnings revision?`
+
+- [x] request-routing.md
+- [x] user-facing-prose.md
+- [x] fundamentals-periods.md
+- [x] Complex Ask Router
+- [x] valuation/accounting
+- [x] comparison baselines are financial facts
+- [x] current multiple/FCF/EPS
+- [x] multiple/earnings sensitivity
+- [x] cap confidence when required evidence
+- [x] not automatically to a playbook
+- [x] expected route: references/request-routing.md#Routes includes Financial Analysis / Ask Question
+
+## scenarios.capability
+
+1/1 cases, 8/8 checks
+
+### PASS scenario.capability-gap-before-refusal
+
+A capability-gap question verifies live coverage before saying no or moving to BYOD.
+
+Prompt: `Does Alva have darkpool L2 realtime data?`
+
+- [x] data-skills.md
+- [x] search.md
+- [x] Before saying Alva lacks a capability
+- [x] alva data-skills list | grep -i <topic>
+- [x] Decompose compound asks
+- [x] Never reject the whole as one unit from memory
+- [x] custom data source URL / BYOD source
+- [x] expected route: references/request-routing.md#Routes includes Capability Verification
+
+## scenarios.playbook
+
+3/3 cases, 31/31 checks
+
+### PASS scenario.dashboard-playbook-build
+
+A hosted dashboard enters the Playbook Creation route and preserves feed-first, live-read, README, lint, release, and screenshot gates.
+
+Prompt: `Build and publish a live dashboard for BTC dominance breakouts.`
+
+- [x] Publication Layer: Playbook Creation Tree
+- [x] playbook-creation.md
+- [x] feed-lifecycle.md
+- [x] design.md
+- [x] api/release.md
+- [x] AlvaToolkit.AlvaClient
+- [x] Build live feeds first
+- [x] HTML fetches quantitative data from feeds, not inline literals
+- [x] Every release needs a current README
+- [x] screenshot verification must show real feed-backed marks
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
+
+### PASS scenario.remix-existing-playbook
+
+A remix reads source artifacts and preserves lineage instead of regenerating from memory.
+
+Prompt: `<remix https://alva.ai/u/alva/playbooks/screener> make my own version`
+
+- [x] Playbook Subroute: Remix
+- [x] remix-workflow.md
+- [x] playbook-creation.md
+- [x] Extract source owner/name from the tag URL
+- [x] read the source feed scripts, HTML, README, and playbook metadata
+- [x] preserve them unless the user explicitly asks otherwise
+- [x] Do not regenerate from memory
+- [x] expected route: references/request-routing.md#Routes includes Debug / Edit
+
+### PASS scenario.annotation-edit
+
+An annotation edit changes the generator behind the element and re-enters HTML gates.
+
+Prompt: `<annotation id="hero-title">make this chart title shorter</annotation>`
+
+- [x] Playbook Subroute: Annotation Edits
+- [x] annotation-edits.md
+- [x] playbook-creation.md
+- [x] change the generator behind the selected element
+- [x] Never freeze rendered feed values into static text
+- [x] HTML edits re-enter `before-build-html`
+- [x] expected route: references/request-routing.md#Routes includes Debug / Edit
+- [x] html gate: references/playbook-creation.md<HARD-GATE:before-build-html> includes The HTML follows the Browser request rule
+- [x] html gate: references/playbook-creation.md<HARD-GATE:before-build-html> includes Do not rely on memory of prior sessions
+
+## scenarios.push
+
+1/1 cases, 9/9 checks
+
+### PASS scenario.alert-push-monitor
+
+A monitoring request routes to Automation / Push and validates sidecar, release, subscription, and real-run delivery.
+
+Prompt: `Track BTC dominance and notify me when it breaks out.`
+
+- [x] push-notifications.md
+- [x] feed-lifecycle.md
+- [x] Build or modify a feed that emits actionable `signal/targets` or `notify/message`
+- [x] A push is set up only after all of these succeed
+- [x] alva deploy update --id <ID> --push-notify
+- [x] alva subscriptions subscribe-feed
+- [x] read `@last/1` of the sidecar
+- [x] do not claim push is set up
+- [x] expected route: references/request-routing.md#Routes includes Automation / Push
+
+## scenarios.strategy
+
+1/1 cases, 8/8 checks
+
+### PASS scenario.backtest-strategy
+
+A backtest routes through Strategy / Trading Analysis and requires Altra instead of hand-rolled loops.
+
+Prompt: `Backtest a weekly NVDA momentum strategy and show drawdowns.`
+
+- [x] altra-trading.md
+- [x] api/trading.md
+- [x] Always use Altra for backtesting
+- [x] FeedAltra
+- [x] look-ahead bias
+- [x] drawdown
+- [x] package results as a concise answer, feed, signal, or visual playbook depending on the request
+- [x] expected route: references/request-routing.md#Routes includes Strategy / Trading Analysis
+
+## scenarios.skillhub
+
+1/1 cases, 10/10 checks
+
+### PASS scenario.skillhub-method
+
+A Skillhub directive fetches the blueprint fresh, avoids bulk download, and only becomes a playbook if the user or blueprint asks.
+
+Prompt: `/use-skill:alva/thesis NVDA AI capex read-through`
+
+- [x] request-routing.md
+- [x] playbook-creation.md
+- [x] api/release.md
+- [x] If the user's message contains `/use-skill:<username>/<name>`, the Skillhub path is mandatory
+- [x] alva skillhub get
+- [x] alva skillhub file
+- [x] Do not bulk-download
+- [x] Do not turn every Skillhub task into a playbook
+- [x] --skill-id <username>/<name>
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+
+## scenarios.udf
+
+1/1 cases, 9/9 checks
+
+### PASS scenario.udf-strict-opt-in
+
+A UDF request is explicit opt-in and routes to the PBSV/browser runtime and functions CLI checks.
+
+Prompt: `Add a button so viewers can run my custom analysis function.`
+
+- [x] api/udf-runtime.md
+- [x] playbook-creation.md
+- [x] User-Defined Functions are strict opt-in
+- [x] registerable/shareable interactive function
+- [x] window.alva.udf
+- [x] alva functions
+- [x] allowance consent
+- [x] Never hand-write bearer headers
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -6,7 +6,7 @@ SKILL.md lines: 780
 
 Cases: 47/47
 
-Checks: 403/403 (100.00%)
+Checks: 416/416 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -292,7 +292,7 @@ When structured data lags a known official release, web is an official-source fa
 
 ## issue592
 
-5/5 cases, 52/52 checks
+5/5 cases, 65/65 checks
 
 ### PASS issue592.scoped-eval-checks
 
@@ -302,16 +302,29 @@ The eval runner can verify scoped behavior and scenario contracts instead of onl
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes section_includes
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes hard_gate_includes
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenariosPath
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes mutation-smoke.mjs
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes evaluateScenario
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes scenarioAsCase
+- [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes requirements.sections
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes expected route
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractMarkdownSection
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes extractHardGate
 - [x] runner: evals/alva-skill-docs/skill-doc-eval.mjs includes getFileText
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes prompt
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes "route"
+- [x] scenarios: evals/alva-skill-docs/scenarios.json includes "sections"
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes Capability Verification
 - [x] scenarios: evals/alva-skill-docs/scenarios.json includes before-playbook-release
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes MUTATIONS
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes simple-latest-one-hop
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes scenario.simple-latest-price
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes capability-before-refusal
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes issue592.capability-verification-before-refusal
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes playbook-release-readme
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes before-playbook-release
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes udf-strict-opt-in
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes scenario.udf-strict-opt-in
+- [x] mutation smoke: evals/alva-skill-docs/mutation-smoke.mjs includes expectFailedCases
 
 ### PASS issue592.financial-ask-contract
 
@@ -584,12 +597,12 @@ Prompt: `Does Alva have darkpool L2 realtime data?`
 
 - [x] data-skills.md
 - [x] search.md
-- [x] Before saying Alva lacks a capability
-- [x] alva data-skills list | grep -i <topic>
-- [x] Decompose compound asks
-- [x] Never reject the whole as one unit from memory
 - [x] custom data source URL / BYOD source
 - [x] expected route: references/request-routing.md#Routes includes Capability Verification
+- [x] before refusal: references/request-routing.md#Capability Verification includes Before saying Alva lacks a capability
+- [x] before refusal: references/request-routing.md#Capability Verification includes alva data-skills list | grep -i <topic>
+- [x] before refusal: references/request-routing.md#Capability Verification includes Decompose compound asks
+- [x] before refusal: references/request-routing.md#Capability Verification includes Never reject the whole as one unit from memory
 
 ## scenarios.playbook
 

--- a/evals/alva-skill-docs/llm-scenario-trace.mjs
+++ b/evals/alva-skill-docs/llm-scenario-trace.mjs
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "../..");
+const DEFAULT_SCENARIOS = resolve(SCRIPT_DIR, "scenarios.json");
+const DEFAULT_SKILL_DIR = resolve(REPO_ROOT, "skills/alva");
+const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
+
+const ROUTE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["route", "references_to_read", "rationale"],
+  properties: {
+    route: { type: "string" },
+    references_to_read: { type: "array", items: { type: "string" } },
+    rationale: { type: "string" },
+  },
+};
+
+const TRACE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "route",
+    "references_to_read",
+    "gates_to_satisfy",
+    "actions",
+    "boundaries",
+    "forbidden_actions",
+    "quoted_contracts",
+    "confidence",
+    "rationale",
+  ],
+  properties: {
+    route: { type: "string" },
+    references_to_read: { type: "array", items: { type: "string" } },
+    gates_to_satisfy: { type: "array", items: { type: "string" } },
+    actions: { type: "array", items: { type: "string" } },
+    boundaries: { type: "array", items: { type: "string" } },
+    forbidden_actions: { type: "array", items: { type: "string" } },
+    quoted_contracts: { type: "array", items: { type: "string" } },
+    confidence: { type: "string", enum: ["high", "medium", "low"] },
+    rationale: { type: "string" },
+  },
+};
+
+function parseArgs(argv) {
+  const opts = {
+    scenariosPath: DEFAULT_SCENARIOS,
+    skillDir: DEFAULT_SKILL_DIR,
+    out: null,
+    jsonOut: null,
+    model: process.env.ALVA_SKILL_LLM_EVAL_MODEL ?? "",
+    apiKey: process.env.OPENAI_API_KEY ?? "",
+    scenarioIds: [],
+    limit: null,
+    selfTest: false,
+    skipWithoutConfig: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--scenarios") {
+      opts.scenariosPath = resolve(argv[++i]);
+    } else if (arg === "--skill-dir") {
+      opts.skillDir = resolve(argv[++i]);
+    } else if (arg === "--out") {
+      opts.out = resolve(argv[++i]);
+    } else if (arg === "--json-out") {
+      opts.jsonOut = resolve(argv[++i]);
+    } else if (arg === "--model") {
+      opts.model = argv[++i];
+    } else if (arg === "--scenario") {
+      opts.scenarioIds.push(argv[++i]);
+    } else if (arg === "--limit") {
+      opts.limit = Number.parseInt(argv[++i], 10);
+    } else if (arg === "--self-test") {
+      opts.selfTest = true;
+    } else if (arg === "--skip-without-config") {
+      opts.skipWithoutConfig = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: node evals/alva-skill-docs/llm-scenario-trace.mjs [options]
+
+Options:
+  --skill-dir <path>         Skill directory. Default: skills/alva.
+  --scenarios <path>         Scenario manifest. Default: evals/alva-skill-docs/scenarios.json.
+  --out <path>               Write markdown report.
+  --json-out <path>          Write raw trace/check JSON.
+  --model <model>            OpenAI model. Defaults to ALVA_SKILL_LLM_EVAL_MODEL.
+  --scenario <id>            Run one scenario. Repeatable.
+  --limit <n>                Limit scenario count after filtering.
+  --self-test                Do not call an LLM; validate checker with synthetic passing traces.
+  --skip-without-config      Exit 0 with a skipped report if OPENAI_API_KEY or model is missing.
+  -h, --help                 Show this help.
+`);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function ensureParent(path) {
+  mkdirSync(dirname(path), { recursive: true });
+}
+
+function listFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) out.push(...listFiles(path));
+    else out.push(path);
+  }
+  return out;
+}
+
+function normalizePath(path) {
+  return path.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^skills\/alva\//, "");
+}
+
+function normalizeText(text) {
+  return String(text).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function normalizeRef(ref) {
+  return normalizePath(String(ref))
+    .replace(/^references\//, "")
+    .replace(/^skills\/alva\/references\//, "")
+    .replace(/^\.\/references\//, "")
+    .toLowerCase();
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function loadSkillCorpus(skillDir) {
+  const skillPath = resolve(skillDir, "SKILL.md");
+  if (!existsSync(skillPath)) throw new Error(`No SKILL.md at ${skillPath}`);
+
+  const referencesDir = resolve(skillDir, "references");
+  const referenceFiles = listFiles(referencesDir)
+    .filter((path) => /\.(md|yaml|css)$/.test(path))
+    .sort();
+  const references = new Map();
+  for (const path of referenceFiles) {
+    const key = normalizePath(relative(skillDir, path));
+    references.set(key, readFileSync(path, "utf8"));
+  }
+
+  return {
+    skill: readFileSync(skillPath, "utf8"),
+    references,
+    referenceList: [...references.keys()],
+  };
+}
+
+function filterScenarios(manifest, opts) {
+  let scenarios = manifest.scenarios ?? [];
+  if (opts.scenarioIds.length > 0) {
+    const wanted = new Set(opts.scenarioIds);
+    scenarios = scenarios.filter((scenario) => wanted.has(scenario.id));
+  }
+  if (Number.isInteger(opts.limit) && opts.limit >= 0) {
+    scenarios = scenarios.slice(0, opts.limit);
+  }
+  return scenarios;
+}
+
+function makeRoutePrompt(corpus, scenario) {
+  return [
+    "You are acting as the Alva skill routing layer. Use only the supplied skill text.",
+    "Do not execute tools. Do not answer the user's finance question.",
+    "Choose the route and the reference files a careful agent should read next.",
+    "Return only the requested structured trace.",
+    "",
+    "# User prompt",
+    scenario.prompt,
+    "",
+    "# Available references",
+    corpus.referenceList.map((file) => `- ${file}`).join("\n"),
+    "",
+    "# SKILL.md",
+    corpus.skill,
+  ].join("\n");
+}
+
+function refKeyForOutput(corpus, ref) {
+  const wanted = normalizeRef(ref);
+  return corpus.referenceList.find((file) => {
+    const normalized = normalizeRef(file);
+    return normalized === wanted || normalized.endsWith(`/${wanted}`) || wanted.endsWith(normalized);
+  });
+}
+
+function selectedReferenceBundle(corpus, refs) {
+  const keys = unique(["references/request-routing.md", ...refs.map((ref) => refKeyForOutput(corpus, ref))]);
+  return keys
+    .filter((key) => key && corpus.references.has(key))
+    .map((key) => {
+      const body = corpus.references.get(key);
+      return `\n\n--- ${key} ---\n${body}`;
+    })
+    .join("");
+}
+
+function makeTracePrompt(corpus, scenario, routeTrace) {
+  return [
+    "You are acting as the Alva skill after its first routing pass.",
+    "Use only the supplied SKILL.md and reference excerpts. Do not execute tools.",
+    "Produce the next-step trace a careful agent would follow.",
+    "For quoted_contracts, copy exact short phrases from the supplied docs that govern the route, gates, actions, and boundaries.",
+    "Do not include phrases you cannot find in the supplied docs.",
+    "",
+    "# User prompt",
+    scenario.prompt,
+    "",
+    "# First-pass route trace",
+    JSON.stringify(routeTrace, null, 2),
+    "",
+    "# SKILL.md",
+    corpus.skill,
+    "",
+    "# Reference excerpts selected by the first-pass trace",
+    selectedReferenceBundle(corpus, routeTrace.references_to_read ?? []),
+  ].join("\n");
+}
+
+async function callResponsesApi(opts, schemaName, schema, prompt) {
+  const response = await fetch(OPENAI_RESPONSES_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${opts.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: opts.model,
+      store: false,
+      input: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: schemaName,
+          strict: true,
+          schema,
+        },
+      },
+    }),
+  });
+
+  const bodyText = await response.text();
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    body = null;
+  }
+
+  if (!response.ok) {
+    const message = body?.error?.message ?? bodyText;
+    throw new Error(`OpenAI Responses API failed (${response.status}): ${message}`);
+  }
+
+  const outputText = extractOutputText(body);
+  if (!outputText) {
+    throw new Error("OpenAI Responses API returned no output_text content.");
+  }
+  return JSON.parse(outputText);
+}
+
+function extractOutputText(responseBody) {
+  if (typeof responseBody?.output_text === "string") return responseBody.output_text;
+  const parts = [];
+  for (const item of responseBody?.output ?? []) {
+    for (const content of item.content ?? []) {
+      if (content.type === "output_text" && typeof content.text === "string") {
+        parts.push(content.text);
+      }
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+function syntheticTrace(scenario) {
+  const expect = scenario.expect ?? {};
+  const gates = (expect.gates ?? []).map((gate) => gate.id ?? gate.heading).filter(Boolean);
+  const quoted = [
+    expect.top_level_route,
+    ...(expect.behaviors ?? []),
+    ...(expect.forbidden_behaviors ?? []),
+    ...(expect.sections ?? []).flatMap((section) => section.includes ?? []),
+    ...(expect.gates ?? []).flatMap((gate) => [gate.id, ...(gate.includes ?? [])]),
+  ];
+
+  return {
+    route: expect.route ?? "",
+    references_to_read: expect.references ?? [],
+    gates_to_satisfy: gates,
+    actions: expect.behaviors ?? [],
+    boundaries: expect.forbidden_behaviors ?? [],
+    forbidden_actions: expect.forbidden_behaviors ?? [],
+    quoted_contracts: unique(quoted),
+    confidence: "high",
+    rationale: "Synthetic self-test trace generated from scenario expectations.",
+  };
+}
+
+function traceText(trace) {
+  return normalizeText(JSON.stringify(trace));
+}
+
+function hasRef(refs, expected) {
+  const normalizedRefs = refs.map(normalizeRef);
+  const wanted = normalizeRef(expected);
+  return normalizedRefs.some(
+    (ref) => ref === wanted || ref.endsWith(`/${wanted}`) || wanted.endsWith(`/${ref}`),
+  );
+}
+
+function hasText(trace, expected) {
+  return traceText(trace).includes(normalizeText(expected));
+}
+
+function pushCheck(checks, label, pass, detail = "") {
+  checks.push({ label, pass, detail });
+}
+
+function evaluateTrace(scenario, trace) {
+  const expect = scenario.expect ?? {};
+  const checks = [];
+
+  if (expect.route) {
+    pushCheck(checks, `route is ${expect.route}`, normalizeText(trace.route) === normalizeText(expect.route), trace.route);
+  }
+
+  for (const ref of expect.references ?? []) {
+    pushCheck(checks, `references include ${ref}`, hasRef(trace.references_to_read ?? [], ref), (trace.references_to_read ?? []).join(", "));
+  }
+
+  if (expect.top_level_route) {
+    pushCheck(checks, `trace cites ${expect.top_level_route}`, hasText(trace, expect.top_level_route));
+  }
+
+  for (const behavior of expect.behaviors ?? []) {
+    pushCheck(checks, `trace cites ${behavior}`, hasText(trace, behavior));
+  }
+
+  for (const forbidden of expect.forbidden_behaviors ?? []) {
+    pushCheck(checks, `trace preserves boundary ${forbidden}`, hasText(trace, forbidden));
+  }
+
+  for (const section of expect.sections ?? []) {
+    for (const phrase of section.includes ?? []) {
+      pushCheck(checks, `trace cites ${section.file}#${section.heading}: ${phrase}`, hasText(trace, phrase));
+    }
+  }
+
+  for (const gate of expect.gates ?? []) {
+    const gateName = gate.id ?? gate.heading;
+    if (gateName) {
+      pushCheck(checks, `gates include ${gateName}`, hasText(trace.gates_to_satisfy ?? [], gateName) || hasText(trace, gateName));
+    }
+    for (const phrase of gate.includes ?? []) {
+      pushCheck(checks, `trace cites ${gateName}: ${phrase}`, hasText(trace, phrase));
+    }
+  }
+
+  const passed = checks.filter((check) => check.pass).length;
+  return {
+    id: scenario.id,
+    group: scenario.group ?? "scenarios",
+    prompt: scenario.prompt,
+    ok: passed === checks.length,
+    passed,
+    total: checks.length,
+    checks,
+    trace,
+  };
+}
+
+async function runScenario(opts, corpus, scenario) {
+  if (opts.selfTest) {
+    return evaluateTrace(scenario, syntheticTrace(scenario));
+  }
+
+  const routeTrace = await callResponsesApi(opts, "alva_skill_route_trace", ROUTE_SCHEMA, makeRoutePrompt(corpus, scenario));
+  const trace = await callResponsesApi(opts, "alva_skill_scenario_trace", TRACE_SCHEMA, makeTracePrompt(corpus, scenario, routeTrace));
+  trace.route_stage = routeTrace;
+  return evaluateTrace(scenario, trace);
+}
+
+function renderReport({ manifest, sourceLabel, model, results, skippedReason }) {
+  const now = new Date().toISOString();
+  let out = `# ${manifest.name} LLM Trace Eval\n\n`;
+  out += `Generated: ${now}\n\n`;
+  out += `Source: \`${sourceLabel}\`\n\n`;
+  out += `Model: \`${model || "not configured"}\`\n\n`;
+
+  if (skippedReason) {
+    out += `Status: skipped\n\nReason: ${skippedReason}\n`;
+    return out;
+  }
+
+  const passedCases = results.filter((result) => result.ok).length;
+  const totalChecks = results.reduce((sum, result) => sum + result.total, 0);
+  const passedChecks = results.reduce((sum, result) => sum + result.passed, 0);
+  const pct = totalChecks === 0 ? 100 : (passedChecks / totalChecks) * 100;
+  out += `Cases: ${passedCases}/${results.length}\n\n`;
+  out += `Checks: ${passedChecks}/${totalChecks} (${pct.toFixed(2)}%)\n\n`;
+  out += "This is a periodic LLM-as-actor diagnostic. The checker is deterministic, but the actor may vary by model and date; inspect failures before editing docs.\n\n";
+
+  for (const result of results) {
+    out += `## ${result.ok ? "PASS" : "FAIL"} ${result.id}\n\n`;
+    out += `Prompt: \`${result.prompt}\`\n\n`;
+    out += `Route: \`${result.trace.route}\`\n\n`;
+    out += `References: ${(result.trace.references_to_read ?? []).map((ref) => `\`${ref}\``).join(", ") || "(none)"}\n\n`;
+    for (const check of result.checks) {
+      out += `- ${check.pass ? "[x]" : "[ ]"} ${check.label}`;
+      if (!check.pass && check.detail) out += ` (actual: ${check.detail})`;
+      out += "\n";
+    }
+    out += "\n";
+  }
+
+  return out;
+}
+
+function writeOutputs(opts, report, payload) {
+  if (opts.out) {
+    ensureParent(opts.out);
+    writeFileSync(opts.out, report, "utf8");
+  }
+  if (opts.jsonOut) {
+    ensureParent(opts.jsonOut);
+    writeFileSync(opts.jsonOut, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const manifest = readJson(opts.scenariosPath);
+  const scenarios = filterScenarios(manifest, opts);
+  const sourceLabel = opts.selfTest ? "synthetic self-test" : opts.skillDir;
+
+  if (!opts.selfTest && (!opts.apiKey || !opts.model)) {
+    const missing = [!opts.apiKey ? "OPENAI_API_KEY" : "", !opts.model ? "ALVA_SKILL_LLM_EVAL_MODEL or --model" : ""]
+      .filter(Boolean)
+      .join(" and ");
+    if (opts.skipWithoutConfig) {
+      const payload = { skipped: true, missing, results: [] };
+      const report = renderReport({ manifest, sourceLabel, model: opts.model, results: [], skippedReason: `Missing ${missing}.` });
+      writeOutputs(opts, report, payload);
+      process.stdout.write(report);
+      return;
+    }
+    throw new Error(`Missing ${missing}.`);
+  }
+
+  const corpus = loadSkillCorpus(opts.skillDir);
+  const results = [];
+  for (const scenario of scenarios) {
+    results.push(await runScenario(opts, corpus, scenario));
+  }
+
+  const payload = {
+    model: opts.model,
+    source: sourceLabel,
+    self_test: opts.selfTest,
+    results,
+  };
+  const report = renderReport({ manifest, sourceLabel, model: opts.model, results });
+  writeOutputs(opts, report, payload);
+  process.stdout.write(report);
+  if (results.some((result) => !result.ok)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? String(error));
+  process.exitCode = 1;
+});

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "../..");
+const EVAL_RUNNER = resolve(SCRIPT_DIR, "skill-doc-eval.mjs");
+const DEFAULT_SKILL_DIR = resolve(REPO_ROOT, "skills/alva");
+
+const MUTATIONS = [
+  {
+    id: "simple-latest-one-hop",
+    file: "SKILL.md",
+    remove: "Simple latest-fact asks stop there after one\nsourced hop; ",
+    expectFailedCases: ["issue592.financial-ask-contract", "scenario.simple-latest-price"],
+  },
+  {
+    id: "capability-before-refusal",
+    file: "references/request-routing.md",
+    remove: "Before saying Alva lacks a capability or recommending BYOD, verify the catalog:",
+    expectFailedCases: [
+      "issue592.capability-verification-before-refusal",
+      "scenario.capability-gap-before-refusal",
+    ],
+  },
+  {
+    id: "before-playbook-release-readme",
+    file: "references/playbook-creation.md",
+    remove: "9. README exists, is current, and is passed via absolute `--readme-url`.\n",
+    expectFailedCases: ["issue592.playbook-release-behavior", "scenario.dashboard-playbook-build"],
+  },
+  {
+    id: "udf-strict-opt-in",
+    file: "references/playbook-creation.md",
+    remove: "User-Defined Functions are strict opt-in. ",
+    expectFailedCases: ["scenario.udf-strict-opt-in"],
+  },
+];
+
+function parseArgs(argv) {
+  const opts = {
+    skillDir: DEFAULT_SKILL_DIR,
+    keepTemp: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--skill-dir") {
+      opts.skillDir = resolve(argv[++i]);
+    } else if (arg === "--keep-temp") {
+      opts.keepTemp = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: node evals/alva-skill-docs/mutation-smoke.mjs [options]
+
+Options:
+  --skill-dir <path>   Skill directory to copy and mutate. Default: skills/alva.
+  --keep-temp          Keep mutated temporary copies for debugging.
+  -h, --help           Show this help.
+`);
+}
+
+function runEval(skillDir) {
+  const result = spawnSync(process.execPath, [EVAL_RUNNER, "--skill-dir", skillDir], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    output: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+  };
+}
+
+function replaceOnce(filePath, needle) {
+  const original = readFileSync(filePath, "utf8");
+  if (!original.includes(needle)) {
+    throw new Error(`Mutation target not found in ${filePath}: ${JSON.stringify(needle)}`);
+  }
+  writeFileSync(filePath, original.replace(needle, ""), "utf8");
+}
+
+function copySkill(sourceSkillDir, tempRoot, mutationId) {
+  const target = join(tempRoot, mutationId, "alva");
+  cpSync(sourceSkillDir, target, { recursive: true });
+  return target;
+}
+
+function assertEvalGreen(sourceSkillDir) {
+  const result = runEval(sourceSkillDir);
+  if (result.status !== 0) {
+    process.stderr.write(result.output);
+    throw new Error("Base skill eval must pass before mutation smoke can prove failures.");
+  }
+}
+
+function assertMutationFails(sourceSkillDir, tempRoot, mutation) {
+  const mutatedSkillDir = copySkill(sourceSkillDir, tempRoot, mutation.id);
+  replaceOnce(resolve(mutatedSkillDir, mutation.file), mutation.remove);
+
+  const result = runEval(mutatedSkillDir);
+  if (result.status === 0) {
+    throw new Error(`${mutation.id}: eval unexpectedly passed after removing ${mutation.file}`);
+  }
+
+  const missingExpectedCases = mutation.expectFailedCases.filter(
+    (caseId) => !result.output.includes(`FAIL ${caseId}`),
+  );
+  if (missingExpectedCases.length > 0) {
+    process.stderr.write(result.output);
+    throw new Error(
+      `${mutation.id}: eval failed, but not through expected cases: ${missingExpectedCases.join(", ")}`,
+    );
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const tempRoot = mkdtempSync(join(tmpdir(), "alva-skill-doc-mutations-"));
+
+  try {
+    assertEvalGreen(opts.skillDir);
+    for (const mutation of MUTATIONS) {
+      assertMutationFails(opts.skillDir, tempRoot, mutation);
+      console.log(`PASS ${mutation.id}`);
+    }
+    console.log(`Mutation smoke passed: ${MUTATIONS.length}/${MUTATIONS.length} mutations failed as expected.`);
+  } finally {
+    if (opts.keepTemp) {
+      console.log(`Kept temporary mutation copies at ${tempRoot}`);
+    } else {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main();

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -62,11 +62,20 @@
           "search.md"
         ],
         "behaviors": [
-          "Before saying Alva lacks a capability",
-          "alva data-skills list | grep -i <topic>",
-          "Decompose compound asks",
-          "Never reject the whole as one unit from memory",
           "custom data source URL / BYOD source"
+        ],
+        "sections": [
+          {
+            "file": "references/request-routing.md",
+            "heading": "Capability Verification",
+            "label": "before refusal",
+            "includes": [
+              "Before saying Alva lacks a capability",
+              "alva data-skills list | grep -i <topic>",
+              "Decompose compound asks",
+              "Never reject the whole as one unit from memory"
+            ]
+          }
         ]
       }
     },

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -1,0 +1,245 @@
+{
+  "schema_version": "2026-06-11",
+  "name": "alva-skill-scenario-routing",
+  "description": "Deterministic prompt-intent contracts for Alva skill routing. These scenarios do not call an LLM; they bind representative user prompts to the route, references, gates, and boundaries the skill docs must preserve.",
+  "scenarios": [
+    {
+      "id": "scenario.simple-latest-price",
+      "group": "scenarios.ask",
+      "prompt": "What is BTC doing right now?",
+      "description": "A simple latest-fact ask stays in Financial Analysis, uses fresh sourced evidence, and does not inherit playbook gates.",
+      "expect": {
+        "route": "Financial Analysis / Ask Question",
+        "top_level_route": "Simple latest-fact asks stop there after one sourced hop",
+        "references": [
+          "user-facing-prose.md",
+          "content-legitimacy.md"
+        ],
+        "behaviors": [
+          "Direct latest price for covered US equities and crypto: intraday klines, not daily close",
+          "Do not answer until you can name the decomposition",
+          "Do not let playbook creation become the default"
+        ],
+        "forbidden_behaviors": [
+          "not automatically to a playbook"
+        ]
+      }
+    },
+    {
+      "id": "scenario.complex-valuation-ask",
+      "group": "scenarios.ask",
+      "prompt": "Is NVDA cheap versus peers after the latest earnings revision?",
+      "description": "A complex valuation ask uses the ask evidence gate plus Complex Ask Router without becoming a playbook by default.",
+      "expect": {
+        "route": "Financial Analysis / Ask Question",
+        "references": [
+          "request-routing.md",
+          "user-facing-prose.md",
+          "fundamentals-periods.md"
+        ],
+        "behaviors": [
+          "Complex Ask Router",
+          "valuation/accounting",
+          "comparison baselines are financial facts",
+          "current multiple/FCF/EPS",
+          "multiple/earnings sensitivity",
+          "cap confidence when required evidence"
+        ],
+        "forbidden_behaviors": [
+          "not automatically to a playbook"
+        ]
+      }
+    },
+    {
+      "id": "scenario.capability-gap-before-refusal",
+      "group": "scenarios.capability",
+      "prompt": "Does Alva have darkpool L2 realtime data?",
+      "description": "A capability-gap question verifies live coverage before saying no or moving to BYOD.",
+      "expect": {
+        "route": "Capability Verification",
+        "references": [
+          "data-skills.md",
+          "search.md"
+        ],
+        "behaviors": [
+          "Before saying Alva lacks a capability",
+          "alva data-skills list | grep -i <topic>",
+          "Decompose compound asks",
+          "Never reject the whole as one unit from memory",
+          "custom data source URL / BYOD source"
+        ]
+      }
+    },
+    {
+      "id": "scenario.dashboard-playbook-build",
+      "group": "scenarios.playbook",
+      "prompt": "Build and publish a live dashboard for BTC dominance breakouts.",
+      "description": "A hosted dashboard enters the Playbook Creation route and preserves feed-first, live-read, README, lint, release, and screenshot gates.",
+      "expect": {
+        "route": "Playbook Creation",
+        "top_level_route": "Publication Layer: Playbook Creation Tree",
+        "references": [
+          "playbook-creation.md",
+          "feed-lifecycle.md",
+          "design.md",
+          "api/release.md",
+          "AlvaToolkit.AlvaClient"
+        ],
+        "behaviors": [
+          "Build live feeds first",
+          "HTML fetches quantitative data from feeds, not inline literals",
+          "Every release needs a current README",
+          "screenshot verification must show real feed-backed marks"
+        ],
+        "gates": [
+          {
+            "type": "hard_gate",
+            "file": "references/playbook-creation.md",
+            "id": "before-playbook-release",
+            "label": "playbook release",
+            "includes": [
+              "Every backing feed passed `before-feed-release`",
+              "README exists, is current, and is passed via absolute `--readme-url`",
+              "alva lint playbook ./index.html"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "scenario.alert-push-monitor",
+      "group": "scenarios.push",
+      "prompt": "Track BTC dominance and notify me when it breaks out.",
+      "description": "A monitoring request routes to Automation / Push and validates sidecar, release, subscription, and real-run delivery.",
+      "expect": {
+        "route": "Automation / Push",
+        "references": [
+          "push-notifications.md",
+          "feed-lifecycle.md"
+        ],
+        "behaviors": [
+          "Build or modify a feed that emits actionable `signal/targets` or `notify/message`",
+          "A push is set up only after all of these succeed",
+          "alva deploy update --id <ID> --push-notify",
+          "alva subscriptions subscribe-feed",
+          "read `@last/1` of the sidecar",
+          "do not claim push is set up"
+        ]
+      }
+    },
+    {
+      "id": "scenario.backtest-strategy",
+      "group": "scenarios.strategy",
+      "prompt": "Backtest a weekly NVDA momentum strategy and show drawdowns.",
+      "description": "A backtest routes through Strategy / Trading Analysis and requires Altra instead of hand-rolled loops.",
+      "expect": {
+        "route": "Strategy / Trading Analysis",
+        "references": [
+          "altra-trading.md",
+          "api/trading.md"
+        ],
+        "behaviors": [
+          "Always use Altra for backtesting",
+          "FeedAltra",
+          "look-ahead bias",
+          "drawdown",
+          "package results as a concise answer, feed, signal, or visual playbook depending on the request"
+        ]
+      }
+    },
+    {
+      "id": "scenario.skillhub-method",
+      "group": "scenarios.skillhub",
+      "prompt": "/use-skill:alva/thesis NVDA AI capex read-through",
+      "description": "A Skillhub directive fetches the blueprint fresh, avoids bulk download, and only becomes a playbook if the user or blueprint asks.",
+      "expect": {
+        "route": "Playbook Creation",
+        "references": [
+          "request-routing.md",
+          "playbook-creation.md",
+          "api/release.md"
+        ],
+        "behaviors": [
+          "If the user's message contains `/use-skill:<username>/<name>`, the Skillhub path is mandatory",
+          "alva skillhub get",
+          "alva skillhub file",
+          "Do not bulk-download",
+          "Do not turn every Skillhub task into a playbook",
+          "--skill-id <username>/<name>"
+        ]
+      }
+    },
+    {
+      "id": "scenario.remix-existing-playbook",
+      "group": "scenarios.playbook",
+      "prompt": "<remix https://alva.ai/u/alva/playbooks/screener> make my own version",
+      "description": "A remix reads source artifacts and preserves lineage instead of regenerating from memory.",
+      "expect": {
+        "route": "Debug / Edit",
+        "top_level_route": "Playbook Subroute: Remix",
+        "references": [
+          "remix-workflow.md",
+          "playbook-creation.md"
+        ],
+        "behaviors": [
+          "Extract source owner/name from the tag URL",
+          "read the source feed scripts, HTML, README, and playbook metadata",
+          "preserve them unless the user explicitly asks otherwise",
+          "Do not regenerate from memory"
+        ]
+      }
+    },
+    {
+      "id": "scenario.annotation-edit",
+      "group": "scenarios.playbook",
+      "prompt": "<annotation id=\"hero-title\">make this chart title shorter</annotation>",
+      "description": "An annotation edit changes the generator behind the element and re-enters HTML gates.",
+      "expect": {
+        "route": "Debug / Edit",
+        "top_level_route": "Playbook Subroute: Annotation Edits",
+        "references": [
+          "annotation-edits.md",
+          "playbook-creation.md"
+        ],
+        "behaviors": [
+          "change the generator behind the selected element",
+          "Never freeze rendered feed values into static text",
+          "HTML edits re-enter `before-build-html`"
+        ],
+        "gates": [
+          {
+            "type": "hard_gate",
+            "file": "references/playbook-creation.md",
+            "id": "before-build-html",
+            "label": "html gate",
+            "includes": [
+              "The HTML follows the Browser request rule",
+              "Do not rely on memory of prior sessions"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "scenario.udf-strict-opt-in",
+      "group": "scenarios.udf",
+      "prompt": "Add a button so viewers can run my custom analysis function.",
+      "description": "A UDF request is explicit opt-in and routes to the PBSV/browser runtime and functions CLI checks.",
+      "expect": {
+        "route": "Playbook Creation",
+        "references": [
+          "api/udf-runtime.md",
+          "playbook-creation.md"
+        ],
+        "behaviors": [
+          "User-Defined Functions are strict opt-in",
+          "registerable/shareable interactive function",
+          "window.alva.udf",
+          "alva functions",
+          "allowance consent",
+          "Never hand-write bearer headers"
+        ]
+      }
+    }
+  ]
+}

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -96,9 +96,28 @@
         ],
         "behaviors": [
           "Build live feeds first",
-          "HTML fetches quantitative data from feeds, not inline literals",
-          "Every release needs a current README",
-          "screenshot verification must show real feed-backed marks"
+          "HTML fetches quantitative data from feeds, not inline literals"
+        ],
+        "sections": [
+          {
+            "file": "references/api/release.md",
+            "heading": "Freshness and version updates",
+            "label": "readme freshness",
+            "includes": [
+              "Every `alva release playbook` call needs a freshly reviewed README",
+              "regenerate the README",
+              "upload it again to `~/playbooks/<name>/README.md` before release"
+            ]
+          },
+          {
+            "file": "references/playbook-creation.md",
+            "heading": "Screenshot",
+            "label": "visual verification",
+            "includes": [
+              "Pass screenshot verification only when",
+              "real feed-backed chart marks"
+            ]
+          }
         ],
         "gates": [
           {

--- a/evals/alva-skill-docs/skill-doc-eval.mjs
+++ b/evals/alva-skill-docs/skill-doc-eval.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -89,6 +89,10 @@ function readWorktree(path) {
   return existsSync(path) ? readFileSync(path, "utf8") : null;
 }
 
+function normalizeFilePath(path) {
+  return path.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^skills\/alva\//, "");
+}
+
 function loadEvalMaterials(casesPath) {
   const files = [SCRIPT_PATH, casesPath];
   return files
@@ -97,26 +101,45 @@ function loadEvalMaterials(casesPath) {
     .join("");
 }
 
+function loadEvalFileTexts(casesPath) {
+  const cwd = resolve(".");
+  const files = [
+    [SCRIPT_PATH, "evals/alva-skill-docs/skill-doc-eval.mjs"],
+    [casesPath, normalizeFilePath(relative(cwd, casesPath))],
+  ];
+  const fileTexts = new Map();
+  for (const [path, key] of files) {
+    if (existsSync(path)) fileTexts.set(key, readFileSync(path, "utf8"));
+  }
+  return fileTexts;
+}
+
 function loadCorpus(opts) {
   const evalText = loadEvalMaterials(opts.casesPath);
+  const evalFiles = loadEvalFileTexts(opts.casesPath);
   if (opts.treeish) {
     const skill = gitShow(opts.treeish, "skills/alva/SKILL.md");
     if (skill == null) throw new Error(`No skills/alva/SKILL.md at ${opts.treeish}`);
 
     const files = gitLsTree(opts.treeish, "skills/alva/references");
+    const fileTexts = new Map([...evalFiles, ["SKILL.md", skill]]);
     let references = "";
     for (const file of files) {
       if (/\.(md|yaml|css)$/.test(file)) {
         const body = gitShow(opts.treeish, file);
-        if (body != null) references += `\n\n--- ${file} ---\n${body}`;
+        if (body != null) {
+          references += `\n\n--- ${file} ---\n${body}`;
+          fileTexts.set(normalizeFilePath(file), body);
+        }
       }
     }
-    return { label: opts.treeish, skill, references, corpus: `${skill}${references}`, eval: evalText };
+    return { label: opts.treeish, skill, references, corpus: `${skill}${references}`, eval: evalText, files: fileTexts };
   }
 
   const skillPath = resolve(opts.skillDir, "SKILL.md");
   const skill = readWorktree(skillPath);
   if (skill == null) throw new Error(`No SKILL.md at ${skillPath}`);
+  const fileTexts = new Map([...evalFiles, ["SKILL.md", skill]]);
 
   const refFiles = execFileSync("find", [
     resolve(opts.skillDir, "references"),
@@ -140,9 +163,11 @@ function loadCorpus(opts) {
 
   let references = "";
   for (const file of refFiles) {
-    references += `\n\n--- ${file} ---\n${readFileSync(file, "utf8")}`;
+    const body = readFileSync(file, "utf8");
+    references += `\n\n--- ${file} ---\n${body}`;
+    fileTexts.set(normalizeFilePath(relative(opts.skillDir, file)), body);
   }
-  return { label: opts.skillDir, skill, references, corpus: `${skill}${references}`, eval: evalText };
+  return { label: opts.skillDir, skill, references, corpus: `${skill}${references}`, eval: evalText, files: fileTexts };
 }
 
 function includesAll(text, needles) {
@@ -157,17 +182,137 @@ function normalizeText(text) {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+function getTargetText(testCase, docs) {
+  return testCase.target === "skill"
+    ? docs.skill
+    : testCase.target === "eval"
+      ? docs.eval
+      : docs.corpus;
+}
+
+function getFileText(docs, file) {
+  return docs.files.get(normalizeFilePath(file)) ?? null;
+}
+
+function normalizeHeading(text) {
+  return normalizeText(text.replace(/#+\s*$/, "").replace(/[`*_]/g, ""));
+}
+
+function extractMarkdownSection(text, heading) {
+  const wanted = normalizeHeading(heading);
+  const lines = text.split(/\r?\n/);
+  let start = -1;
+  let level = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (match && normalizeHeading(match[2]) === wanted) {
+      start = i;
+      level = match[1].length;
+      break;
+    }
+  }
+
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const match = lines[i].match(/^(#{1,6})\s+/);
+    if (match && match[1].length <= level) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+function extractHardGate(text, id) {
+  const escaped = String(id).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`<HARD-GATE\\s+id=["']${escaped}["'][^>]*>[\\s\\S]*?<\\/HARD-GATE>`, "i");
+  const match = text.match(pattern);
+  return match ? match[0] : null;
+}
+
+function formatScope(spec) {
+  const label = spec.label ? `${spec.label}: ` : "";
+  if (spec.heading) return `${label}${spec.file}#${spec.heading}`;
+  if (spec.file) return `${label}${spec.file}`;
+  return label.replace(/: $/, "");
+}
+
+function evaluateFileIncludes(spec, docs) {
+  const text = getFileText(docs, spec.file);
+  const scope = formatScope(spec);
+  if (text == null) {
+    return [{ needle: `${scope} exists`, pass: false }];
+  }
+  return includesAll(text, spec.includes ?? []).map((check) => ({
+    needle: `${scope} includes ${check.needle}`,
+    pass: check.pass,
+  }));
+}
+
+function evaluateSectionIncludes(spec, docs) {
+  const fileText = getFileText(docs, spec.file);
+  const scope = formatScope(spec);
+  if (fileText == null) {
+    return [{ needle: `${scope} file exists`, pass: false }];
+  }
+
+  const sectionText = extractMarkdownSection(fileText, spec.heading);
+  if (sectionText == null) {
+    return [{ needle: `${scope} section exists`, pass: false }];
+  }
+
+  return includesAll(sectionText, spec.includes ?? []).map((check) => ({
+    needle: `${scope} includes ${check.needle}`,
+    pass: check.pass,
+  }));
+}
+
+function evaluateHardGateIncludes(spec, docs) {
+  const fileText = getFileText(docs, spec.file);
+  const label = spec.label ? `${spec.label}: ` : "";
+  const scope = `${label}${spec.file}<HARD-GATE:${spec.id}>`;
+  if (fileText == null) {
+    return [{ needle: `${scope} file exists`, pass: false }];
+  }
+
+  const gateText = extractHardGate(fileText, spec.id);
+  if (gateText == null) {
+    return [{ needle: `${scope} block exists`, pass: false }];
+  }
+
+  return includesAll(gateText, spec.includes ?? []).map((check) => ({
+    needle: `${scope} includes ${check.needle}`,
+    pass: check.pass,
+  }));
+}
+
 function evaluateCase(testCase, docs) {
-  const text =
-    testCase.target === "skill"
-      ? docs.skill
-      : testCase.target === "eval"
-        ? docs.eval
-        : docs.corpus;
+  const text = getTargetText(testCase, docs);
   const checks = [];
 
   if (Array.isArray(testCase.includes)) {
     checks.push(...includesAll(text, testCase.includes));
+  }
+
+  if (Array.isArray(testCase.file_includes)) {
+    for (const spec of testCase.file_includes) {
+      checks.push(...evaluateFileIncludes(spec, docs));
+    }
+  }
+
+  if (Array.isArray(testCase.section_includes)) {
+    for (const spec of testCase.section_includes) {
+      checks.push(...evaluateSectionIncludes(spec, docs));
+    }
+  }
+
+  if (Array.isArray(testCase.hard_gate_includes)) {
+    for (const spec of testCase.hard_gate_includes) {
+      checks.push(...evaluateHardGateIncludes(spec, docs));
+    }
   }
 
   if (typeof testCase.max_lines === "number" || typeof testCase.min_lines === "number") {

--- a/evals/alva-skill-docs/skill-doc-eval.mjs
+++ b/evals/alva-skill-docs/skill-doc-eval.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CASES = resolve(SCRIPT_DIR, "cases.json");
 const DEFAULT_SCENARIOS = resolve(SCRIPT_DIR, "scenarios.json");
+const MUTATION_SMOKE = resolve(SCRIPT_DIR, "mutation-smoke.mjs");
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
 const SCORE_DIAGNOSIS_GUIDE = [
@@ -103,7 +104,7 @@ function normalizeFilePath(path) {
 }
 
 function loadEvalMaterials(casesPath, scenariosPath) {
-  const files = [SCRIPT_PATH, casesPath, scenariosPath];
+  const files = [SCRIPT_PATH, casesPath, scenariosPath, MUTATION_SMOKE];
   return files
     .filter((path, index, all) => all.indexOf(path) === index && existsSync(path))
     .map((path) => `\n\n--- ${path} ---\n${readFileSync(path, "utf8")}`)
@@ -116,6 +117,7 @@ function loadEvalFileTexts(casesPath, scenariosPath) {
     [SCRIPT_PATH, "evals/alva-skill-docs/skill-doc-eval.mjs"],
     [casesPath, normalizeFilePath(relative(cwd, casesPath))],
     [scenariosPath, normalizeFilePath(relative(cwd, scenariosPath))],
+    [MUTATION_SMOKE, "evals/alva-skill-docs/mutation-smoke.mjs"],
   ];
   const fileTexts = new Map();
   for (const [path, key] of files) {
@@ -381,6 +383,15 @@ function scenarioAsCase(scenario) {
 
   for (const forbidden of requirements.forbidden_behaviors ?? []) {
     includes.push(forbidden);
+  }
+
+  for (const section of requirements.sections ?? []) {
+    sectionIncludes.push({
+      file: section.file,
+      heading: section.heading,
+      label: section.label ?? section.heading,
+      includes: section.includes ?? [],
+    });
   }
 
   for (const gate of requirements.gates ?? []) {

--- a/evals/alva-skill-docs/skill-doc-eval.mjs
+++ b/evals/alva-skill-docs/skill-doc-eval.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CASES = resolve(SCRIPT_DIR, "cases.json");
+const DEFAULT_SCENARIOS = resolve(SCRIPT_DIR, "scenarios.json");
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
 const SCORE_DIAGNOSIS_GUIDE = [
@@ -19,6 +20,7 @@ const SCORE_DIAGNOSIS_GUIDE = [
 function parseArgs(argv) {
   const opts = {
     casesPath: DEFAULT_CASES,
+    scenariosPath: DEFAULT_SCENARIOS,
     skillDir: resolve("skills/alva"),
     treeish: null,
     out: null,
@@ -28,6 +30,8 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === "--cases") {
       opts.casesPath = resolve(argv[++i]);
+    } else if (arg === "--scenarios") {
+      opts.scenariosPath = resolve(argv[++i]);
     } else if (arg === "--skill-dir") {
       opts.skillDir = resolve(argv[++i]);
     } else if (arg === "--treeish") {
@@ -52,6 +56,7 @@ Options:
   --treeish <ref>      Read skills/alva from a git ref instead of the worktree.
   --skill-dir <path>   Skill directory in the worktree. Default: skills/alva.
   --cases <path>       Cases manifest. Default: evals/alva-skill-docs/cases.json.
+  --scenarios <path>   Scenario manifest. Default: evals/alva-skill-docs/scenarios.json.
   --out <path>         Write markdown report.
   -h, --help           Show this help.
 `);
@@ -59,6 +64,10 @@ Options:
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readOptionalJson(path, fallback) {
+  return existsSync(path) ? readJson(path) : fallback;
 }
 
 function gitShow(treeish, path) {
@@ -93,19 +102,20 @@ function normalizeFilePath(path) {
   return path.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^skills\/alva\//, "");
 }
 
-function loadEvalMaterials(casesPath) {
-  const files = [SCRIPT_PATH, casesPath];
+function loadEvalMaterials(casesPath, scenariosPath) {
+  const files = [SCRIPT_PATH, casesPath, scenariosPath];
   return files
     .filter((path, index, all) => all.indexOf(path) === index && existsSync(path))
     .map((path) => `\n\n--- ${path} ---\n${readFileSync(path, "utf8")}`)
     .join("");
 }
 
-function loadEvalFileTexts(casesPath) {
+function loadEvalFileTexts(casesPath, scenariosPath) {
   const cwd = resolve(".");
   const files = [
     [SCRIPT_PATH, "evals/alva-skill-docs/skill-doc-eval.mjs"],
     [casesPath, normalizeFilePath(relative(cwd, casesPath))],
+    [scenariosPath, normalizeFilePath(relative(cwd, scenariosPath))],
   ];
   const fileTexts = new Map();
   for (const [path, key] of files) {
@@ -115,8 +125,8 @@ function loadEvalFileTexts(casesPath) {
 }
 
 function loadCorpus(opts) {
-  const evalText = loadEvalMaterials(opts.casesPath);
-  const evalFiles = loadEvalFileTexts(opts.casesPath);
+  const evalText = loadEvalMaterials(opts.casesPath, opts.scenariosPath);
+  const evalFiles = loadEvalFileTexts(opts.casesPath, opts.scenariosPath);
   if (opts.treeish) {
     const skill = gitShow(opts.treeish, "skills/alva/SKILL.md");
     if (skill == null) throw new Error(`No skills/alva/SKILL.md at ${opts.treeish}`);
@@ -334,11 +344,78 @@ function evaluateCase(testCase, docs) {
   const passed = checks.filter((check) => check.pass).length;
   return {
     ...testCase,
+    kind: testCase.kind ?? "case",
     passed,
     total: checks.length,
     ok: passed === checks.length,
     checks,
   };
+}
+
+function scenarioAsCase(scenario) {
+  const requirements = scenario.expect ?? {};
+  const includes = [];
+  const sectionIncludes = [];
+  const hardGateIncludes = [];
+
+  if (requirements.route) {
+    sectionIncludes.push({
+      file: "references/request-routing.md",
+      heading: "Routes",
+      label: "expected route",
+      includes: [requirements.route],
+    });
+  }
+
+  if (requirements.top_level_route) {
+    includes.push(requirements.top_level_route);
+  }
+
+  for (const ref of requirements.references ?? []) {
+    includes.push(ref);
+  }
+
+  for (const phrase of requirements.behaviors ?? []) {
+    includes.push(phrase);
+  }
+
+  for (const forbidden of requirements.forbidden_behaviors ?? []) {
+    includes.push(forbidden);
+  }
+
+  for (const gate of requirements.gates ?? []) {
+    if (gate.type === "hard_gate") {
+      hardGateIncludes.push({
+        file: gate.file,
+        id: gate.id,
+        label: gate.label ?? gate.id,
+        includes: gate.includes ?? [gate.id],
+      });
+    } else if (gate.heading) {
+      sectionIncludes.push({
+        file: gate.file,
+        heading: gate.heading,
+        label: gate.label ?? gate.heading,
+        includes: gate.includes ?? [],
+      });
+    }
+  }
+
+  return {
+    id: scenario.id,
+    kind: "scenario",
+    group: scenario.group ?? "scenarios",
+    target: "corpus",
+    prompt: scenario.prompt,
+    description: scenario.description,
+    includes,
+    section_includes: sectionIncludes,
+    hard_gate_includes: hardGateIncludes,
+  };
+}
+
+function evaluateScenario(scenario, docs) {
+  return evaluateCase(scenarioAsCase(scenario), docs);
 }
 
 function renderReport(manifest, docs, results) {
@@ -386,6 +463,9 @@ function renderReport(manifest, docs, results) {
     for (const result of groupResults) {
       out += `### ${result.ok ? "PASS" : "FAIL"} ${result.id}\n\n`;
       out += `${result.description}\n\n`;
+      if (result.kind === "scenario" && result.prompt) {
+        out += `Prompt: \`${result.prompt}\`\n\n`;
+      }
       for (const check of result.checks) {
         out += `- ${check.pass ? "[x]" : "[ ]"} ${check.needle}\n`;
       }
@@ -398,8 +478,11 @@ function renderReport(manifest, docs, results) {
 
 const opts = parseArgs(process.argv.slice(2));
 const manifest = readJson(opts.casesPath);
+const scenarioManifest = readOptionalJson(opts.scenariosPath, { scenarios: [] });
 const docs = loadCorpus(opts);
-const results = manifest.cases.map((testCase) => evaluateCase(testCase, docs));
+const caseResults = manifest.cases.map((testCase) => evaluateCase(testCase, docs));
+const scenarioResults = (scenarioManifest.scenarios ?? []).map((scenario) => evaluateScenario(scenario, docs));
+const results = [...caseResults, ...scenarioResults];
 const report = renderReport(manifest, docs, results);
 
 if (opts.out) {

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -390,40 +390,28 @@ each feed, ALFS, deploy, and release step.
 
 #### Publication Layer: Playbook Creation Tree
 
-Playbooks are hosted investing apps. They can be dashboards, screeners,
-thesis trackers, backtest surfaces, what-if studies, event studies, or custom
-interactive tools. Creation is a concrete task, so the detailed workflow lives
-in [playbook-creation.md](references/playbook-creation.md).
+Playbooks are hosted investing apps: dashboards, screeners, thesis trackers,
+backtest surfaces, what-if studies, event studies, or custom interactive tools.
+Enter this branch only when the user wants a hosted/shareable surface, remix,
+annotation edit, release/version update, or playbook subscription setup.
 
-Before HTML work, satisfy `before-build-html`: read [design.md](references/design.md)
-first, then the relevant companion reference, and follow the Browser request
-rule in [playbook-creation.md](references/playbook-creation.md). If a Skillhub
-blueprint is active, its layout and data contract override stale memories or
-companion code.
+Read [playbook-creation.md](references/playbook-creation.md) before creating
+or changing the hosted surface. It owns the build order, Browser-safe feed
+reads, README, draft/release gates, screenshot verification, tier/visibility
+flow, and push-after-release handoff. Read [api/release.md](references/api/release.md)
+for README, tags, trading-symbol, and `--skill-id` details; read
+[remix-workflow.md](references/remix-workflow.md) or
+[annotation-edits.md](references/annotation-edits.md) for those subroutes.
 
-Before release, satisfy `before-playbook-draft` and `before-playbook-release`.
-Every release needs a current README at `~/playbooks/<name>/README.md`, passed
-via absolute `--readme-url`; see [api/release.md](references/api/release.md).
-
-After a successful draft and release gates, publish publicly by default unless
-the user explicitly asks to stop at draft/private. Existing published
-visibility can be changed with `alva playbooks set-visibility` after reading
-`alva playbooks --help`; private and paid visibility are Pro-gated.
-
-Playbook creation is where many Alva concepts meet: Data Skills or BYOD feed
-the runtime, Feed SDK writes outputs, design rules govern the UI, release
-metadata explains discovery, README explains trust, and screenshots prove the
-published URL renders. The top-level rule is simple: if a number is visible,
-the viewer's browser should be able to read where it came from, and screenshot
-verification must show real feed-backed marks, rows, or KPI values rather than
-a loaded page shell.
+The top-level boundary is feed-first and live-read: build feeds before HTML,
+and visible numbers must be read from feed outputs in the viewer's browser.
+Before HTML work, satisfy `before-build-html`; before draft/release satisfy
+`before-playbook-draft` and `before-playbook-release` in the reference. Keep
+procedure, release, screenshot, and tier details in the owning references.
 
 Subroutes are new build, Skillhub-guided build, remix, annotation/edit,
-release/version update, and push after release. Keep those steps inside
-[playbook-creation.md](references/playbook-creation.md),
-[remix-workflow.md](references/remix-workflow.md), and
-[annotation-edits.md](references/annotation-edits.md); do not let every
-financial question inherit playbook gates.
+release/version update, and push after release. Do not let every financial
+question inherit playbook gates.
 
 #### Strategy Layer: Altra
 
@@ -602,18 +590,18 @@ failure instead of substituting a web snippet or model memory. If the user then
 asks to track, alert, share, or publish, upgrade the route to a feed, signal,
 alert, or playbook.
 
-### Durable Artifacts / Playbook Tree
+### Hosted Playbook Workflow
 
 Enter this tree when the user wants a hosted app, share URL, dashboard,
 screener app, report surface, remix, annotation edit, release/version update,
-or playbook subscription setup. Turn the request into a data contract before
-UI work: universe, metrics, freshness, output groups, widgets, and release
-path. Build feeds first, then HTML that reads those feeds, then README, draft,
-release, screenshot, and optional push. Details live in
+or playbook subscription setup. First choose the artifact shape: direct answer,
+feed, signal, model output, or hosted playbook. For hosted/shareable surfaces,
+turn the request into a data contract before UI work: universe, metrics,
+freshness, output groups, widgets, and release path. Then open
 [playbook-creation.md](references/playbook-creation.md),
 [remix-workflow.md](references/remix-workflow.md),
 [annotation-edits.md](references/annotation-edits.md), and
-[api/release.md](references/api/release.md).
+[api/release.md](references/api/release.md); they own the procedure.
 
 ### Thesis, Digest, And Monitoring
 


### PR DESCRIPTION
## Summary

Start the #592 refactor path from the eval layer instead of changing the skill text first.

- extend `skill-doc-eval.mjs` with scoped checks for files, markdown sections, and `<HARD-GATE>` blocks
- add `scenarios.json` for deterministic prompt-intent routing contracts
- add scenario-level section assertions so prompt contracts can pin behavior to the owning heading, not only the whole corpus
- add `mutation-smoke.mjs`, which copies `skills/alva` to a temp dir, removes key contract text, and requires the eval to fail through expected cases
- add a required GitHub Actions workflow that runs the deterministic doc regression eval and mutation smoke on Alva skill/eval changes
- add a separate scheduled/manual LLM trace diagnostic that reuses `scenarios.json` but is not triggered by PRs or pushes
- add issue592 behavior contracts for financial ask routing, capability verification before refusal, playbook release gates, and push delivery setup
- add 10 scenario cases covering simple asks, complex asks, capability gaps, playbook builds, push monitors, backtests, Skillhub, remix, annotations, and UDF opt-in
- remove the `SKILL.md` minimum line-count assertion so future compression is not blocked by the regression net itself
- regenerate checked-in baseline/final reports so the manifest, scenarios, and reports stay in sync

## Why

The current eval was mostly corpus-wide string presence. That protects against accidental deletion, but it also makes the next SKILL.md slimming pass hard to validate because important behavior can only be represented as exact phrase retention.

This keeps the existing checks while adding route/gate scoped assertions, deterministic scenarios, and mutation smoke coverage that proves selected contracts can turn red when their owning text is removed.

The LLM trace layer uses the model as an actor, not as the judge: it asks for a structured route/reference/gate/action trace, then checks that trace deterministically against the same scenario contracts. It runs only on `workflow_dispatch` or the weekly schedule, so it is diagnostic rather than a merge gate.

## Validation

- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` -> 47/47 cases, 416/416 checks
- `node evals/alva-skill-docs/skill-doc-eval.mjs --treeish origin/main` -> 47/47 cases, 416/416 checks
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` -> 4/4 mutations failed as expected
- `node --check evals/alva-skill-docs/llm-scenario-trace.mjs`
- `node evals/alva-skill-docs/llm-scenario-trace.mjs --self-test` -> 10/10 cases, 96/96 checks
- `env -u OPENAI_API_KEY -u ALVA_SKILL_LLM_EVAL_MODEL node evals/alva-skill-docs/llm-scenario-trace.mjs --skip-without-config --out /tmp/alva-llm-trace-skip.md --json-out /tmp/alva-llm-trace-skip.json` -> writes skipped report
- `git diff --check`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva` -> no broken links, no orphan references

CI now runs the first and third commands in `.github/workflows/alva-skill-doc-evals.yml` for PRs and main pushes that touch `skills/alva/**`, `evals/alva-skill-docs/**`, or the workflow itself.

Periodic LLM trace runs live in `.github/workflows/alva-skill-llm-trace.yml`; configure `OPENAI_API_KEY` plus `ALVA_SKILL_LLM_EVAL_MODEL` and use either the Monday schedule or manual dispatch.
