### PR TITLE
docs(alva): default line to l12 0.5px; route tables to design-widgets

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -455,10 +455,11 @@ The design system is a release gate, not decoration. Read
 [design.md](references/design.md) first for tokens, typography, theme, layout,
 and the canonical stylesheet. Then read:
 
-- [design-widgets.md](references/design-widgets.md) for charts and widget
-  layouts.
+- [design-widgets.md](references/design-widgets.md) for charts, widget
+  layouts, and tables (the authoritative Table Card spec lives here, not in
+  design-components.md).
 - [design-components.md](references/design-components.md) for buttons, tabs,
-  tags, dropdowns, tables, and component details.
+  tags, dropdowns, and component details.
 - [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md)
   for strategy/backtest playbooks.
 

--- a/skills/alva/references/css/design-system.css
+++ b/skills/alva/references/css/design-system.css
@@ -1546,13 +1546,13 @@ body {
   width: 0.5px;
   flex-shrink: 0;
   margin-block: var(--spacing-l);
-  background-color: var(--line-l07);
+  background-color: var(--line-l12);
 }
 
 .divider-h {
   height: 0.5px;
   margin-inline: var(--spacing-l);
-  background-color: var(--line-l07);
+  background-color: var(--line-l12);
 }
 
 /* ── Equal Height Fill ── */
@@ -1777,7 +1777,7 @@ body {
   left: var(--spacing-m);
   right: var(--spacing-m);
   height: 0.5px;
-  background: var(--line-l07);
+  background: var(--line-l12);
 }
 
 .feed-item:last-child::after {
@@ -1973,7 +1973,7 @@ body {
   width: 88px;
   height: 70px;
   border-radius: var(--radius-ct-s);
-  border: 1px solid var(--line-l07);
+  border: 0.5px solid var(--line-l12);
   flex-shrink: 0;
   overflow: hidden;
   position: relative;

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -25,7 +25,7 @@
 1. **Widget-internal layout uses `flex-wrap`** (metric rows, metric groups,
    side-by-side elements). Never `grid-cols-N` — grid is only for page-level
    `.widget-grid`. → [Details](#content-reflow)
-2. **No border/outline on widgets** — use `--grey-g01` or `--line-l07` dividers.
+2. **No border/outline on widgets** — use `--grey-g01` or `--line-l12` dividers.
    Only Tags may have borders. → [Details](#widget-background)
 3. **Dividers don't span full width** — align both ends with content padding. →
    [Details](#divider)
@@ -98,13 +98,13 @@
   width: 0.5px;
   flex-shrink: 0;
   margin-block: var(--spacing-l);
-  background-color: var(--line-l07);
+  background-color: var(--line-l12);
 }
 
 .divider-h {
   height: 0.5px;
   margin-inline: var(--spacing-l);
-  background-color: var(--line-l07);
+  background-color: var(--line-l12);
 }
 
 /* ── Equal Height Fill ── */
@@ -879,7 +879,7 @@ for rich text rendering.
   left: var(--spacing-m);
   right: var(--spacing-m);
   height: 0.5px;
-  background: var(--line-l07);
+  background: var(--line-l12);
 }
 
 .feed-item:last-child::after {
@@ -1075,7 +1075,7 @@ for rich text rendering.
   width: 88px;
   height: 70px;
   border-radius: var(--radius-ct-s);
-  border: 1px solid var(--line-l07);
+  border: 0.5px solid var(--line-l12);
   flex-shrink: 0;
   overflow: hidden;
   position: relative;
@@ -1371,7 +1371,7 @@ Youtube thumbnails show a play button.
 - **Info line** (`.feed-info`): for Podcast / Youtube / News — `Source · Date · By Author`.
 - **Actions** (`.feed-actions`): for X / Reddit — icon 14×14 + count, `gap: var(--spacing-xs)`.
 - **Thumbnail** (`.feed-thumb`): 88×70, right side via flex order,
-  `border: 1px solid var(--line-l07)`. Optional for all types.
+  `border: 0.5px solid var(--line-l12)`. Optional for all types.
 - **Play button**: Podcast and Youtube thumbnails show a centered play icon
   (`.feed-thumb-play`, 28×28).
 - **Divider** (`.feed-item::after`): 1px line between items, inset by

--- a/skills/alva/references/design.md
+++ b/skills/alva/references/design.md
@@ -36,7 +36,7 @@ Token quick reference:
 | Chart colors | `--chart-{color}-main/1/2`                     | Grey only when ≥ 3 series               |
 | Text         | `--text-n9/n7/n5/n3/n2`                        | n9=primary, n7=secondary, n5=supporting |
 | Background   | `--b0-page`, `--grey-g01`~`g7`                 | g01 for card backgrounds                |
-| Line         | `--line-l05/l07/l12/l2/l3/l9`                  | l07=default, l9=hover/active            |
+| Line         | `--line-l05/l07/l12/l2/l3/l9`                  | l12=default (0.5px), l9=hover/active     |
 | Shadow       | `--shadow-xs/s/l`                              | Floating surfaces only (dropdown/tooltip) |
 | Spacing      | `--spacing-xxxs`(2) ~ `--spacing-xxxxxxl`(56)  | Common: xs=8, m=16, xl=24               |
 | Radius       | `--radius-ct-min`(2) ~ `--radius-ct-max`(960)  | min=Tag, s=Card, l=Page                 |


### PR DESCRIPTION
## What

- **design.md** — default line token `l07` → `l12` (0.5px)
- **design-widgets.md** — replace all `--line-l07` dividers/borders with `--line-l12`; `.feed-thumb` border `1px` → `0.5px`
- **SKILL.md** — point the table spec to `design-widgets.md` (authoritative Table Card); drop the misleading "tables" pointer from `design-components.md`

## Why

The default line token and the table-spec routing were inconsistent. The SKILL routed agents to `design-components.md` for tables, but the authoritative Table Card spec lives in `design-widgets.md` — a likely cause of generated tables drifting off-spec. This aligns the default line weight/color and fixes the routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)