### PR TITLE
docs(alva): add playbook alert feed example

### DIFF
--- a/skills/alva/examples/playbook-alert-feed.js
+++ b/skills/alva/examples/playbook-alert-feed.js
@@ -1,0 +1,24 @@
+const { Feed, feedPath, makeDoc, str } = require("@alva/feed");
+
+const feed = new Feed({ path: feedPath("playbook-alert-example") });
+
+feed.def("notify", {
+  message: makeDoc("Playbook Alert", "Minimal push content for a playbook-facing alert", [
+    str("title"),
+    str("body"),
+  ]),
+});
+
+(async () => {
+  const now = Date.now();
+
+  await feed.run(async (ctx) => {
+    await ctx.self.ts("notify", "message").append([
+      {
+        date: now,
+        title: "Playbook Alert",
+        body: "**Playbook alert:** the watch condition fired. Open the playbook to review the latest feed-backed context.",
+      },
+    ]);
+  });
+})();

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -266,6 +266,9 @@ output. When the cronjob completes with `--push-notify`, the platform reads
 this path and dispatches `feed_alert_ready` to users or groups that explicitly
 subscribed to the feed, or to a playbook that references the feed.
 
+For a minimal standalone playbook-facing alert script, see
+[`examples/playbook-alert-feed.js`](../examples/playbook-alert-feed.js).
+
 ```javascript
 const { ask } = require("@alva/alvaask");
 const { Feed, feedPath, makeDoc, str } = require("@alva/feed");


### PR DESCRIPTION
## Summary
- add a minimal Feed SDK example for a playbook-facing alert using the `notify/message` push sidecar
- link the example from the Feed SDK notification pattern so agents can find a copyable script without bloating `SKILL.md`

## Validation
- `node --check skills/alva/examples/playbook-alert-feed.js`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/playbook-alert-feed-example/skills/alva`
- `node evals/alva-skill-docs/skill-doc-eval.mjs` (`32/32` cases, `258/258` checks)
- `git diff --check`
- cold Codex audit of the diff; applied its finding by using `notify/message` instead of over-broad `signal/targets`
