### PR TITLE
docs(alva): default playbook push to notify message

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -225,6 +225,19 @@
       ]
     },
     {
+      "id": "target.playbook-notify-message",
+      "group": "target",
+      "target": "corpus",
+      "description": "Playbook-facing notifications default to notify/message while structured execution targets stay on signal/targets.",
+      "includes": [
+        "Prefer `notify/message` for playbook-facing notifications",
+        "Route playbook alert/feed prompts through this pattern when the output is notification text",
+        "\"write a playbook alert feed\"",
+        "Use this as the default for playbook-facing signals that are notification text",
+        "Keep `signal/targets` only when a downstream trading, signal-card, or execution path needs the structured target"
+      ]
+    },
+    {
       "id": "retained.memory-secrets",
       "group": "retained",
       "target": "corpus",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -498,10 +498,11 @@ authentication, `alva functions` creator registration and allowance tools,
 
 #### Action Layer: Push Notifications
 
-Push is a feed/playbook subscription flow. A feed may emit `signal/targets` or
-`notify/message`; both dispatch `feed_alert_ready`. `--push-notify` only marks
-the publisher capable of alerts. It does not subscribe users or bypass
-preferences.
+Push is a feed/playbook subscription flow. Prefer `notify/message` for
+playbook-facing notifications; reserve `signal/targets` for structured
+trading/execution targets. Both dispatch `feed_alert_ready`. `--push-notify`
+only marks the publisher capable of alerts. It does not subscribe users or
+bypass preferences.
 
 Open [push-notifications.md](references/push-notifications.md) for sidecar
 creation, release, subscription, and verification. Quiet runs use
@@ -642,7 +643,8 @@ generator behind the selected element rather than the rendered DOM.
 
 ### Push Monitor
 
-For a recurring alert, design the feed output first: signal target or message,
+For a recurring alert, design the feed output first: `notify/message` by
+default, `signal/targets` only for structured trading/execution targets,
 quiet-run sentinel, cadence, and subscriber. Release the feed after adding the
 sidecar, then verify a real run. A cronjob with `--push-notify` and no
 subscription is not a completed push setup.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -81,8 +81,8 @@ Push-capable feeds write one of these streams:
 
 | Output stream | Use |
 | --- | --- |
-| `signal/targets` | Playbook signals, trading targets, actionable alerts. |
-| `notify/message` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts. |
+| `notify/message` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts, playbook-facing notifications, and plain-text playbook alerts. |
+| `signal/targets` | Altra/trading targets and other machine-readable execution signals. |
 
 Both dispatch `feed_alert_ready`. Do not use legacy names such as
 `playbook_data_ready` or `feed_run_complete` in new docs.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -162,12 +162,13 @@ await feed.run(async (ctx) => {
 
 Read `@last/N` (where N >= batch size) to get the most recent batch.
 
-### Pattern D: Signal / Playbook Push Notification
+### Pattern D: Structured Signal / Trading Target
 
-For feeds that produce actionable signals worth pushing to users or groups
-that explicitly subscribed to the feed, or to a playbook that references the
-feed. Write signal records to the **`signal`** group with a **`targets`**
-output -- the resulting path
+Use this when the feed produces an Altra/trading target or another
+machine-readable execution signal.
+
+Write structured signal records to the **`signal`** group with a **`targets`**
+output. The resulting path
 `~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
 when dispatching the canonical `feed_alert_ready` notification event.
 
@@ -179,7 +180,7 @@ const { Feed, feedPath, makeDoc, str, num, obj, arr, fld } = require("@alva/feed
 const feed = new Feed({ path: feedPath("my-signal") });
 
 feed.def("signal", {
-  targets: makeDoc("Signal Targets", "Actionable signals for playbook notifications", [
+  targets: makeDoc("Signal Targets", "Machine-readable trading targets", [
     obj("instruction", [
       str("type"),       // "allocate" | "orders"
       arr("weights", [   // for type: "allocate"
@@ -247,21 +248,28 @@ require a 500-character summary.
   notification-native. Use a push-safe projection only when a channel has a
   real hard limit or cannot render the feed's richer format.
 - One record per run is typical; the platform reads `@last/1`.
-- Altra strategies write to this path automatically. Use this pattern only for
-  non-Altra feeds that want to produce push-worthy signals.
+- Altra strategies write to this path automatically. For non-Altra
+  playbook-facing notifications, prefer `notify/message` unless a downstream
+  machine must consume the structured target.
 
-### Pattern E: AlvaAsk + Feed Notification (notify/message)
+### Pattern E: Feed Notification (notify/message)
 
-**Preferred pattern for scheduled tasks.** Use `@alva/alvaask` instead of a
-custom alpi loop for cronjob feeds when you need Alva's full agent behavior —
-it's simpler (no sandbox/session management) and the `ask()` call handles tool
-use, web search, and ALFS access automatically.
+For scheduled agent-written notifications, prefer `@alva/alvaask` over a
+custom alpi loop: it is simpler (no sandbox/session management) and `ask()`
+handles tool use, web search, and ALFS access automatically.
 
-For feeds that use `@alva/alvaask` to call Alva's agent and publish the result
-as a feed completion notification. Common use cases: scheduled market reports,
-periodic research summaries, heartbeat monitoring, and proactive alerts.
+For feeds that publish the message recipients should read. Common use cases:
+scheduled market reports, periodic research summaries, heartbeat monitoring,
+proactive alerts, and playbook-facing signal notifications that do not need
+machine-readable trading targets.
 
-Write the agent's response to the **`notify`** group with a **`message`**
+Route playbook alert/feed prompts through this pattern when the output is
+notification text, including "write a playbook alert feed", "notify when a
+playbook condition fires", and "push a signal message to playbook
+subscribers". Use Pattern D only when the user also asks for a structured
+trading target, signal-card data, or execution.
+
+Write the notification content to the **`notify`** group with a **`message`**
 output. When the cronjob completes with `--push-notify`, the platform reads
 this path and dispatches `feed_alert_ready` to users or groups that explicitly
 subscribed to the feed, or to a playbook that references the feed.
@@ -324,6 +332,9 @@ alva release feed --name daily-briefing --version 1.0.0 \
 - If `body`/`text` contains `<|SKIP_NOTIFICATION|>`, fanout state advances but
   no user-visible notification is sent. Teach AlvaAsk to output this sentinel
   when there is no material update.
+- Use this as the default for playbook-facing signals that are notification
+  text. Keep `signal/targets` only when a downstream trading, signal-card, or
+  execution path needs the structured target.
 - **`alva release feed` is required** — without it, the push is still
   dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
@@ -335,8 +346,8 @@ alva release feed --name daily-briefing --version 1.0.0 \
   unsubscribe (including ghost rows of deleted targets), see
   [push-notifications.md](push-notifications.md) § Inventory And
   Unsubscribe.
-- Combine with Pattern D if you want both feed completion notifications and
-  signal-style notifications.
+- Combine with Pattern D only when the same run must produce both a readable
+  notification and a machine-readable trading/execution target.
 
 ### Deduplication
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -29,9 +29,11 @@ the user can connect Telegram, Discord, or Slack at <https://alva.ai/settings>.
 A push is set up only after all of these succeed:
 
 1. Add the intended push sidecar:
-   - `signal/targets` for playbook signals and trading targets.
-   - `notify/message` for feed completion, AlvaAsk reports, heartbeat checks,
-     and proactive alerts.
+   - `notify/message` for playbook-facing notifications, feed completion,
+     AlvaAsk reports, heartbeat checks, proactive alerts, and prompts like
+     "write a playbook alert feed".
+   - `signal/targets` only for Altra/trading targets or other
+     machine-readable execution signals.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-feed-release`.
 3. Enable publisher push on the cronjob:

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -26,7 +26,7 @@ Decision order:
 | Financial Analysis / Ask Question | Answer market, asset, portfolio, valuation, comparison, and "why" questions with fresh data/search/`alva run` evidence. Comparison baselines are figures too: fetch or qualify them. Every answer must read [user-facing-prose.md](user-facing-prose.md), then pass the ask evidence gate. |
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. |
-| Automation / Push | Build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
+| Automation / Push | Build or modify a feed that emits `notify/message` by default, or `signal/targets` for structured trading/execution signals, then verify subscription and delivery path. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |
 


### PR DESCRIPTION
## Summary

- default playbook-facing push guidance to `notify/message`
- reserve `signal/targets` for Altra/trading targets and other machine-readable execution signals
- add a docs eval case that protects the notify/message vs signal/targets boundary, including the validation prompt that previously misrouted (`write a playbook alert feed`)

## Why

Playbook-facing signals can start as notification text without carrying a structured target schema. Keeping `signal/targets` for machine-readable execution paths preserves the trading/signal-card escape hatch while simplifying the common playbook notification path.

A validation agent initially misrouted “playbook-facing alert” toward `signal/targets`, then corrected to `notify/message`. This PR now makes the positive route explicit: Pattern E routes playbook alert/feed prompts with notification-text output through `notify/message`, while Pattern D remains for structured trading targets, signal-card data, or execution.

## Validation

- `node evals/alva-skill-docs/skill-doc-eval.mjs --treeish origin/main --out /tmp/playbook-notify-message-baseline.md` -> 32/33 cases, 258/263 checks; only the new target case fails on main
- `node evals/alva-skill-docs/skill-doc-eval.mjs --out /tmp/playbook-notify-message-eval.md` -> 33/33 cases, 263/263 checks
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/playbook-notify-message/skills/alva` -> no broken links, no orphan references
- `git diff --check`
