### PR TITLE
[jaxxjj] docs(alva): YouTube transcript via bundled yt-dlp

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -745,7 +745,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.14.0",
+        "version: v1.15.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.15.0
+  version: v1.15.1
 ---
 
 # Alva

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -62,6 +62,14 @@ below live in the `unified_search` partition.
 - **Signals**: `views`, `likes`
 - **URL filter**: Only accept `/watch?v=`, `/shorts/`, `youtu.be/{id}`. Drop channel pages, playlists.
 - **Video ID extraction**: `url.match(/(?:v=|shorts\/)([\w-]{11})/)`
+- **Transcript / "what's this video about"**: to read a video's spoken content, use the bundled `yt-dlp` CLI from **Bash** (a local sandbox binary, not a Cloud SDK module). It fetches captions without downloading the video:
+
+  ```bash
+  yt-dlp --skip-download --write-auto-subs --write-subs \
+    --sub-langs "en.*,en" --sub-format json3 -o "/tmp/yt.%(ext)s" "<VIDEO_URL>"
+  ```
+
+  Then read `/tmp/yt.*.json3` and concatenate every `events[].segs[].utf8` into the transcript text (prefer the human `.en.json3` over the auto `.en-orig.json3` when both exist). For a long transcript, summarize first and offer to expand a section/time range. **Bot-block caveat**: if `yt-dlp` errors with `Sign in to confirm you're not a bot`, the sandbox IP is blocked by YouTube — tell the user the transcript is unavailable; do NOT fabricate one. `--write-auto-subs` only yields text when the video has captions; there is no audio-transcription fallback in the sandbox.
 
 ### Podcasts
 


### PR DESCRIPTION
## What
Teach the `alva` skill to read a YouTube video's transcript, using the `yt-dlp` CLI now bundled in the sandbox image (companion PR in sandbox-agent-ts).

- New **Transcript** bullet in `references/search.md` YouTube section: the exact `yt-dlp --write-auto-subs --skip-download --sub-format json3` command + parse (`events[].segs[].utf8`, prefer human over auto subs) + long-transcript handling.
- Documents the **bot-block caveat** (surface, don't fabricate) and that captions-only has no audio-transcription fallback in the sandbox.
- Bumps `metadata.version` v1.14.0 → v1.15.0.

Content-only; ships when the sandbox image rebuilds at a new SKILL_REF. Related: sandbox-agent-ts PR bundles yt-dlp.