### PR TITLE
docs(alva-skill): document cronjob user prompt

### DIFF
--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -9,6 +9,11 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 > [user-facing-prose.md](user-facing-prose.md#voice-block) verbatim in
 > `systemPrompt`.
 
+For deployed cronjobs, prefer `alva deploy create/update --user-prompt` for
+per-deployment agent instructions. The runtime appends that prompt to Agent and
+AgentHarness system prompts before start, so do not duplicate the same prompt
+through `--args` unless the script needs to read it as ordinary data.
+
 ## Quick Start
 
 ```javascript

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -28,7 +28,8 @@ The deployment workflow:
 
 Cronjobs execute the script through the same jagent runtime as `alva run`.
 The script receives the same environment (`require("env").args` contains the
-cronjob's args).
+cronjob's args; `require("env").userPrompt` contains the cronjob user prompt
+when one is configured).
 
 ---
 
@@ -39,7 +40,7 @@ All cronjob operations use `alva deploy <subcommand>`.
 ### Create Cronjob
 
 ```bash
-alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *" --args '{"symbol": "BTC"}' --push-notify
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *" --args '{"symbol": "BTC"}' --user-prompt "Focus on risk changes since the last run." --push-notify
 ```
 
 | Flag            | Type   | Required | Description                                            |
@@ -48,6 +49,7 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 | --cron          | string | yes      | Standard cron expression                               |
 | --name          | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
 | --args          | JSON   | no       | JSON passed to `require("env").args` on each execution |
+| --user-prompt   | string | no       | Runtime prompt available as `require("env").userPrompt`; see [jagent-runtime.md](jagent-runtime.md#env----environment) and [alpi.md](alpi.md) for consumption |
 | --push-notify   | flag   | no       | Let this cronjob emit feed alert events after successful feed runs |
 
 When `--push-notify` is set, every successful cronjob execution checks the
@@ -73,6 +75,7 @@ the cronjob.
   "cron_expression": "0 */4 * * *",
   "status": "active",
   "args": { "symbol": "BTC" },
+  "user_prompt": "Focus on risk changes since the last run.",
   "push_notify": true,
   "created_at": "2026-03-04T12:00:00Z",
   "updated_at": "2026-03-04T12:00:00Z"
@@ -101,10 +104,10 @@ alva deploy get --id 42
 Partial update -- only include flags you want to change.
 
 ```bash
-alva deploy update --id 42 --cron "0 */2 * * *" --args '{"symbol":"ETH"}'
+alva deploy update --id 42 --cron "0 */2 * * *" --args '{"symbol":"ETH"}' --user-prompt "Focus on ETH-specific liquidity changes."
 ```
 
-Updatable fields: `--name`, `--cron`, `--args`, `--push-notify` / `--no-push-notify`.
+Updatable fields: `--name`, `--cron`, `--args`, `--user-prompt`, `--push-notify` / `--no-push-notify`.
 
 ### Delete Cronjob
 
@@ -230,7 +233,7 @@ rejected.
 When a cronjob triggers:
 
 1. The scheduler reads the cronjob config
-2. It executes the script with the configured `entry_path` and `args`
+2. It executes the script with the configured `entry_path`, `args`, and user prompt
 3. The script runs in the same environment as a manual `alva run` call
 
 The script has full access to:
@@ -238,6 +241,7 @@ The script has full access to:
 - All `require()` modules (alfs, env, net/http, runtime libraries, @alva/feed,
   etc.)
 - `require("env").args` contains the args from the cronjob configuration
+- `require("env").userPrompt` contains the configured user prompt
 - Filesystem read/write
 - HTTP requests
 

--- a/skills/alva/references/jagent-runtime.md
+++ b/skills/alva/references/jagent-runtime.md
@@ -105,12 +105,17 @@ env.userId; // "1" (string) -- your numeric user ID
 env.callerUserId; // "2" (string) -- invoking user's ID for UDF calls, when present
 env.username; // "alice" (string) -- your username, used in ALFS paths
 env.args; // parsed JSON from the request's "args" field
+env.userPrompt; // configured cronjob user prompt, when present
 ```
 
 For UDF executions, `env.userId` / `env.username` identify the execution owner
 whose ALFS context runs the script. `env.callerUserId` identifies the caller who
 invoked the UDF and may differ from the owner. It is absent when no caller ID is
 available.
+
+When a deployed cronjob uses `--user-prompt`, the value is available as
+`env.userPrompt`. If the script uses `@alva/pi`, see [alpi.md](alpi.md) for
+the automatic prompt-injection behavior.
 
 ### secret-manager -- Third-Party Secrets
 


### PR DESCRIPTION
## Summary
- document `alva deploy create/update --user-prompt` in the deployment reference
- document `require("env").userPrompt` in the jagent runtime reference
- document `@alva/pi` automatic pre-start prompt injection guidance

## Dependency
- Pairs with toolkit support: https://github.com/alva-ai/toolkit-ts/pull/107

## Tests
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/cronjob-user-prompt/skills/alva`
- `git diff --check`
