### PR TITLE
docs(alva): document feed.loadPrompt + release feed --agent-type

### DIFF
--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -103,6 +103,9 @@ events unless the script truly needs progress updates.
 | `initialState.thinkingLevel` | no | Use `"off"` for deterministic result-only jobs unless reasoning is needed. |
 | `getApiKey` | no | Omit to use the jagent-managed platform key (default). For BYOK, return your own key loaded via `secret-manager` — passed through to the provider, not billed to platform credits. |
 
+For an owner-editable `systemPrompt`, load it from the feed with
+`feed.loadPrompt(fallback)` — see [feed-sdk.md](feed-sdk.md#editable-system-prompt--loadpromptfallback).
+
 ### Tool
 
 | Field | Description |

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -55,9 +55,18 @@ the agent ran `alva skillhub get` / `alva skillhub file` during building.
 ## Agent type
 
 `alva release feed --agent-type <kind>` marks the feed as a prompt-editable
-agent. The only v1 value is `alpi`. The flag is recorded on the released feed;
-the frontend then shows a system-prompt editor to the feed's owner, who can edit
-the prompt without a redeploy (the next scheduled run picks up the change).
+agent. `<kind>` must be a value from the known catalog — the backend **rejects
+unknown values** (`InvalidArgument`):
+
+| `agent_type` | Meaning |
+|--------------|---------|
+| `alpi` | an `@alva/pi` prompt-editable agent (reads `AGENTS.md` via `feed.loadPrompt`) |
+| *(omitted / empty)* | an ordinary, non-agent feed (no prompt editor) |
+
+`alpi` is the only kind in v1; more may be added. The flag is recorded on the
+released feed; the frontend then shows a system-prompt editor to the feed's
+owner, who can edit the prompt without a redeploy (the next scheduled run picks
+up the change).
 
 The agent reads its editable prompt with `feed.loadPrompt(fallback)`, which
 reads `${feed.path}/AGENTS.md` — see

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -9,6 +9,7 @@ flags, display-name conventions, and examples. This file covers only:
 3. `--trading-symbols` and `--tags` semantics, person-name discovery tags,
    and the required overlap between trading symbols and tags
 4. `--skill-id` — when it is required
+5. `--agent-type` — marking a feed as a prompt-editable agent
 
 ## Feed `--description` conventions
 
@@ -50,6 +51,19 @@ Examples:
 `--skill-id` is required whenever a Skillhub skill informed the build —
 i.e. the request carried a `/use-skill:<username>/<name>` directive, or
 the agent ran `alva skillhub get` / `alva skillhub file` during building.
+
+## Agent type
+
+`alva release feed --agent-type <kind>` marks the feed as a prompt-editable
+agent. The only v1 value is `alpi`. The flag is recorded on the released feed;
+the frontend then shows a system-prompt editor to the feed's owner, who can edit
+the prompt without a redeploy (the next scheduled run picks up the change).
+
+The agent reads its editable prompt with `feed.loadPrompt(fallback)`, which
+reads `${feed.path}/prompt.md` — see
+[feed-sdk.md](../feed-sdk.md#editable-system-prompt--loadpromptfallback). The
+prompt path is **backend-derived** from the feed; there is no `--prompt-path`
+flag.
 
 ## Playbook README
 

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -60,7 +60,7 @@ the frontend then shows a system-prompt editor to the feed's owner, who can edit
 the prompt without a redeploy (the next scheduled run picks up the change).
 
 The agent reads its editable prompt with `feed.loadPrompt(fallback)`, which
-reads `${feed.path}/prompt.md` — see
+reads `${feed.path}/AGENTS.md` — see
 [feed-sdk.md](../feed-sdk.md#editable-system-prompt--loadpromptfallback). The
 prompt path is **backend-derived** from the feed; there is no `--prompt-path`
 flag.

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -191,6 +191,10 @@ These three move in lockstep at create time (`alva deploy create` →
 lifecycle row. Deleting one does **not** automatically delete the
 others — see the cascade notes in each `--help`.
 
+`alva release feed` also accepts `--agent-type alpi` to mark a feed whose
+alpi agent has an owner-editable system prompt — see
+[api/release.md](api/release.md#agent-type).
+
 **Don't use `alva fs remove` to delete a feed or playbook.** It clears
 the ALFS files (the rendered HTML, the data mount), but the
 `playbooks` / `feeds` DB row stays alive. The platform still:

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -435,7 +435,7 @@ feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 
 When a feed runs an alpi `Agent`, externalize the agent's system prompt so the
 owner can edit it without a redeploy. `feed.loadPrompt(fallback)` reads
-`${feed.path}/prompt.md` (i.e. `~/feeds/<name>/v<major>/prompt.md`) at run start
+`${feed.path}/AGENTS.md` (i.e. `~/feeds/<name>/v<major>/AGENTS.md`) at run start
 and returns its content, else the `fallback`. The `Feed` already knows its path,
 feed name, and major — pass no path/feed/major args, only the fallback.
 
@@ -445,7 +445,7 @@ const { Feed, feedPath } = require("@alva/feed");
 const feed = new Feed({ path: feedPath("<name>") });
 const agent = new Agent({
   initialState: {
-    // reads ~/feeds/<name>/v<major>/prompt.md, else the fallback (which
+    // reads ~/feeds/<name>/v<major>/AGENTS.md, else the fallback (which
     // includes the user-facing-prose voice block if this agent emits prose)
     systemPrompt: await feed.loadPrompt("You are ..."),
     model: getModel("openai", "gpt-5.5"),
@@ -457,9 +457,9 @@ const agent = new Agent({
 If this agent emits user-facing prose (TLDR, digest, why-it-matters, delta
 body, push line), put the voice block from
 [user-facing-prose.md](user-facing-prose.md#voice-block) verbatim in the
-`fallback` so the agent still has it when `prompt.md` is absent.
+`fallback` so the agent still has it when `AGENTS.md` is absent.
 
-Edits to `prompt.md` apply on the next scheduled run — no redeploy. To surface
+Edits to `AGENTS.md` apply on the next scheduled run — no redeploy. To surface
 the prompt editor to the feed's owner in the frontend, release the feed as a
 prompt-editable agent with `alva release feed --agent-type alpi` (the prompt
 path is backend-derived; there is no `--prompt-path` flag). See

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -431,6 +431,40 @@ The resolved base path (no `/data` suffix).
 feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 ```
 
+### Editable system prompt — `loadPrompt(fallback)`
+
+When a feed runs an alpi `Agent`, externalize the agent's system prompt so the
+owner can edit it without a redeploy. `feed.loadPrompt(fallback)` reads
+`${feed.path}/prompt.md` (i.e. `~/feeds/<name>/v<major>/prompt.md`) at run start
+and returns its content, else the `fallback`. The `Feed` already knows its path,
+feed name, and major — pass no path/feed/major args, only the fallback.
+
+```javascript
+const { Agent, getModel } = require("@alva/pi");
+const { Feed, feedPath } = require("@alva/feed");
+const feed = new Feed({ path: feedPath("<name>") });
+const agent = new Agent({
+  initialState: {
+    // reads ~/feeds/<name>/v<major>/prompt.md, else the fallback (which
+    // includes the user-facing-prose voice block if this agent emits prose)
+    systemPrompt: await feed.loadPrompt("You are ..."),
+    model: getModel("openai", "gpt-5.5"),
+    tools: [/* ... */],
+  },
+});
+```
+
+If this agent emits user-facing prose (TLDR, digest, why-it-matters, delta
+body, push line), put the voice block from
+[user-facing-prose.md](user-facing-prose.md#voice-block) verbatim in the
+`fallback` so the agent still has it when `prompt.md` is absent.
+
+Edits to `prompt.md` apply on the next scheduled run — no redeploy. To surface
+the prompt editor to the feed's owner in the frontend, release the feed as a
+prompt-editable agent with `alva release feed --agent-type alpi` (the prompt
+path is backend-derived; there is no `--prompt-path` flag). See
+[api/release.md](api/release.md#agent-type).
+
 ---
 
 ## feedPath(name, version?)


### PR DESCRIPTION
## Summary
- Documents `feed.loadPrompt(fallback)` (the editable-system-prompt idiom) in `references/feed-sdk.md`, and the new `alva release feed --agent-type` flag in `references/api/release.md`, with brief pointers from `alpi.md` and `deployment.md`. `SKILL.md` unchanged (it already routes to these).

## Breaking Changes
None — docs only.

## Database Migrations
None.

## Merge Order
None (docs; describes behavior shipping in the related PRs).

## Related
- alva-ai/alva-backend#1576 — backend feed marker + migration + proto
- alva-ai/backtest-js#311 — `@alva/feed` `Feed.loadPrompt`
- alva-ai/toolkit-ts#108 — `alva release feed --agent-type`
- alva-gateway / frontend-monorepo / jagent(bundle) — deferred to integration

## Test Plan
- [x] Links resolve; DRY (depth in feed-sdk.md / api/release.md; alpi.md + deployment.md are pointers); no SKILL.md duplication
- [ ] CI green (if any markdown lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)