### PR TITLE
docs(alva): document custom Altra OHLCV providers

### DIFF
--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -239,6 +239,7 @@ const {
   fld,
   makeDoc,
   createArraysOhlcvProvider,
+  createOhlcvProviderFromMultipleJson,
 } = require("@alva/feed");
 const {
   FeedAltra,
@@ -262,6 +263,7 @@ const {
 | `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level)   | Field type helpers (same as Feed SDK)            |
 | `makeDoc`                                 | `@alva/feed` (top level)   | Type document helper                             |
 | `createArraysOhlcvProvider`               | `@alva/feed` (top level)    | Builds the OHLCV provider used by Altra          |
+| `createOhlcvProviderFromMultipleJson`     | `@alva/feed` (top level)    | OHLCV provider from your own bars                |
 
 ---
 
@@ -306,6 +308,30 @@ When a user asks for a multi-year intraday stock backtest, do not blindly set a
 to daily/weekly bars if that still answers the question, or use a provider path
 that explicitly chunks the request. Retrying the same full-window request across
 regions usually does not fix this class of request.
+
+### Custom OHLCV Provider
+
+Use `createOhlcvProviderFromMultipleJson` when the traded series has no built-in
+Arrays symbol, such as a rotating contract, expiring option, roll, spread, or
+basket. Fetch or compute the bars first, then let Altra own event dispatch,
+orders, portfolio, and performance.
+
+```javascript
+const { createOhlcvProviderFromMultipleJson } = require("@alva/feed");
+
+// bars: [{ date, endTime, open, high, low, close, volume }] with ms timestamps.
+const provider = createOhlcvProviderFromMultipleJson([
+  JSON.stringify({ pair, interval: simTick, bars: minuteBars }),
+  JSON.stringify({ pair, interval: "1d", bars: dayBars }),
+]);
+
+const altra = new FeedAltra(config, provider);
+altra.getDataGraph().registerOhlcv(pair, simTick);
+```
+
+Provide the strategy interval and `"1d"` for each synthetic pair; performance
+valuation reads daily bars too. Keep `pair` in valid `VENUE_CONTRACT_BASE_QUOTE`
+form with no underscores inside the base segment, or order validation fails.
 
 ---
 


### PR DESCRIPTION
Fixes alva-ai/eval-issues#1606
Source: alva-ai/eval-issues#1606

## Problem
Partial improvement for eval backtest#7: codex often read the Altra reference but bypassed FeedAltra for custom option/rotating-contract series because the reference only showed built-in Arrays OHLCV symbols, so it fell back to raw net/http kline loops and custom P&L accounting.

## Fix
Added a lean Custom OHLCV Provider pattern to skills/alva/references/altra-trading.md, including the verified createOhlcvProviderFromMultipleJson export, registration shape, daily-bar requirement, and valid-pair naming gotcha.

## Why this works
When an instrument has no built-in Arrays symbol, the agent now has a concrete Altra provider path instead of treating missing symbol coverage as a reason to become the backtest engine. The fix improved codex eval backtest#7 from mean -0.1667 to 0.3333 over 4 runs (Δ +0.50), with residual stochastic failures where the agent either timed out in probing or ignored the reference and hand-rolled the loop.

## Verification (local, skill ba3d15a.codex)
`f150fdc.codex` → `ba3d15a.codex`

- Fixed: **1**  |  Regressed (good→bad): **0**
- 0/1 evals unchanged (hidden)

| eval | from | to | Δ |
|---|---|---|---|
| `#7` | -0.17 | 0.33 | +0.50 ✅ |

> Auto-prepared by alva-skill-iterator (no CI gate). Reviewer: confirm the
> problem framing, the fix, and that the baseline went RED→green with no
> regression above, then merge.
