### PR TITLE
docs(alva): agent_type release + loadPrompt append pattern

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -440,8 +440,9 @@ upstream data.
 Do **not** use it for one-off research the user asks interactively, and do
 not use it to produce numbers or events that should come from real data. Read
 [alpi.md](references/alpi.md) for API, tool calling, memory patterns,
-owner-editable system prompts (release with `--agent-type alpi` + append
-`feed.loadPrompt`), and jagent-specific constraints.
+supplemental owner-editable prompts (release with `--agent-type alpi`, then
+append `feed.loadPrompt` on top of your base prompt), and jagent-specific
+constraints.
 
 #### Model Layer: ONNX
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -439,8 +439,9 @@ upstream data.
 
 Do **not** use it for one-off research the user asks interactively, and do
 not use it to produce numbers or events that should come from real data. Read
-[alpi.md](references/alpi.md) for API, tool calling, memory patterns, and
-jagent-specific constraints.
+[alpi.md](references/alpi.md) for API, tool calling, memory patterns,
+owner-editable system prompts (release with `--agent-type alpi` + append
+`feed.loadPrompt`), and jagent-specific constraints.
 
 #### Model Layer: ONNX
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -440,9 +440,8 @@ upstream data.
 Do **not** use it for one-off research the user asks interactively, and do
 not use it to produce numbers or events that should come from real data. Read
 [alpi.md](references/alpi.md) for API, tool calling, memory patterns,
