### PR TITLE
[codex] document ALFS-native agent writes

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -378,7 +378,7 @@ digest, signal, reusable dataset, or future answer.
 
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic, upload source, `alva run`, grant
+short lifecycle is: write schema and logic to ALFS, `alva run`, grant
 public read if needed, deploy, then `alva release feed`.
 
 Before feed release, satisfy `before-feed-release`: fresh run, expected shape,

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -13,7 +13,7 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 
 ```javascript
 // @ts-nocheck
-/** alva run --local-file ./run-result.js */
+/** alva run --entry-path '~/tasks/run-result.js' */
 (async () => {
 	const { Agent, Type, getModel } = require("@alva/pi");
 	const args = require("env").args || {};

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -65,11 +65,11 @@ Every `alva release playbook` call needs a freshly reviewed README for the
 version being released. Initial releases, version bumps, and re-releases all
 follow the same rule: regenerate the README from the current HTML, feed
 scripts, feed ids, cron cadences, metadata, and known blind spots, then
-upload it again to `~/playbooks/<name>/README.md` before release.
+write it again to `~/playbooks/<name>/README.md` before release.
 
 Do not point `--readme-url` at a README copied from a prior version. A README
 may keep the same wording only if you have re-checked it against the current
-implementation and re-uploaded the reviewed file for this release.
+implementation and re-written the reviewed file for this release.
 
 ### Path and `--readme-url` form
 

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -263,6 +263,10 @@ flags, response fields, and examples.
 
 The stable flow is:
 
+Use ALFS-native write/edit tools for the entry script when available. The
+`--file` and `--params-schema-file` forms below are for shell-only CLI
+sessions; embedded jagent mode should pass inline `--params-schema` instead.
+
 ```bash
 alva fs write --path '/alva/home/<username>/playbooks/<name>/udf/analyze.js' --file ./analyze.js --mkdir-parents
 alva functions register --playbook-id <playbook-id> --function-name analyze --entry-script-path '/alva/home/<username>/playbooks/<name>/udf/analyze.js' --params-schema-file ./schema.json --no-allow-charges
@@ -273,9 +277,10 @@ CLI gotchas the help text may not make obvious:
 
 - `entry_script_path` is an absolute ALFS path under the creator's home and
   must point at a `.js` file. Do not pass a local filesystem path or `~/...`.
-- Prefer `--params-schema-file` for nontrivial schemas so shell quoting does
-  not corrupt the JSON Schema. The schema must match both UI inputs and
-  server-side validation.
+- In shell-only CLI sessions, prefer `--params-schema-file` for nontrivial
+  schemas so shell quoting does not corrupt the JSON Schema. In embedded
+  jagent mode, pass inline `--params-schema` instead. The schema must match
+  both UI inputs and server-side validation.
 - Registration is no-charge by default; pass `--no-allow-charges` unless the
   user explicitly wants viewer-credit charging and the consent flow is wired.
   Do not silently opt viewers into charges.

--- a/skills/alva/references/api/udf-runtime.md
+++ b/skills/alva/references/api/udf-runtime.md
@@ -265,7 +265,8 @@ The stable flow is:
 
 Use ALFS-native write/edit tools for the entry script when available. The
 `--file` and `--params-schema-file` forms below are for shell-only CLI
-sessions; embedded jagent mode should pass inline `--params-schema` instead.
+sessions; PI/jagent agent tool mode should pass inline `--params-schema`
+instead.
 
 ```bash
 alva fs write --path '/alva/home/<username>/playbooks/<name>/udf/analyze.js' --file ./analyze.js --mkdir-parents
@@ -278,9 +279,9 @@ CLI gotchas the help text may not make obvious:
 - `entry_script_path` is an absolute ALFS path under the creator's home and
   must point at a `.js` file. Do not pass a local filesystem path or `~/...`.
 - In shell-only CLI sessions, prefer `--params-schema-file` for nontrivial
-  schemas so shell quoting does not corrupt the JSON Schema. In embedded
-  jagent mode, pass inline `--params-schema` instead. The schema must match
-  both UI inputs and server-side validation.
+  schemas so shell quoting does not corrupt the JSON Schema. In PI/jagent
+  agent tool mode, pass inline `--params-schema` instead. The schema must
+  match both UI inputs and server-side validation.
 - Registration is no-charge by default; pass `--no-allow-charges` unless the
   user explicitly wants viewer-credit charging and the consent flow is wired.
   Do not silently opt viewers into charges.

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -19,7 +19,7 @@ The three lifecycle CLI groups:
 
 The deployment workflow:
 
-1. **Write** a script (feed or task) and upload it to the filesystem
+1. **Write** a script (feed or task) to ALFS
 2. **Test** it manually via `alva run`
 3. **Deploy** it as a cronjob via `alva deploy create`
 4. **Verify** the deployment via `alva deploy trigger` (one out-of-schedule run)
@@ -263,7 +263,8 @@ This example creates a BTC price feed that runs every 4 hours.
 alva fs mkdir --path '~/feeds/btc-hourly/v1/src'
 ```
 
