### PR TITLE
docs(alva): require intraday for realtime prices

### DIFF
--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -16,7 +16,7 @@
           "content-legitimacy.md"
         ],
         "behaviors": [
-          "Direct latest price for covered US equities and crypto: intraday klines, not daily close",
+          "Direct latest/realtime price for covered US equities and crypto: intraday klines, not daily-level bars or closes",
           "Do not answer until you can name the decomposition",
           "Do not let playbook creation become the default"
         ],

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -272,8 +272,8 @@ Source routing:
 - Global X search beyond Arrays' index, news/web search, non-US finance, or
   off-catalog asset classes: [search.md](references/search.md) /
   `unified_search`.
-- Direct latest price for covered US equities and crypto: intraday klines, not
-  daily close.
+- Direct latest/realtime price for covered US equities and crypto: intraday
+  klines, not daily-level bars or closes.
 - Non-US equities (dotted-suffix tickers like `0700.HK`, `000660.KS`): try Data
   Skills non-US daily kline first; fall back to `searchPerplexityFinance` for
   uncovered tickers or intraday/live prices.

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -56,8 +56,9 @@ Twitter/X routing:
 
 Direct latest-price routing:
 
-- Covered US equities and crypto: use structured intraday kline data, not daily
-  bars during market hours.
+- Covered US equities and crypto: latest/realtime price answers must use
+  structured intraday kline data. Do not use daily-level bars or daily closes as
+  current prices.
 - Non-US equities (dotted-suffix tickers like `0700.HK`, `000660.KS`): try Data
   Skills first for daily (`1d`) kline and company detail. Coverage is a curated,
   daily-only subset, so fall back to `searchPerplexityFinance` when the ticker

--- a/skills/alva/references/operational-pitfalls.md
+++ b/skills/alva/references/operational-pitfalls.md
@@ -52,8 +52,8 @@ Do not use destructive resets in production.
 
 ## Chart And HTML
 
-- Covered US equities and crypto latest-price answers need intraday klines.
-  Daily bars return prior close during trading hours.
+- Covered US equities and crypto latest/realtime price answers need intraday
+  klines; daily-level bars and closes are not current-price sources.
 - ECharts date axes should use `type: 'time'`, not raw epoch values as category
   labels.
 - ECharts in tabs or hidden containers must initialize/resize through


### PR DESCRIPTION
## Summary
- tighten Alva latest/realtime price routing to require intraday klines for covered US equities and crypto
- clarify that daily-level bars and daily closes are not valid current-price sources
- update the simple latest-price scenario expectation to protect the new wording

## Validation
- bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva
- node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva
- node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva
- git diff --check