-supplemental owner-editable prompts (release with `--agent-type alpi`, then
-append `feed.loadPrompt` on top of your base prompt), and jagent-specific
-constraints.
+user-editable agent instructions (release with `--agent-type alpi`, then append
+the owner's `AGENTS.md` via `feed.loadPrompt`), and jagent-specific constraints.
 
 #### Model Layer: ONNX
 

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -159,58 +159,21 @@ Guidelines:
 
 ## Patterns & Examples
 
-### Supplemental (owner-editable) system prompt — alpi feed
+### User-editable instructions — alpi feed
 
-When an alpi script *produces a feed*, let the owner tune its behavior with a
-**supplemental prompt** they edit in the feed's `AGENTS.md` — no redeploy from
-you. Your `BASE_PROMPT` (the agent's real instructions) stays in code; the
-supplement is *appended on top*, never a replacement. See
-[feed-sdk.md](feed-sdk.md#loadpromptfallback) for the `loadPrompt` API.
+Let the feed owner steer the agent by editing the feed's `AGENTS.md` (their own
+instructions), no redeploy. Release with `--agent-type alpi`, then append those
+instructions onto your `BASE_PROMPT`:
 
-1. **Release the feed with `agent_type`** so its `AGENTS.md` becomes editable:
+```javascript
+const userInstructions = await feed.loadPrompt(""); // owner's AGENTS.md, "" if none
+const systemPrompt = userInstructions
+  ? `${BASE_PROMPT}\n\n## User instructions\n${userInstructions}`
+  : BASE_PROMPT;
+```
 
-   ```bash
-   alva release feed --name market-pulse --version 1.0.0 --cronjob-id 44 --agent-type alpi
-   ```
-
-2. **Append the supplement to your base prompt** and use it as `systemPrompt`:
-
-   ```javascript
-   const { Feed, feedPath } = require("@alva/feed");
-   const { Agent, getModel } = require("@alva/pi");
-
-   const feed = new Feed({ path: feedPath("market-pulse") });
-
-   const BASE_PROMPT =
-     "You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.";
-
-   // AGENTS.md is a SUPPLEMENT appended on top — not a replacement.
-   const supplement = await feed.loadPrompt(""); // "" when the owner hasn't written one
-   const systemPrompt = supplement
-     ? `${BASE_PROMPT}\n\n## Additional instructions from the feed owner\n${supplement}`
-     : BASE_PROMPT;
-
-   const agent = new Agent({
-     initialState: { systemPrompt, model: getModel("openai", "gpt-5.5"), tools: [] },
-   });
-   const { message } = await agent.ask("Summarize today's BTC move.");
-   ```
-
-3. **The owner customizes by editing `AGENTS.md`** (just the supplement, plain
-   text), e.g.:
-
-   ```text
-   Focus only on spot-ETF flows; ignore funding-rate noise.
-   End with a one-line "So what?" for a long-term holder.
-   ```
-
-   The next run's effective `systemPrompt` is base **+** that supplement,
-   appended under the labeled block — applied with no redeploy.
-
-   Pass `""` (not `BASE_PROMPT`) as the fallback: a missing supplement then adds
-   nothing and can never override the base. Never do
-   `feed.loadPrompt(BASE_PROMPT)` — that *replaces* your base instead of
-   supplementing it.
+Append, never replace (pass `""`, not `BASE_PROMPT`). File location + details:
+[feed-sdk.md](feed-sdk.md#loadpromptfallback).
 
 ### Historical Reference (Feed as Memory)
 

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -159,6 +159,44 @@ Guidelines:
 
 ## Patterns & Examples
 
+### User-Editable System Prompt (alpi feed)
+
+When an alpi script *produces a feed*, expose its `systemPrompt` as an
+owner-editable layer so the user can tune the agent's behavior without you
+redeploying. Two steps:
+
+1. **Release the feed with `agent_type` set** so the platform treats its prompt
+   file as editable:
+
+   ```bash
+   alva release feed --name market-pulse --version 1.0.0 --cronjob-id 44 --agent-type alpi
+   ```
+
+2. **In the script, keep a `BASE_PROMPT` and append the editable layer** via
+   `feed.loadPrompt("")` (see [feed-sdk.md](feed-sdk.md#loadpromptfallback)).
+   The base prompt is your real instructions; the editable `AGENTS.md` only adds
+   to it, and a missing file changes nothing:
+
+   ```javascript
+   const { Feed, feedPath } = require("@alva/feed");
+   const { Agent, getModel } = require("@alva/pi");
+
+   const feed = new Feed({ path: feedPath("market-pulse") });
+
+   const BASE_PROMPT =
+     "You are a market analyst. Summarize the day's BTC move in 2 sentences.";
+   const extra = await feed.loadPrompt(""); // owner's AGENTS.md, or "" if none
+   const systemPrompt = extra ? `${BASE_PROMPT}\n\n${extra}` : BASE_PROMPT;
+
+   const agent = new Agent({
+     initialState: { systemPrompt, model: getModel("openai", "gpt-5.5"), tools: [] },
+   });
+   ```
+
+   Append, never replace: pass `""` (not `BASE_PROMPT`) as the fallback, so the
+   editable file *extends* the base behavior instead of overwriting it. Edits to
+   `AGENTS.md` take effect on the next run — no redeploy.
+
 ### Historical Reference (Feed as Memory)
 
 Read the agent's previous output via feed time-series paths

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -159,23 +159,21 @@ Guidelines:
 
 ## Patterns & Examples
 
-### User-Editable System Prompt (alpi feed)
+### Supplemental (owner-editable) system prompt — alpi feed
 
-When an alpi script *produces a feed*, expose its `systemPrompt` as an
-owner-editable layer so the user can tune the agent's behavior without you
-redeploying. Two steps:
+When an alpi script *produces a feed*, let the owner tune its behavior with a
+**supplemental prompt** they edit in the feed's `AGENTS.md` — no redeploy from
+you. Your `BASE_PROMPT` (the agent's real instructions) stays in code; the
+supplement is *appended on top*, never a replacement. See
+[feed-sdk.md](feed-sdk.md#loadpromptfallback) for the `loadPrompt` API.
 
-1. **Release the feed with `agent_type` set** so the platform treats its prompt
-   file as editable:
+1. **Release the feed with `agent_type`** so its `AGENTS.md` becomes editable:
 
    ```bash
    alva release feed --name market-pulse --version 1.0.0 --cronjob-id 44 --agent-type alpi
    ```
 
-2. **In the script, keep a `BASE_PROMPT` and append the editable layer** via
-   `feed.loadPrompt("")` (see [feed-sdk.md](feed-sdk.md#loadpromptfallback)).
-   The base prompt is your real instructions; the editable `AGENTS.md` only adds
-   to it, and a missing file changes nothing:
+2. **Append the supplement to your base prompt** and use it as `systemPrompt`:
 
    ```javascript
    const { Feed, feedPath } = require("@alva/feed");
@@ -184,18 +182,35 @@ redeploying. Two steps:
    const feed = new Feed({ path: feedPath("market-pulse") });
 
    const BASE_PROMPT =
-     "You are a market analyst. Summarize the day's BTC move in 2 sentences.";
-   const extra = await feed.loadPrompt(""); // owner's AGENTS.md, or "" if none
-   const systemPrompt = extra ? `${BASE_PROMPT}\n\n${extra}` : BASE_PROMPT;
+     "You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.";
+
+   // AGENTS.md is a SUPPLEMENT appended on top — not a replacement.
+   const supplement = await feed.loadPrompt(""); // "" when the owner hasn't written one
+   const systemPrompt = supplement
+     ? `${BASE_PROMPT}\n\n## Additional instructions from the feed owner\n${supplement}`
+     : BASE_PROMPT;
 
    const agent = new Agent({
      initialState: { systemPrompt, model: getModel("openai", "gpt-5.5"), tools: [] },
    });
+   const { message } = await agent.ask("Summarize today's BTC move.");
    ```
 
-   Append, never replace: pass `""` (not `BASE_PROMPT`) as the fallback, so the
-   editable file *extends* the base behavior instead of overwriting it. Edits to
-   `AGENTS.md` take effect on the next run — no redeploy.
+3. **The owner customizes by editing `AGENTS.md`** (just the supplement, plain
+   text), e.g.:
+
+   ```text
+   Focus only on spot-ETF flows; ignore funding-rate noise.
+   End with a one-line "So what?" for a long-term holder.
+   ```
+
+   The next run's effective `systemPrompt` is base **+** that supplement,
+   appended under the labeled block — applied with no redeploy.
+
+   Pass `""` (not `BASE_PROMPT`) as the fallback: a missing supplement then adds
+   nothing and can never override the base. Never do
+   `feed.loadPrompt(BASE_PROMPT)` — that *replaces* your base instead of
+   supplementing it.
 
 ### Historical Reference (Feed as Memory)
 

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -9,6 +9,7 @@ flags, display-name conventions, and examples. This file covers only:
 3. `--trading-symbols` and `--tags` semantics, person-name discovery tags,
    and the required overlap between trading symbols and tags
 4. `--skill-id` — when it is required
+5. `--agent-type` — marking a feed as a prompt-editable agent
 
 ## Feed `--description` conventions
 
@@ -50,6 +51,26 @@ Examples:
 `--skill-id` is required whenever a Skillhub skill informed the build —
 i.e. the request carried a `/use-skill:<username>/<name>` directive, or
 the agent ran `alva skillhub get` / `alva skillhub file` during building.
+
+## Agent type
+
+`alva release feed --agent-type <kind>` marks the feed as a prompt-editable
+agent. `<kind>` must be a value from the known catalog — the backend **rejects
+unknown values** (`InvalidArgument`):
+
+| `agent_type` | Meaning |
+|--------------|---------|
+| `alpi` | an `@alva/pi` prompt-editable agent that reads a **supplemental** prompt from `AGENTS.md` via `feed.loadPrompt` |
+| *(omitted / empty)* | an ordinary, non-agent feed (no editable prompt) |
+
+`alpi` is the only kind in v1; more may be added. The flag is recorded on the
+released feed; its owner can then edit the prompt by writing the feed's
+`AGENTS.md` — no redeploy, the next scheduled run picks up the change.
+
+The script reads that editable file with `feed.loadPrompt(fallback)`
+(`${feed.path}/AGENTS.md`) and **appends** it to its base prompt — see
+[feed-sdk.md](../feed-sdk.md#loadpromptfallback). The prompt path is
+**backend-derived** from the feed; there is no `--prompt-path` flag.
 
 ## Playbook README
 

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -55,22 +55,17 @@ the agent ran `alva skillhub get` / `alva skillhub file` during building.
 ## Agent type
 
 `alva release feed --agent-type <kind>` marks the feed as a prompt-editable
-agent. `<kind>` must be a value from the known catalog — the backend **rejects
-unknown values** (`InvalidArgument`):
+agent. `<kind>` must be in the catalog (the backend rejects unknown values with
+`InvalidArgument`); `alpi` is the only kind in v1:
 
 | `agent_type` | Meaning |
 |--------------|---------|
-| `alpi` | an `@alva/pi` prompt-editable agent that reads a **supplemental** prompt from `AGENTS.md` via `feed.loadPrompt` |
-| *(omitted / empty)* | an ordinary, non-agent feed (no editable prompt) |
+| `alpi` | `@alva/pi` agent; its script appends the owner's `AGENTS.md` instructions via `feed.loadPrompt` |
+| *(omitted)* | ordinary feed, no editable prompt |
 
-`alpi` is the only kind in v1; more may be added. The flag is recorded on the
-released feed; its owner can then edit the prompt by writing the feed's
-`AGENTS.md` — no redeploy, the next scheduled run picks up the change.
-
-The script reads that editable file with `feed.loadPrompt(fallback)`
-(`${feed.path}/AGENTS.md`) and **appends** it to its base prompt — see
-[feed-sdk.md](../feed-sdk.md#loadpromptfallback). The prompt path is
-**backend-derived** from the feed; there is no `--prompt-path` flag.
+The owner edits the feed's `AGENTS.md` (`~/feeds/<name>/v<major>/AGENTS.md`) — no
+redeploy. The path is backend-derived (no `--prompt-path` flag). See
+[feed-sdk.md](../feed-sdk.md#loadpromptfallback).
 
 ## Playbook README
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -192,7 +192,7 @@ lifecycle row. Deleting one does **not** automatically delete the
 others — see the cascade notes in each `--help`.
 
 `alva release feed` also accepts `--agent-type alpi` to mark a feed whose
-alpi agent has an owner-editable, supplemental system prompt — see
+alpi agent appends the owner's editable `AGENTS.md` instructions — see
 [api/release.md](api/release.md#agent-type).
 
 **Don't use `alva fs remove` to delete a feed or playbook.** It clears

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -191,6 +191,10 @@ These three move in lockstep at create time (`alva deploy create` →
 lifecycle row. Deleting one does **not** automatically delete the
 others — see the cascade notes in each `--help`.
 
+`alva release feed` also accepts `--agent-type alpi` to mark a feed whose
+alpi agent has an owner-editable, supplemental system prompt — see
+[api/release.md](api/release.md#agent-type).
+
 **Don't use `alva fs remove` to delete a feed or playbook.** It clears
 the ALFS files (the rendered HTML, the data mount), but the
 `playbooks` / `feeds` DB row stays alive. The platform still:

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -433,28 +433,53 @@ feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 
 ### loadPrompt(fallback)
 
-Reads the feed's owner-editable prompt file `AGENTS.md` (at `feed.path/AGENTS.md`)
-and returns its trimmed contents, or `fallback` when the file is missing or
-empty. A missing file is **not** an error. This lets a feed owner tune the
-producer's prompt by editing `AGENTS.md` — it takes effect on the next run with
-no redeploy. The prompt is only surfaced as editable when the feed is released
-with an `agent_type` (e.g. `--agent-type alpi`, see below).
+Reads the feed's owner-editable file `AGENTS.md` (at `feed.path/AGENTS.md`) and
+returns its trimmed contents, or `fallback` when the file is missing or empty (a
+missing file is **not** an error). `AGENTS.md` is only editable when the feed was
+released with an `agent_type` (e.g. `--agent-type alpi`).
 
-**Use it as an additive layer, not a replacement.** Keep your real instructions
-as a `BASE_PROMPT` constant in the script and **append** the editable file on
-top — so the agent always has its base behavior and the editable file only
-customizes it:
+**`AGENTS.md` is a *supplemental* prompt — never the whole prompt.** Your script
+owns a fixed `BASE_PROMPT` (the agent's real behavior, versioned in code).
+`AGENTS.md` is an *additional-instructions* layer the owner tweaks without a
+redeploy. You **append** the supplement to the base; you never let it replace
+the base. Pass `""` as the fallback so a missing supplement contributes nothing.
+
+Canonical pattern — append the supplement as a clearly-labeled block:
 
 ```javascript
-const BASE_PROMPT = "You are a market analyst. Summarize the day's BTC move in 2 sentences.";
-// AGENTS.md content (or "" when the owner hasn't written one yet), appended on top.
-const extra = await feed.loadPrompt("");
-const systemPrompt = extra ? `${BASE_PROMPT}\n\n${extra}` : BASE_PROMPT;
+const BASE_PROMPT =
+  "You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.";
+
+const supplement = await feed.loadPrompt(""); // owner's AGENTS.md, or "" if none
+const systemPrompt = supplement
+  ? `${BASE_PROMPT}\n\n## Additional instructions from the feed owner\n${supplement}`
+  : BASE_PROMPT;
 ```
 
-Pass `""` as the fallback so a missing file contributes nothing; never pass the
-base prompt as the fallback (that would make the editable file *replace* the
-base instead of extending it).
+**What the owner writes** in `AGENTS.md` is *only* the supplement — plain text,
+nothing else. For example, to sharpen the focus the owner writes:
+
+```text
+Focus only on spot-ETF flows and on-chain data; ignore funding-rate noise.
+Always end with a one-line "So what?" for a long-term holder.
+```
+
+**The effective `systemPrompt`** the agent then runs with is base + supplement:
+
+```text
+You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.
+
+## Additional instructions from the feed owner
+Focus only on spot-ETF flows and on-chain data; ignore funding-rate noise.
+Always end with a one-line "So what?" for a long-term holder.
+```
+
+When `AGENTS.md` is empty or absent, the agent runs with `BASE_PROMPT` alone.
+Edits take effect on the next run — no redeploy.
+
+**Do NOT** pass the base as the fallback (`feed.loadPrompt(BASE_PROMPT)`): that
+makes the editable file *replace* your base behavior instead of supplementing
+it. The supplement is always **added on top**, never a substitute.
 
 ---
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -431,6 +431,31 @@ The resolved base path (no `/data` suffix).
 feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 ```
 
+### loadPrompt(fallback)
+
+Reads the feed's owner-editable prompt file `AGENTS.md` (at `feed.path/AGENTS.md`)
+and returns its trimmed contents, or `fallback` when the file is missing or
+empty. A missing file is **not** an error. This lets a feed owner tune the
+producer's prompt by editing `AGENTS.md` — it takes effect on the next run with
+no redeploy. The prompt is only surfaced as editable when the feed is released
+with an `agent_type` (e.g. `--agent-type alpi`, see below).
+
+**Use it as an additive layer, not a replacement.** Keep your real instructions
+as a `BASE_PROMPT` constant in the script and **append** the editable file on
+top — so the agent always has its base behavior and the editable file only
+customizes it:
+
+```javascript
+const BASE_PROMPT = "You are a market analyst. Summarize the day's BTC move in 2 sentences.";
+// AGENTS.md content (or "" when the owner hasn't written one yet), appended on top.
+const extra = await feed.loadPrompt("");
+const systemPrompt = extra ? `${BASE_PROMPT}\n\n${extra}` : BASE_PROMPT;
+```
+
+Pass `""` as the fallback so a missing file contributes nothing; never pass the
+base prompt as the fallback (that would make the editable file *replace* the
+base instead of extending it).
+
 ---
 
 ## feedPath(name, version?)

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -433,53 +433,25 @@ feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 
 ### loadPrompt(fallback)
 
-Reads the feed's owner-editable file `AGENTS.md` (at `feed.path/AGENTS.md`) and
-returns its trimmed contents, or `fallback` when the file is missing or empty (a
-missing file is **not** an error). `AGENTS.md` is only editable when the feed was
-released with an `agent_type` (e.g. `--agent-type alpi`).
+Returns the feed owner's **user instructions** from the feed's `AGENTS.md` —
+`${feed.path}/AGENTS.md`, e.g. `~/feeds/market-pulse/v1/AGENTS.md` — or
+`fallback` when the file is missing/empty (missing is not an error). It is
+editable only on feeds released with an `agent_type` (`--agent-type alpi`).
 
-**`AGENTS.md` is a *supplemental* prompt — never the whole prompt.** Your script
-owns a fixed `BASE_PROMPT` (the agent's real behavior, versioned in code).
-`AGENTS.md` is an *additional-instructions* layer the owner tweaks without a
-redeploy. You **append** the supplement to the base; you never let it replace
-the base. Pass `""` as the fallback so a missing supplement contributes nothing.
-
-Canonical pattern — append the supplement as a clearly-labeled block:
+**Append the user instructions to your base prompt; never let them replace it.**
+Keep your real instructions in `BASE_PROMPT` and pass `""` as the fallback so a
+missing file adds nothing:
 
 ```javascript
-const BASE_PROMPT =
-  "You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.";
-
-const supplement = await feed.loadPrompt(""); // owner's AGENTS.md, or "" if none
-const systemPrompt = supplement
-  ? `${BASE_PROMPT}\n\n## Additional instructions from the feed owner\n${supplement}`
+const userInstructions = await feed.loadPrompt("");
+const systemPrompt = userInstructions
+  ? `${BASE_PROMPT}\n\n## User instructions\n${userInstructions}`
   : BASE_PROMPT;
 ```
 
-**What the owner writes** in `AGENTS.md` is *only* the supplement — plain text,
-nothing else. For example, to sharpen the focus the owner writes:
-
-```text
-Focus only on spot-ETF flows and on-chain data; ignore funding-rate noise.
-Always end with a one-line "So what?" for a long-term holder.
-```
-
-**The effective `systemPrompt`** the agent then runs with is base + supplement:
-
-```text
-You are a crypto market analyst. Summarize the day's BTC move in 2 sentences.
-
-## Additional instructions from the feed owner
-Focus only on spot-ETF flows and on-chain data; ignore funding-rate noise.
-Always end with a one-line "So what?" for a long-term holder.
-```
-
-When `AGENTS.md` is empty or absent, the agent runs with `BASE_PROMPT` alone.
-Edits take effect on the next run — no redeploy.
-
-**Do NOT** pass the base as the fallback (`feed.loadPrompt(BASE_PROMPT)`): that
-makes the editable file *replace* your base behavior instead of supplementing
-it. The supplement is always **added on top**, never a substitute.
+The owner edits `AGENTS.md` (plain-text instructions); the next run picks it up,
+no redeploy. Don't pass `BASE_PROMPT` as the fallback — that lets the file
+*replace* your base instead of extending it.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `feed.loadPrompt(fallback)` in `feed-sdk.md` (reads the feed's editable `AGENTS.md`, or the fallback when missing).
- Add an `alpi.md` pattern for **owner-editable system prompts**: release the feed with `--agent-type alpi`, then **append** the editable `AGENTS.md` onto a `BASE_PROMPT` constant (additive layer — pass `""` as the fallback so a missing file changes nothing; never let it replace the base).
- SKILL.md pointer in the alpi section.

## Related
- https://github.com/alva-ai/alva-gateway/pull/584 (gateway agent_type forwarding)
- https://github.com/alva-ai/toolkit-ts/pull/110 (toolkit `--agent-type` flag)

## Test Plan
- [x] Docs only; loadPrompt anchor verified; reflects shipped `loadPrompt(fallback)` behavior (kept replace-with-fallback; skill teaches the append usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)