-Write the script (upload from local file):
+Write the script to ALFS. Prefer ALFS-native write/edit tools when available;
+the `--file` form is for shell-only CLI sessions:
 
 ```bash
 alva fs write --path '~/feeds/btc-hourly/v1/src/index.js' --file ./index.js --mkdir-parents

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -756,6 +756,7 @@ Public reads must use absolute paths:
 ### Step 1: Create the directory and write the script
 
 ```bash
+# Prefer ALFS-native write/edit tools when available; --file is shell-only fallback.
 alva fs write --path '~/feeds/btc-ema/v1/src/index.js' --file ./index.js --mkdir-parents
 ```
 

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -118,7 +118,7 @@ The canonical content shape lives in [api/release.md](api/release.md#playbook-re
 Before `alva release playbook-draft`, write:
 
 Use ALFS-native write/edit tools when available. The `--file` examples below
-are for shell-only CLI sessions; in embedded jagent mode, write the same
+are for shell-only CLI sessions; in PI/jagent agent tool mode, write the same
 content directly to the target ALFS paths.
 
 ```bash

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -108,14 +108,18 @@ Every released playbook ships a README at:
 
 It is the single source of truth for the playbook's "How does this work?"
 surface. For every release, version bump, or rerelease, regenerate it from the
-current HTML, feeds, metadata, and blind spots, then upload it again before
-release. Do not reuse a prior-version README.
+current HTML, feeds, metadata, and blind spots, then write it to ALFS again
+before release. Do not reuse a prior-version README.
 
 The canonical content shape lives in [api/release.md](api/release.md#playbook-readme).
 
 ## Draft
 
 Before `alva release playbook-draft`, write:
+
+Use ALFS-native write/edit tools when available. The `--file` examples below
+are for shell-only CLI sessions; in embedded jagent mode, write the same
+content directly to the target ALFS paths.
 
 ```bash
 alva fs write --path '~/playbooks/{name}/index.html' --file ./index.html --mkdir-parents

--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -36,13 +36,13 @@ npm install -g @alva-ai/toolkit
 npm install -g @alva-ai/toolkit@latest
 ```
 
-## ALFS-Native Agent Mode
+## ALFS-Native Agent Tool Mode
 
-When the agent environment exposes ALFS-native read/write/edit tools or an
-embedded `@alva-ai/toolkit/cli` dispatcher running with `mode: "jagent"`, use
-those tools for file preparation. Do not route through local-file upload flags
-such as `alva fs write --file`, `alva run --local-file`,
-`--params-schema-file`, or screenshot `--out`.
+When this skill is running in a PI/jagent-style agent environment with an
+`alva` model tool plus ALFS-native `read`/`write`/`edit` tools, use those tools
+for file preparation. Do not route through local-file upload flags such as
+`alva fs write --file`, `alva run --local-file`, `--params-schema-file`, or
+screenshot `--out`.
 
 In that mode, prepare or edit content directly in ALFS, then call Alva commands
 with ALFS paths or inline JSON/data:

--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -36,6 +36,27 @@ npm install -g @alva-ai/toolkit
 npm install -g @alva-ai/toolkit@latest
 ```
 
+## ALFS-Native Agent Mode
+
+When the agent environment exposes ALFS-native read/write/edit tools or an
+embedded `@alva-ai/toolkit/cli` dispatcher running with `mode: "jagent"`, use
+those tools for file preparation. Do not route through local-file upload flags
+such as `alva fs write --file`, `alva run --local-file`,
+`--params-schema-file`, or screenshot `--out`.
+
+In that mode, prepare or edit content directly in ALFS, then call Alva commands
+with ALFS paths or inline JSON/data:
+
+- Use `alva fs write --data ...` or the ALFS write/edit tool for source, HTML,
+  README, and schema files.
+- Use `alva run --entry-path <alfs-js-path>` or `alva run --code <inline-js>`;
+  do not use `--local-file`.
+- Use `alva functions register --params-schema '<json>'` when the schema was
+  prepared in ALFS or memory; do not use `--params-schema-file`.
+
+CLI examples that use local files are fallback instructions for shell-only
+Node.js sessions.
+
 Third-party vendor secrets belong in Alva Secret Manager
 (`require("secret-manager")`), not CLI config, source files, or chat.
 

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -90,39 +90,43 @@ same `function_name` and `params_schema` on the remixed playbook.
 
 ---
 
-## Step 2 — Download UI Layer (HTML Source)
+## Step 2 — Read UI Layer (HTML Source)
 
-**Download to a local file — do not regenerate from memory.** Redirect
-`alva fs read` output into a local file so you can edit it in place
-(e.g. with the `Edit` tool). Reconstructing the HTML from what you
-remember of the read output drops layout details, comments, and working
-code that the user expects to inherit.
+If ALFS-native read/write/edit tools are available, inspect and edit the ALFS
+source directly. Do not force a local download/upload loop in embedded jagent
+mode.
+
+In a shell-only CLI session, download to a local file; do not regenerate from
+memory. Redirect `alva fs read` output into a local file so you can edit it in
+place (e.g. with the `Edit` tool). Reconstructing the HTML from what you
+remember of the read output drops layout details, comments, and working code
+that the user expects to inherit.
 
 ```bash
 alva fs read --path '/alva/home/{owner}/playbooks/{name}/index.html' > ./index.html
 ```
 
 This is the full HTML source of the playbook dashboard — the ECharts
-charts, metric cards, layout, and data-fetching logic. Edit this local
-file directly in Step 5; do not rewrite it from scratch.
+charts, metric cards, layout, and data-fetching logic. Edit this source
+directly in Step 5; do not rewrite it from scratch.
 
 ---
 
-## Step 3 — Download Code Layer (Feed Scripts)
+## Step 3 — Read Code Layer (Feed Scripts)
 
-Each entry in `releases[0].feeds` carries `feed_name` — download each
-feed's script source the same way:
+Each entry in `releases[0].feeds` carries `feed_name` — inspect each feed's
+script source the same way. In shell-only CLI sessions, download each source:
 
 ```bash
 alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js' > ./{feed_name}.js
 ```
 
 This contains the strategy logic, data fetching, and indicator
-computations. As with the HTML, **modify the downloaded file in place**
+computations. As with the HTML, **modify the inspected source in place**
 rather than re-typing the script from your reading of it.
 
-If Step 1 found registered UDFs, download each UDF entry script from its
-`entry_script_path` into a local file as well:
+If Step 1 found registered UDFs, inspect each UDF entry script from its
+`entry_script_path` as well. In shell-only CLI sessions, download it:
 
 ```bash
 alva fs read --path '{source_entry_script_path}' > ./udf-{function_name}.js
@@ -180,7 +184,7 @@ If the source structure conflicts with the new topic (e.g. source has a
 the user** whether to leave the tab empty/hidden or remove it. Do not
 silently restructure.
 
-Concretely, before uploading the edited HTML, diff its tab list and
+Concretely, before writing the edited HTML back to ALFS, diff its tab list and
 top-level section headings against the source. If they don't match and
 the user didn't ask for the change, revert the structure and re-apply
 only the data swap.
@@ -189,29 +193,28 @@ only the data swap.
 
 ## Step 5 — Deploy as New Playbook
 
-Follow the standard playbook creation flow (see SKILL.md), starting from
-the local files you downloaded in Steps 2–3. **Edit those files in
-place** with the `Edit` tool — swap data paths to your own namespace,
-adjust strategy parameters, and apply the user's customization request
-**within the scope defined above** (data/topic by default; structure
-only on explicit request). Do not write fresh files from scratch.
+Follow the standard playbook creation flow (see SKILL.md), starting from the
+sources you inspected in Steps 2–3. With ALFS-native edit tools, edit those
+ALFS files directly. In shell-only CLI sessions, edit the downloaded local
+files in place with the `Edit` tool. Swap data paths to your own namespace,
+adjust strategy parameters, and apply the user's customization request **within
+the scope defined above** (data/topic by default; structure only on explicit
+request). Do not write fresh files from scratch.
 
-1. **Edit local feed script** (the `./{feed_name}.js` from Step 3) and
-   upload to ALFS:
+1. **Write the edited feed script** to ALFS:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
 3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
 4. **Deploy cronjob**: `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
 5. **Release feed**: `alva release feed --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
-6. **Edit local HTML** (the `./index.html` from Step 2 — update data
-   paths to point to your own feed) and upload:
+6. **Write the edited HTML** to ALFS after updating data paths to point to
+   your own feed:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
 7. **Copy inherited UDF entry scripts when present**: for each source UDF,
-   upload the edited local entry script to a path under the new playbook, for
-   example
+   write the edited entry script to a path under the new playbook, for example
    `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
 8. **Write README** (mandatory) — adapt the source playbook's README to
-   your data sources and methodology, then upload:
+   your data sources and methodology, then write it to ALFS:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
 9. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
@@ -252,27 +255,28 @@ Extracted from the `url` attribute: owner = `alice`, name =
 `btc-momentum`. The user's customization request is the text after the
 tag: "Add a summary section at the bottom."
 
-Agent downloads sources to local files (so they can be edited in place,
-not retyped):
+Agent inspects sources so they can be edited in place, not retyped. With
+ALFS-native tools, edit the ALFS sources directly; in shell-only CLI sessions,
+save them to local files:
 
 ```bash
 # 1. Metadata — releases[0].feeds carries feed_name + feed_id per ref
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/playbook.json'
 
-# 2. HTML source — saved locally for in-place editing
+# 2. HTML source — save locally only in shell-only CLI sessions
 alva fs read --path '/alva/home/alice/playbooks/btc-momentum/index.html' > ./index.html
 
-# 3. Feed source code (use feed_name from playbook.json) — saved locally
+# 3. Feed source code (use feed_name from playbook.json) — same shell-only fallback
 alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/src/index.js' > ./btc-momentum.js
 
 # 4. (Optional) Sample data for schema understanding — reference only, no redirect
 alva fs read --path '/alva/home/alice/feeds/btc-momentum/v1/data/market/ohlcv/@last/3'
 ```
 
-Agent then runs the content-legitimacy audit on `./index.html` and
-`./btc-momentum.js` (Step 4), edits those local files in place to apply
-the user's customization, then uploads them under the user's own
-namespace with a new name (e.g. `my-btc-strategy`) and releases.
+Agent then runs the content-legitimacy audit on the inspected HTML and feed
+script (Step 4), edits them in place to apply the user's customization, then
+writes them under the user's own namespace with a new name (e.g.
+`my-btc-strategy`) and releases.
 
 Save lineage (assuming current user is `bob`, new playbook name is `my-btc-strategy`):
 

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -93,8 +93,8 @@ same `function_name` and `params_schema` on the remixed playbook.
 ## Step 2 — Read UI Layer (HTML Source)
 
 If ALFS-native read/write/edit tools are available, inspect and edit the ALFS
-source directly. Do not force a local download/upload loop in embedded jagent
-mode.
+source directly. Do not force a local download/upload loop in PI/jagent agent
+tool mode.
 
 In a shell-only CLI session, download to a local file; do not regenerate from
 memory. Redirect `alva fs read` output into a local file so you can edit it in
@@ -201,20 +201,24 @@ adjust strategy parameters, and apply the user's customization request **within
 the scope defined above** (data/topic by default; structure only on explicit
 request). Do not write fresh files from scratch.
 
-1. **Write the edited feed script** to ALFS:
+1. **Write the edited feed script** to ALFS. Use the ALFS write/edit tool in
+   agent tool mode; shell-only fallback:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
 3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
 4. **Deploy cronjob**: `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
 5. **Release feed**: `alva release feed --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
 6. **Write the edited HTML** to ALFS after updating data paths to point to
-   your own feed:
+   your own feed. Use the ALFS write/edit tool in agent tool mode; shell-only
+   fallback:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
 7. **Copy inherited UDF entry scripts when present**: for each source UDF,
-   write the edited entry script to a path under the new playbook, for example
+   write the edited entry script to a path under the new playbook. Use the
+   ALFS write/edit tool in agent tool mode; shell-only fallback:
    `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
 8. **Write README** (mandatory) — adapt the source playbook's README to
-   your data sources and methodology, then write it to ALFS:
+   your data sources and methodology, then write it to ALFS. Use the ALFS
+   write/edit tool in agent tool mode; shell-only fallback:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
 9. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`


### PR DESCRIPTION
## Summary

- Document PI/jagent agent tool mode for the Alva skill: when an `alva` model tool and ALFS-native `read`/`write`/`edit` tools are available, use them instead of local download/upload loops.
- Update feed, playbook, remix, UDF, release, and alpi references so `--file`, `--local-file`, `--params-schema-file`, and screenshot `--out` examples are clearly shell-only fallbacks.
- Prefer ALFS paths, inline data/JSON, and direct ALFS write/edit flows for agent tool execution.

## Why

The full Alva PI agent now exposes an `alva` tool backed by the toolkit CLI dispatcher, while skill loading stays with PI's normal skill mechanism. The skill docs should steer models toward calling the tool and editing ALFS directly, not toward local filesystem uploads that are unavailable in agent tool mode.

## Dependencies

- alva-ai/toolkit-ts#101: merged.
- alva-ai/alpi#11: merged.
- alva-ai/jagent#679: merged fetch headers compatibility used by the toolkit path.

## Validation

- `git diff --check`