### PR TITLE
docs(alva): read AGENTS.md via feed.path instead of feed.loadPrompt

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -441,7 +441,8 @@ Do **not** use it for one-off research the user asks interactively, and do
 not use it to produce numbers or events that should come from real data. Read
 [alpi.md](references/alpi.md) for API, tool calling, memory patterns,
 user-editable agent instructions (release with `--agent-type alpi`, then append
-the owner's `AGENTS.md` via `feed.loadPrompt`), and jagent-specific constraints.
+the owner's `AGENTS.md` (read `${feed.path}/AGENTS.md` yourself)), and
+jagent-specific constraints.
 
 #### Model Layer: ONNX
 

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -166,14 +166,19 @@ instructions), no redeploy. Release with `--agent-type alpi`, then append those
 instructions onto your `BASE_PROMPT`:
 
 ```javascript
-const userInstructions = await feed.loadPrompt(""); // owner's AGENTS.md, "" if none
+const alfs = require("alfs");
+let userInstructions = ""; // owner's AGENTS.md, "" if none
+try {
+  const c = await alfs.readFile(`${feed.path}/AGENTS.md`);
+  if (typeof c === "string") userInstructions = c.trim();
+} catch (_) {}
 const systemPrompt = userInstructions
   ? `${BASE_PROMPT}\n\n## User instructions\n${userInstructions}`
   : BASE_PROMPT;
 ```
 
-Append, never replace (pass `""`, not `BASE_PROMPT`). File location + details:
-[feed-sdk.md](feed-sdk.md#loadpromptfallback).
+Append, never replace (a missing/empty file extends nothing). File location +
+details: [feed-sdk.md](feed-sdk.md#user-instructions-agentsmd).
 
 ### Historical Reference (Feed as Memory)
 

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -162,23 +162,10 @@ Guidelines:
 ### User-editable instructions — alpi feed
 
 Let the feed owner steer the agent by editing the feed's `AGENTS.md` (their own
-instructions), no redeploy. Release with `--agent-type alpi`, then append those
-instructions onto your `BASE_PROMPT`:
-
-```javascript
-const alfs = require("alfs");
-let userInstructions = ""; // owner's AGENTS.md, "" if none
-try {
-  const c = await alfs.readFile(`${feed.path}/AGENTS.md`);
-  if (typeof c === "string") userInstructions = c.trim();
-} catch (_) {}
-const systemPrompt = userInstructions
-  ? `${BASE_PROMPT}\n\n## User instructions\n${userInstructions}`
-  : BASE_PROMPT;
-```
-
-Append, never replace (a missing/empty file extends nothing). File location +
-details: [feed-sdk.md](feed-sdk.md#user-instructions-agentsmd).
+instructions), no redeploy. Release with `--agent-type alpi`, then read
+`${feed.path}/AGENTS.md` and **append** it to your `BASE_PROMPT` — append, never
+replace, so a missing/empty file extends nothing. Read snippet + rules:
+[feed-sdk.md](feed-sdk.md#user-instructions-agentsmd).
 
 ### Historical Reference (Feed as Memory)
 

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -60,12 +60,12 @@ agent. `<kind>` must be in the catalog (the backend rejects unknown values with
 
 | `agent_type` | Meaning |
 |--------------|---------|
-| `alpi` | `@alva/pi` agent; its script appends the owner's `AGENTS.md` instructions via `feed.loadPrompt` |
+| `alpi` | `@alva/pi` agent; its script reads & appends the owner's `AGENTS.md` instructions (`${feed.path}/AGENTS.md`) |
 | *(omitted)* | ordinary feed, no editable prompt |
 
 The owner edits the feed's `AGENTS.md` (`~/feeds/<name>/v<major>/AGENTS.md`) — no
 redeploy. The path is backend-derived (no `--prompt-path` flag). See
-[feed-sdk.md](../feed-sdk.md#loadpromptfallback).
+[feed-sdk.md](../feed-sdk.md#user-instructions-agentsmd).
 
 ## Playbook README
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -431,27 +431,33 @@ The resolved base path (no `/data` suffix).
 feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 ```
 
-### loadPrompt(fallback)
+### User instructions (AGENTS.md)
 
-Returns the feed owner's **user instructions** from the feed's `AGENTS.md` —
-`${feed.path}/AGENTS.md`, e.g. `~/feeds/market-pulse/v1/AGENTS.md` — or
-`fallback` when the file is missing/empty (missing is not an error). It is
+Read the feed owner's **user instructions** from the feed's `AGENTS.md` —
+`${feed.path}/AGENTS.md`, e.g. `~/feeds/market-pulse/v1/AGENTS.md`. It is
 editable only on feeds released with an `agent_type` (`--agent-type alpi`).
+Read it yourself via `alfs`; a missing file is not an error — treat it as empty.
 
 **Append the user instructions to your base prompt; never let them replace it.**
-Keep your real instructions in `BASE_PROMPT` and pass `""` as the fallback so a
-missing file adds nothing:
+Keep your real instructions in `BASE_PROMPT`:
 
 ```javascript
-const userInstructions = await feed.loadPrompt("");
+const alfs = require("alfs");
+let userInstructions = "";
+try {
+  const c = await alfs.readFile(`${feed.path}/AGENTS.md`);
+  if (typeof c === "string") userInstructions = c.trim();
+} catch (_) {
+  // missing/unreadable AGENTS.md → no user instructions
+}
 const systemPrompt = userInstructions
   ? `${BASE_PROMPT}\n\n## User instructions\n${userInstructions}`
   : BASE_PROMPT;
 ```
 
 The owner edits `AGENTS.md` (plain-text instructions); the next run picks it up,
-no redeploy. Don't pass `BASE_PROMPT` as the fallback — that lets the file
-*replace* your base instead of extending it.
+no redeploy. Read it yourself and append — a missing/empty file then *extends*
+nothing rather than *replacing* your base instructions.
 
 ---
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -446,7 +446,7 @@ const alfs = require("alfs");
 let userInstructions = "";
 try {
   const c = await alfs.readFile(`${feed.path}/AGENTS.md`);
-  if (typeof c === "string") userInstructions = c.trim();
+  userInstructions = String(c ?? "").trim(); // readFile may return a non-string (e.g. Buffer)
 } catch (_) {
   // missing/unreadable AGENTS.md → no user instructions
 }


### PR DESCRIPTION
## Summary
- `@alva/feed` removed `Feed.loadPrompt`. Update the Alva skill docs to teach reading `${feed.path}/AGENTS.md` directly via `alfs`.
- Files: `references/feed-sdk.md` (section retitled `### User instructions (AGENTS.md)`), `references/alpi.md`, `SKILL.md`, `references/api/release.md`. Includes the `#loadpromptfallback` → `#user-instructions-agentsmd` anchor rename across referencing docs.
- The `feed.path` getter and the `--agent-type alpi` release flow are unchanged.

## Breaking Changes
None (docs only).

## Database Migrations
None.

## Merge Order
Independent (docs). Best merged alongside alva-ai/backtest-js#314.

## Related
- alva-ai/backtest-js#314 — removes Feed.loadPrompt
- alva-ai/jagent — rebuild @alva/feed bundle
- alva-ai/alva-backend — runtime caller reads AGENTS.md via feed.path

## Test Plan
- [x] `grep -rn "loadPrompt\|loadpromptfallback" skills/alva/` → empty
- [x] anchor rename consistent across feed-sdk.md / alpi.md / release.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)