### PR TITLE
chore(alva): bump version to v1.14.0

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.12.1
+  version: v1.14.0
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.12.1` → `v1.14.0` ahead of cutting the `v1.14.0` release. `rel/v1.14` and the `v1.14.0` tag will point at this commit.

Made with [Cursor](https://cursor.com)