### PR TITLE
test(alva): relax README release eval wording

### DIFF
--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -106,7 +106,8 @@
             "includes": [
               "Every `alva release playbook` call needs a freshly reviewed README",
               "regenerate the README",
-              "upload it again to `~/playbooks/<name>/README.md` before release"
+              "`~/playbooks/<name>/README.md`",
+              "before release"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Relax the dashboard playbook scenario check so it validates README release behavior instead of the exact upload/write wording.
- Keep the important signals: freshly reviewed README, regeneration, canonical README path, and release timing.

## Tests
- node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva
- node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva