### PR TITLE
docs(alva): align automation and alert surfaces

### DIFF
--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -2,11 +2,11 @@
 
 Source: `origin/main`
 
-SKILL.md lines: 780
+SKILL.md lines: 792
 
-Cases: 47/47
+Cases: 44/50
 
-Checks: 416/416 (100.00%)
+Checks: 445/455 (97.80%)
 
 ## Scoring Diagnosis
 
@@ -15,11 +15,16 @@ Classify the gap before editing: missing capability summary, missing routing poi
 Do not expose eval scores as product copy, and do not patch demos to hide a weak result.
 Instead, fix the canonical skill text or eval case, then rerun baseline and final reports so the regression mechanism proves the gap is closed.
 
-No failed cases. Keep the eval in place as a regression mechanism.
+- retained.feed-lifecycle: inspect for a skill gap before editing. Missing checks: alva automation publish; before-automation-publish
+- issue592.playbook-release-behavior: inspect for a skill gap before editing. Missing checks: release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
+- issue592.push-delivery-behavior: inspect for a skill gap before editing. Missing checks: push setup: references/push-notifications.md#Configure And Verify includes before-automation-publish; push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --automation; push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --playbook
+- target.mainline-updates: inspect for a skill gap before editing. Missing checks: alva alert enable --automation; alva alert enable --playbook
+- scenario.dashboard-playbook-build: inspect for a skill gap before editing. Missing checks: playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
+- scenario.alert-push-monitor: inspect for a skill gap before editing. Missing checks: alva alert enable --automation
 
 ## retained
 
-17/17 cases, 98/98 checks
+17/18 cases, 107/109 checks
 
 ### PASS retained.platform-panorama
 
@@ -58,6 +63,7 @@ Routing preserves the major user intents and Guided Planning discipline.
 Skillhub blueprint retrieval remains mandatory and fresh when directed.
 
 - [x] alva skillhub get
+- [x] alva skillhub list
 - [x] alva skillhub file
 - [x] fetch it fresh
 - [x] Do not bulk-download
@@ -107,16 +113,16 @@ Jagent runtime constraints and heap override remain discoverable.
 - [x] --max-heap-size-mb
 - [x] 256 MB
 
-### PASS retained.feed-lifecycle
+### FAIL retained.feed-lifecycle
 
-Feed build, grant, deploy, and release hard gate remain preserved.
+Feed build, grant, deploy, and automation publish hard gate remain preserved.
 
 - [x] Feed SDK
 - [x] alva run --entry-path
 - [x] special:user:*
 - [x] alva deploy create
-- [x] alva release feed
-- [x] before-feed-release
+- [ ] alva automation publish
+- [ ] before-automation-publish
 
 ### PASS retained.playbook-release
 
@@ -162,6 +168,21 @@ Creator-side UDF setup and allowance management route through the functions CLI 
 - [x] alva functions invoke
 - [x] alva functions allowance create
 - [x] Do not hand-roll REST, GraphQL, or curl
+
+### PASS retained.credits-cli
+
+Viewer-scoped credit balance and consumption-history lookup remains discoverable through the credits CLI.
+
+- [x] alva credits --help
+- [x] alva credits wallet
+- [x] alva credits items --today
+- [x] alva credits items --last 7d
+- [x] alva credits items --start 2026-06-23 --end 2026-06-24
+- [x] --session-id <session_id>
+- [x] viewer-scoped
+- [x] Do not invent or request a `--user-id` flag
+- [x] Do not use raw GraphQL
+- [x] items.pageInfo.hasNextPage
 
 ### PASS retained.altra
 
@@ -290,9 +311,26 @@ When structured data lags a known official release, web is an official-source fa
 - [x] official-source stale-feed fallback
 - [x] Do not claim the value came from Data Skills
 
+## platform-data
+
+1/1 cases, 8/8 checks
+
+### PASS platform-data.kol-surfaces
+
+KOL data and the KOL digest SDK are routed together as Alva-maintained Platform Data.
+
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Platform Data is Alva-maintained data and SDK surface
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Fintwit Intelligence / KOL data
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Read [fintwit.md](references/fintwit.md)
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Fintwit Digest SDK
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md)
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes do not copy private runtime internals
+- [x] request routing: SKILL.md#Request Routing includes Platform Data: Fintwit Intelligence
+- [x] request routing: SKILL.md#Request Routing includes Platform Data: Fintwit Digest SDK
+
 ## issue592
 
-5/5 cases, 65/65 checks
+3/5 cases, 61/65 checks
 
 ### PASS issue592.scoped-eval-checks
 
@@ -358,7 +396,7 @@ Capability gaps are verified against live Alva surfaces and reduced-scope/BYOD f
 - [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never stop with zero useful output
 - [x] fallback behavior: references/data-skills.md#Failure And Fallback includes Never replace a missing data source with LLM-fabricated values
 
-### PASS issue592.playbook-release-behavior
+### FAIL issue592.playbook-release-behavior
 
 Playbook release remains protected by behavior-level gates for feed freshness, live data reads, README, lint, and screenshot verification.
 
@@ -366,33 +404,33 @@ Playbook release remains protected by behavior-level gates for feed freshness, l
 - [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
 - [x] visual verification: references/playbook-creation.md#Screenshot includes headers-only tables
 - [x] visual verification: references/playbook-creation.md#Screenshot includes fetch failures are data-rendering failures
-- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [ ] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes HTML fetches quantitative data from feeds, not inline literals
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Latest data from each referenced feed is fresh
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
 
-### PASS issue592.push-delivery-behavior
+### FAIL issue592.push-delivery-behavior
 
 Push setup is evaluated as a full delivery path instead of a single publisher flag.
 
 - [x] push setup: references/push-notifications.md#Configure And Verify includes A push is set up only after all of these succeed
-- [x] push setup: references/push-notifications.md#Configure And Verify includes before-feed-release
+- [ ] push setup: references/push-notifications.md#Configure And Verify includes before-automation-publish
 - [x] push setup: references/push-notifications.md#Configure And Verify includes alva deploy update --id <ID> --push-notify
-- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-feed
-- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-playbook
+- [ ] push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --automation
+- [ ] push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --playbook
 - [x] push setup: references/push-notifications.md#Configure And Verify includes read `@last/1` of the sidecar
 - [x] push setup: references/push-notifications.md#Configure And Verify includes do not claim push is set up
 
 ## target
 
-9/9 cases, 115/115 checks
+8/9 cases, 117/119 checks
 
 ### PASS target.top-level-size
 
 Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count <= 850 (actual 780)
+- [x] line count <= 850 (actual 792)
 
 ### PASS target.playbook-task-offload
 
@@ -410,15 +448,19 @@ Playbook creation is a concrete task reference rather than the dominant top-leve
 
 ### PASS target.top-level-playbook-routing
 
-Top-level routing and final checklist keep playbook work in its concrete reference without making all routing playbook-centric.
+Top-level routing keeps playbook work as route-plus-boundary-plus-pointer instead of duplicating the manual.
 
-- [x] Playbook Creation Tree
-- [x] Durable Artifacts / Playbook Tree
-- [x] Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release
-- [x] do not let every financial question inherit playbook gates
-- [x] route through [playbook-creation.md](references/playbook-creation.md)
-- [x] Did playbook work read [playbook-creation.md](references/playbook-creation.md)
-- [x] relevant hard gates
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Enter this branch only when the user wants a hosted/shareable surface
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Read [playbook-creation.md](references/playbook-creation.md)
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes owns the build order, Browser-safe feed reads, README, draft/release gates, screenshot verification, tier/visibility flow, and push-after-release handoff
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes feed-first and live-read
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Keep procedure, release, screenshot, and tier details in the owning references
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Do not let every financial question inherit playbook gates
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes First choose the artifact shape
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes turn the request into a data contract before UI work
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes they own the procedure
+- [x] final checklist: SKILL.md#Final Sanity Checklist includes Did playbook work read [playbook-creation.md](references/playbook-creation.md)
+- [x] final checklist: SKILL.md#Final Sanity Checklist includes relevant hard gates
 
 ### PASS target.financial-analysis-routing
 
@@ -521,18 +563,18 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 - [x] Touch ALFS paths
 - [x] Build or edit playbook HTML/charts
 
-### PASS target.mainline-updates
+### FAIL target.mainline-updates
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.12.1
+- [x] version: v1.15.1
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
 - [x] api/feedback.md
 - [x] alva feedback --help
-- [x] subscriptions subscribe-feed
-- [x] subscriptions subscribe-playbook
+- [ ] alva alert enable --automation
+- [ ] alva alert enable --playbook
 - [x] publish publicly by default
 - [x] registered UDFs
 - [x] implementation internals
@@ -561,7 +603,7 @@ Prompt: `What is BTC doing right now?`
 - [x] Simple latest-fact asks stop there after one sourced hop
 - [x] user-facing-prose.md
 - [x] content-legitimacy.md
-- [x] Direct latest price for covered US equities and crypto: intraday klines, not daily close
+- [x] Direct latest/realtime price for covered US equities and crypto: intraday klines, not daily-level bars or closes
 - [x] Do not answer until you can name the decomposition
 - [x] Do not let playbook creation become the default
 - [x] not automatically to a playbook
@@ -606,9 +648,9 @@ Prompt: `Does Alva have darkpool L2 realtime data?`
 
 ## scenarios.playbook
 
-3/3 cases, 31/31 checks
+2/3 cases, 34/35 checks
 
-### PASS scenario.dashboard-playbook-build
+### FAIL scenario.dashboard-playbook-build
 
 A hosted dashboard enters the Playbook Creation route and preserves feed-first, live-read, README, lint, release, and screenshot gates.
 
@@ -622,10 +664,14 @@ Prompt: `Build and publish a live dashboard for BTC dominance breakouts.`
 - [x] AlvaToolkit.AlvaClient
 - [x] Build live feeds first
 - [x] HTML fetches quantitative data from feeds, not inline literals
-- [x] Every release needs a current README
-- [x] screenshot verification must show real feed-backed marks
 - [x] expected route: references/request-routing.md#Routes includes Playbook Creation
-- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes Every `alva release playbook` call needs a freshly reviewed README
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes regenerate the README
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes `~/playbooks/<name>/README.md`
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes before release
+- [x] visual verification: references/playbook-creation.md#Screenshot includes Pass screenshot verification only when
+- [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
+- [ ] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
 - [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
 - [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
 
@@ -662,9 +708,9 @@ Prompt: `<annotation id="hero-title">make this chart title shorter</annotation>`
 
 ## scenarios.push
 
-1/1 cases, 9/9 checks
+0/1 cases, 8/9 checks
 
-### PASS scenario.alert-push-monitor
+### FAIL scenario.alert-push-monitor
 
 A monitoring request routes to Automation / Push and validates sidecar, release, subscription, and real-run delivery.
 
@@ -675,7 +721,7 @@ Prompt: `Track BTC dominance and notify me when it breaks out.`
 - [x] Build or modify a feed that emits actionable `signal/targets` or `notify/message`
 - [x] A push is set up only after all of these succeed
 - [x] alva deploy update --id <ID> --push-notify
-- [x] alva subscriptions subscribe-feed
+- [ ] alva alert enable --automation
 - [x] read `@last/1` of the sidecar
 - [x] do not claim push is set up
 - [x] expected route: references/request-routing.md#Routes includes Automation / Push
@@ -701,7 +747,7 @@ Prompt: `Backtest a weekly NVDA momentum strategy and show drawdowns.`
 
 ## scenarios.skillhub
 
-1/1 cases, 10/10 checks
+2/2 cases, 22/22 checks
 
 ### PASS scenario.skillhub-method
 
@@ -714,6 +760,25 @@ Prompt: `/use-skill:alva/thesis NVDA AI capex read-through`
 - [x] api/release.md
 - [x] If the user's message contains `/use-skill:<username>/<name>`, the Skillhub path is mandatory
 - [x] alva skillhub get
+- [x] alva skillhub file
+- [x] Do not bulk-download
+- [x] Do not turn every Skillhub task into a playbook
+- [x] --skill-id <username>/<name>
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+
+### PASS scenario.skillhub-referenced-method
+
+A user skill reference searches Skillhub for relevant catalog matches, resolves one obvious id, and then fetches the blueprint fresh.
+
+Prompt: `Use the thesis skill for NVDA AI capex read-through.`
+
+- [x] request-routing.md
+- [x] playbook-creation.md
+- [x] api/release.md
+- [x] references a skill without an exact id
+- [x] alva skillhub list
+- [x] search for relevant catalog matches
+- [x] Proceed only when exactly one match is obvious
 - [x] alva skillhub file
 - [x] Do not bulk-download
 - [x] Do not turn every Skillhub task into a playbook

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -118,14 +118,14 @@
       "id": "retained.feed-lifecycle",
       "group": "retained",
       "target": "corpus",
-      "description": "Feed build, grant, deploy, and release hard gate remain preserved.",
+      "description": "Feed build, grant, deploy, and automation publish hard gate remain preserved.",
       "includes": [
         "Feed SDK",
         "alva run --entry-path",
         "special:user:*",
         "alva deploy create",
-        "alva release feed",
-        "before-feed-release"
+        "alva automation publish",
+        "before-automation-publish"
       ]
     },
     {
@@ -515,7 +515,7 @@
           "id": "before-playbook-release",
           "label": "release gate",
           "includes": [
-            "Every backing feed passed `before-feed-release`",
+            "Every backing feed passed `before-automation-publish`",
             "HTML fetches quantitative data from feeds, not inline literals",
             "Latest data from each referenced feed is fresh",
             "README exists, is current, and is passed via absolute `--readme-url`",
@@ -549,10 +549,10 @@
           "label": "push setup",
           "includes": [
             "A push is set up only after all of these succeed",
-            "before-feed-release",
+            "before-automation-publish",
             "alva deploy update --id <ID> --push-notify",
-            "alva subscriptions subscribe-feed",
-            "alva subscriptions subscribe-playbook",
+            "alva alert enable --automation",
+            "alva alert enable --playbook",
             "read `@last/1` of the sidecar",
             "do not claim push is set up"
           ]
@@ -751,8 +751,8 @@
         "feedback",
         "api/feedback.md",
         "alva feedback --help",
-        "subscriptions subscribe-feed",
-        "subscriptions subscribe-playbook",
+        "alva alert enable --automation",
+        "alva alert enable --playbook",
         "publish publicly by default",
         "registered UDFs",
         "implementation internals",

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/behavioral-doc-eval/skills/alva`
+Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/automation-alert-surface/skills/alva`
 
-SKILL.md lines: 780
+SKILL.md lines: 791
 
-Cases: 47/47
+Cases: 50/50
 
-Checks: 416/416 (100.00%)
+Checks: 455/455 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -19,7 +19,7 @@ No failed cases. Keep the eval in place as a regression mechanism.
 
 ## retained
 
-17/17 cases, 98/98 checks
+18/18 cases, 109/109 checks
 
 ### PASS retained.platform-panorama
 
@@ -58,6 +58,7 @@ Routing preserves the major user intents and Guided Planning discipline.
 Skillhub blueprint retrieval remains mandatory and fresh when directed.
 
 - [x] alva skillhub get
+- [x] alva skillhub list
 - [x] alva skillhub file
 - [x] fetch it fresh
 - [x] Do not bulk-download
@@ -109,14 +110,14 @@ Jagent runtime constraints and heap override remain discoverable.
 
 ### PASS retained.feed-lifecycle
 
-Feed build, grant, deploy, and release hard gate remain preserved.
+Feed build, grant, deploy, and automation publish hard gate remain preserved.
 
 - [x] Feed SDK
 - [x] alva run --entry-path
 - [x] special:user:*
 - [x] alva deploy create
-- [x] alva release feed
-- [x] before-feed-release
+- [x] alva automation publish
+- [x] before-automation-publish
 
 ### PASS retained.playbook-release
 
@@ -162,6 +163,21 @@ Creator-side UDF setup and allowance management route through the functions CLI 
 - [x] alva functions invoke
 - [x] alva functions allowance create
 - [x] Do not hand-roll REST, GraphQL, or curl
+
+### PASS retained.credits-cli
+
+Viewer-scoped credit balance and consumption-history lookup remains discoverable through the credits CLI.
+
+- [x] alva credits --help
+- [x] alva credits wallet
+- [x] alva credits items --today
+- [x] alva credits items --last 7d
+- [x] alva credits items --start 2026-06-23 --end 2026-06-24
+- [x] --session-id <session_id>
+- [x] viewer-scoped
+- [x] Do not invent or request a `--user-id` flag
+- [x] Do not use raw GraphQL
+- [x] items.pageInfo.hasNextPage
 
 ### PASS retained.altra
 
@@ -290,6 +306,23 @@ When structured data lags a known official release, web is an official-source fa
 - [x] official-source stale-feed fallback
 - [x] Do not claim the value came from Data Skills
 
+## platform-data
+
+1/1 cases, 8/8 checks
+
+### PASS platform-data.kol-surfaces
+
+KOL data and the KOL digest SDK are routed together as Alva-maintained Platform Data.
+
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Platform Data is Alva-maintained data and SDK surface
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Fintwit Intelligence / KOL data
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Read [fintwit.md](references/fintwit.md)
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Fintwit Digest SDK
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes Read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md)
+- [x] platform data section: SKILL.md#Data Access: Platform Data includes do not copy private runtime internals
+- [x] request routing: SKILL.md#Request Routing includes Platform Data: Fintwit Intelligence
+- [x] request routing: SKILL.md#Request Routing includes Platform Data: Fintwit Digest SDK
+
 ## issue592
 
 5/5 cases, 65/65 checks
@@ -366,7 +399,7 @@ Playbook release remains protected by behavior-level gates for feed freshness, l
 - [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
 - [x] visual verification: references/playbook-creation.md#Screenshot includes headers-only tables
 - [x] visual verification: references/playbook-creation.md#Screenshot includes fetch failures are data-rendering failures
-- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes HTML fetches quantitative data from feeds, not inline literals
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Latest data from each referenced feed is fresh
 - [x] release gate: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
@@ -377,22 +410,22 @@ Playbook release remains protected by behavior-level gates for feed freshness, l
 Push setup is evaluated as a full delivery path instead of a single publisher flag.
 
 - [x] push setup: references/push-notifications.md#Configure And Verify includes A push is set up only after all of these succeed
-- [x] push setup: references/push-notifications.md#Configure And Verify includes before-feed-release
+- [x] push setup: references/push-notifications.md#Configure And Verify includes before-automation-publish
 - [x] push setup: references/push-notifications.md#Configure And Verify includes alva deploy update --id <ID> --push-notify
-- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-feed
-- [x] push setup: references/push-notifications.md#Configure And Verify includes alva subscriptions subscribe-playbook
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --automation
+- [x] push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --playbook
 - [x] push setup: references/push-notifications.md#Configure And Verify includes read `@last/1` of the sidecar
 - [x] push setup: references/push-notifications.md#Configure And Verify includes do not claim push is set up
 
 ## target
 
-9/9 cases, 115/115 checks
+9/9 cases, 119/119 checks
 
 ### PASS target.top-level-size
 
 Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count <= 850 (actual 780)
+- [x] line count <= 850 (actual 791)
 
 ### PASS target.playbook-task-offload
 
@@ -410,15 +443,19 @@ Playbook creation is a concrete task reference rather than the dominant top-leve
 
 ### PASS target.top-level-playbook-routing
 
-Top-level routing and final checklist keep playbook work in its concrete reference without making all routing playbook-centric.
+Top-level routing keeps playbook work as route-plus-boundary-plus-pointer instead of duplicating the manual.
 
-- [x] Playbook Creation Tree
-- [x] Durable Artifacts / Playbook Tree
-- [x] Subroutes are new build, Skillhub-guided build, remix, annotation/edit, release/version update, and push after release
-- [x] do not let every financial question inherit playbook gates
-- [x] route through [playbook-creation.md](references/playbook-creation.md)
-- [x] Did playbook work read [playbook-creation.md](references/playbook-creation.md)
-- [x] relevant hard gates
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Enter this branch only when the user wants a hosted/shareable surface
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Read [playbook-creation.md](references/playbook-creation.md)
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes owns the build order, Browser-safe feed reads, README, draft/release gates, screenshot verification, tier/visibility flow, and push-after-release handoff
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes feed-first and live-read
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Keep procedure, release, screenshot, and tier details in the owning references
+- [x] playbook route: SKILL.md#Publication Layer: Playbook Creation Tree includes Do not let every financial question inherit playbook gates
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes First choose the artifact shape
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes turn the request into a data contract before UI work
+- [x] common workflow: SKILL.md#Hosted Playbook Workflow includes they own the procedure
+- [x] final checklist: SKILL.md#Final Sanity Checklist includes Did playbook work read [playbook-creation.md](references/playbook-creation.md)
+- [x] final checklist: SKILL.md#Final Sanity Checklist includes relevant hard gates
 
 ### PASS target.financial-analysis-routing
 
@@ -525,14 +562,14 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.12.1
+- [x] version: v1.15.1
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
 - [x] api/feedback.md
 - [x] alva feedback --help
-- [x] subscriptions subscribe-feed
-- [x] subscriptions subscribe-playbook
+- [x] alva alert enable --automation
+- [x] alva alert enable --playbook
 - [x] publish publicly by default
 - [x] registered UDFs
 - [x] implementation internals
@@ -561,7 +598,7 @@ Prompt: `What is BTC doing right now?`
 - [x] Simple latest-fact asks stop there after one sourced hop
 - [x] user-facing-prose.md
 - [x] content-legitimacy.md
-- [x] Direct latest price for covered US equities and crypto: intraday klines, not daily close
+- [x] Direct latest/realtime price for covered US equities and crypto: intraday klines, not daily-level bars or closes
 - [x] Do not answer until you can name the decomposition
 - [x] Do not let playbook creation become the default
 - [x] not automatically to a playbook
@@ -606,7 +643,7 @@ Prompt: `Does Alva have darkpool L2 realtime data?`
 
 ## scenarios.playbook
 
-3/3 cases, 31/31 checks
+3/3 cases, 35/35 checks
 
 ### PASS scenario.dashboard-playbook-build
 
@@ -622,10 +659,14 @@ Prompt: `Build and publish a live dashboard for BTC dominance breakouts.`
 - [x] AlvaToolkit.AlvaClient
 - [x] Build live feeds first
 - [x] HTML fetches quantitative data from feeds, not inline literals
-- [x] Every release needs a current README
-- [x] screenshot verification must show real feed-backed marks
 - [x] expected route: references/request-routing.md#Routes includes Playbook Creation
-- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-feed-release`
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes Every `alva release playbook` call needs a freshly reviewed README
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes regenerate the README
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes `~/playbooks/<name>/README.md`
+- [x] readme freshness: references/api/release.md#Freshness and version updates includes before release
+- [x] visual verification: references/playbook-creation.md#Screenshot includes Pass screenshot verification only when
+- [x] visual verification: references/playbook-creation.md#Screenshot includes real feed-backed chart marks
+- [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes Every backing feed passed `before-automation-publish`
 - [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes README exists, is current, and is passed via absolute `--readme-url`
 - [x] playbook release: references/playbook-creation.md<HARD-GATE:before-playbook-release> includes alva lint playbook ./index.html
 
@@ -675,7 +716,7 @@ Prompt: `Track BTC dominance and notify me when it breaks out.`
 - [x] Build or modify a feed that emits actionable `signal/targets` or `notify/message`
 - [x] A push is set up only after all of these succeed
 - [x] alva deploy update --id <ID> --push-notify
-- [x] alva subscriptions subscribe-feed
+- [x] alva alert enable --automation
 - [x] read `@last/1` of the sidecar
 - [x] do not claim push is set up
 - [x] expected route: references/request-routing.md#Routes includes Automation / Push
@@ -701,7 +742,7 @@ Prompt: `Backtest a weekly NVDA momentum strategy and show drawdowns.`
 
 ## scenarios.skillhub
 
-1/1 cases, 10/10 checks
+2/2 cases, 22/22 checks
 
 ### PASS scenario.skillhub-method
 
@@ -714,6 +755,25 @@ Prompt: `/use-skill:alva/thesis NVDA AI capex read-through`
 - [x] api/release.md
 - [x] If the user's message contains `/use-skill:<username>/<name>`, the Skillhub path is mandatory
 - [x] alva skillhub get
+- [x] alva skillhub file
+- [x] Do not bulk-download
+- [x] Do not turn every Skillhub task into a playbook
+- [x] --skill-id <username>/<name>
+- [x] expected route: references/request-routing.md#Routes includes Playbook Creation
+
+### PASS scenario.skillhub-referenced-method
+
+A user skill reference searches Skillhub for relevant catalog matches, resolves one obvious id, and then fetches the blueprint fresh.
+
+Prompt: `Use the thesis skill for NVDA AI capex read-through.`
+
+- [x] request-routing.md
+- [x] playbook-creation.md
+- [x] api/release.md
+- [x] references a skill without an exact id
+- [x] alva skillhub list
+- [x] search for relevant catalog matches
+- [x] Proceed only when exactly one match is obvious
 - [x] alva skillhub file
 - [x] Do not bulk-download
 - [x] Do not turn every Skillhub task into a playbook

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -127,7 +127,7 @@
             "id": "before-playbook-release",
             "label": "playbook release",
             "includes": [
-              "Every backing feed passed `before-feed-release`",
+              "Every backing feed passed `before-automation-publish`",
               "README exists, is current, and is passed via absolute `--readme-url`",
               "alva lint playbook ./index.html"
             ]
@@ -150,7 +150,7 @@
           "Build or modify a feed that emits actionable `signal/targets` or `notify/message`",
           "A push is set up only after all of these succeed",
           "alva deploy update --id <ID> --push-notify",
-          "alva subscriptions subscribe-feed",
+          "alva alert enable --automation",
           "read `@last/1` of the sidecar",
           "do not claim push is set up"
         ]

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -378,8 +378,8 @@ Enter this tree when the user asks Alva to keep something running, reusable,
 shareable, inspectable, or actionable. The tree is broader than playbooks: a
 script, feed, alert, signal, model output, or trading analysis may be the right
 artifact without a hosted UI. Enter the playbook branch only for hosted apps,
-   share URLs, remixes, annotation edits, release/version updates, or playbook
-   alert/group-subscription setup.
+share URLs, remixes, annotation edits, release/version updates, or playbook
+alert/group-subscription setup.
 
 #### Data Product Layer: Feed Lifecycle And Automation
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: alva
 description: >-
-  Use this skill when the user asks for financial data ("price of BTC",
-  "P/E ratio of NVDA"), market analysis, stock or crypto research, quant
-  strategies, backtesting ("backtest a momentum strategy"), tracking assets
-  or portfolios, or help turning investing ideas into live playbooks,
-  dashboards, and analytics on Alva.
-  Powered by 250+ financial data sources across crypto, equities, macro,
-  on-chain, and social data, along with cloud-side analytics and backtesting.
-  Also use when the user asks about Alva platform capabilities.
+  Use this skill when the user asks for financial data ("price of BTC", "P/E
+  ratio of NVDA"), market analysis, stock or crypto research, quant strategies,
+  backtesting ("backtest a momentum strategy"), tracking assets or portfolios,
+  or help turning investing ideas into live playbooks, dashboards, and analytics
+  on Alva. Powered by 250+ financial data sources across crypto, equities,
+  macro, on-chain, and social data, along with cloud-side analytics and
+  backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
   version: v1.15.1
@@ -17,16 +16,16 @@ metadata:
 # Alva
 
 Alva is an agentic finance platform. It gives an AI agent access to 250+
-financial data sources, market research, cloud JavaScript execution,
-persistent feeds, scheduled automations, the Altra trading engine, trading
-signals, hosted playbooks, push notifications, and remixable public artifacts.
+financial data sources, market research, cloud JavaScript execution, persistent
+feeds, scheduled automations, the Altra trading engine, trading signals, hosted
+playbooks, push notifications, and remixable public artifacts.
 
 This file is the platform encyclopedia and operating guide. Read it to
 understand what Alva can do, how the concepts fit together, which path a user
-request belongs to, and which focused reference owns the detailed procedure.
-It is intentionally not the full playbook-building manual. Long command
-sequences, API gotchas, release checklists, design rules, examples, and
-debugging recipes live in `references/`.
+request belongs to, and which focused reference owns the detailed procedure. It
+is intentionally not the full playbook-building manual. Long command sequences,
+API gotchas, release checklists, design rules, examples, and debugging recipes
+live in `references/`.
 
 ## Mental Model
 
@@ -36,21 +35,21 @@ shape, computes outputs, persists them, and renders or explains the result.
 
 The main objects are:
 
-| Concept | Meaning | Read when |
-| --- | --- | --- |
-| Data Skills | 250+ structured Arrays endpoints for equities, options, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data. |
-| Runtime script | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs. | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK. |
-| Feed | A persistent data pipeline that writes time-series or grouped outputs to ALFS and can back playbooks or alerts. | Data needs freshness, history, public reads, charts, release, or push. |
-| Playbook | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`. | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface. |
-| Skillhub blueprint | A catalog methodology addressed by `/use-skill:<username>/<name>` or discovered from a user skill/method reference. | The user references a skill/method, or a task matches an official template family. |
-| Altra | The Feed SDK trading engine for event-driven backtesting and signal feeds. | Any strategy, simulation, signal target, portfolio, order, equity curve, or rebalancing logic. |
-| alpi | A fixed LLM reasoning/tool loop inside a deterministic scheduled pipeline. | A feed needs classification, synthesis, TLDR, why-it-matters, or result-only tool use over real upstream data. |
-| BYOD | User-supplied or validated external data source wired into runtime code. | Alva coverage is insufficient after verification. |
+| Concept            | Meaning                                                                                                                                                      | Read when                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Data Skills        | 250+ structured Arrays endpoints for equities, options, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
+| Runtime script     | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs.                                                                          | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK.                                            |
+| Feed               | A persistent data pipeline that writes time-series or grouped outputs to ALFS and can back playbooks or alerts.                                              | Data needs freshness, history, public reads, charts, release, or push.                                         |
+| Playbook           | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`.                                                                                   | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface.                          |
+| Skillhub blueprint | A catalog methodology addressed by `/use-skill:<username>/<name>` or discovered from a user skill/method reference.                                          | The user references a skill/method, or a task matches an official template family.                             |
+| Altra              | The Feed SDK trading engine for event-driven backtesting and signal feeds.                                                                                   | Any strategy, simulation, signal target, portfolio, order, equity curve, or rebalancing logic.                 |
+| alpi               | A fixed LLM reasoning/tool loop inside a deterministic scheduled pipeline.                                                                                   | A feed needs classification, synthesis, TLDR, why-it-matters, or result-only tool use over real upstream data. |
+| BYOD               | User-supplied or validated external data source wired into runtime code.                                                                                     | Alva coverage is insufficient after verification.                                                              |
 
 Alva work usually flows from user intent to data discovery, then runtime/feed
 implementation, then a user-facing artifact. A direct answer may stop after a
-fresh data fetch. A playbook usually continues through feed release, HTML,
-README, lint, screenshot, release, and optional push setup.
+fresh data fetch. A playbook usually continues through automation publish, HTML,
+README, lint, screenshot, release, and optional alert setup.
 
 The stack is layered:
 
@@ -60,22 +59,22 @@ The stack is layered:
    ONNX, and Altra transform source data into repeatable outputs.
 3. **Persistence layer**: ALFS stores source files, feed outputs, playbook
    assets, README files, model artifacts, memory, and reusable libraries.
-4. **Publication layer**: feed release, playbook draft/release, lint,
+4. **Publication layer**: automation publish, playbook draft/release, lint,
    screenshots, visibility, creator notes, and canonical share URLs turn a
    pipeline into something a user can inspect.
-5. **Action layer**: push subscriptions, signal feeds, trading execution, and
-   alerts connect the artifact to ongoing decisions.
+5. **Action layer**: alerts, signal feeds, trading execution, and group
+   subscriptions connect the artifact to ongoing decisions.
 
-Those layers matter because most Alva bugs are layer violations: using search
-as data, using runtime code as a one-off local script, skipping feed release
-before a playbook reads data, treating a blueprint as an optional suggestion,
-or presenting a deployed HTML URL as the share URL.
+Those layers matter because most Alva bugs are layer violations: using search as
+data, using runtime code as a one-off local script, skipping automation publish
+before a playbook reads data, treating a blueprint as an optional suggestion, or
+presenting a deployed HTML URL as the share URL.
 
 Alva is strongest when the user wants something that can keep running: a data
 surface, a monitoring feed, a strategy, a thesis tracker, or a repeatable
 research process. It is also useful for single-shot questions, but the agent
-should not overbuild. A user asking "what is BTC doing now?" needs a fresh
-fetch and a concise answer. A user asking "track BTC dominance and alert me on
+should not overbuild. A user asking "what is BTC doing now?" needs a fresh fetch
+and a concise answer. A user asking "track BTC dominance and alert me on
 breakouts" needs a feed, cadence, push sidecar, and verification.
 
 Think in artifacts:
@@ -83,19 +82,19 @@ Think in artifacts:
 - **Answer**: a direct response grounded in fresh data. No feed or release
   required unless the user asks for persistence.
 - **Script**: an Alva Cloud computation that may be run manually or scheduled.
-- **Feed**: the persistent output of a script, with schema, history, grants,
-  and release metadata.
-- **Playbook**: a browser surface over feeds, README, design rules, and
-  release state.
-- **Signal**: an actionable feed output that may power trading execution or
-  push notifications.
+- **Feed**: the persistent output of a script, with schema, history, grants, and
+  release metadata.
+- **Playbook**: a browser surface over feeds, README, design rules, and release
+  state.
+- **Signal**: an actionable feed output that may power trading execution or push
+  notifications.
 - **Blueprint**: a methodology fetched from Skillhub that constrains the build.
 
 The same user sentence can imply different artifacts depending on verbs. "Ask",
 "explain", "compare", "value", "screen in text", and "what changed" usually mean
 Financial Analysis. "Track", "monitor", "notify", "dashboard", "publish",
-"share", "backtest", "screen as an app", "remix", and `/use-skill:` usually
-mean a larger artifact route.
+"share", "backtest", "screen as an app", "remix", and `/use-skill:` usually mean
+a larger artifact route.
 
 ## Capability Help
 
@@ -107,8 +106,8 @@ Build/remix Playbooks, Discover/manage Playbooks, and Connect accounts.
 Offer 3 concrete starter prompts when helpful. If recent context shows a stable
 interest, adapt one or two prompts to it; otherwise use broad defaults. End
 capability-help replies with: "Reply 1, 2, or 3 to start, or send /help to see
-the full list." If the user replies only "1", "2", or "3", treat it as
-selecting the corresponding latest prompt, then route through
+the full list." If the user replies only "1", "2", or "3", treat it as selecting
+the corresponding latest prompt, then route through
 [request-routing.md](references/request-routing.md).
 
 ## First Principles
@@ -116,18 +115,17 @@ selecting the corresponding latest prompt, then route through
 These rules are the high-signal foundation. If you only remember one section,
 make it this one.
 
-1. **Help-first CLI.** Before using any `alva` command you have not used in
-   this session, run `alva <command> --help`. CLI help is authoritative for
-   commands, flags, response fields, and examples. Read
+1. **Help-first CLI.** Before using any `alva` command you have not used in this
+   session, run `alva <command> --help`. CLI help is authoritative for commands,
+   flags, response fields, and examples. Read
    [preflight.md](references/preflight.md) at session start.
 2. **Fresh identity and memory.** Run `alva whoami`, capture `username`,
    `subscription_tier`, delivery channel fields, and Arrays JWT status. Load
    `~/memory/MEMORY.md` if not already read. Memory is a *claim*, not truth.
 3. **Pipeline, not oracle.** Financial values must come from Data Skills,
-   published Alva feeds, or validated BYOD sources. WebSearch, LLM output,
-   agent memory, synthetic data, and user-pasted examples are not standalone
-   factual data sources. Read
-   [content-legitimacy.md](references/content-legitimacy.md).
+   published Alva feeds, or validated BYOD sources. WebSearch, LLM output, agent
+   memory, synthetic data, and user-pasted examples are not standalone factual
+   data sources. Read [content-legitimacy.md](references/content-legitimacy.md).
 4. **No stale surface assumptions.** Fetch Data Skills endpoint docs, Skillhub
    blueprints, CLI help, and runtime docs in the current session. Do not act
    from remembered field names.
@@ -143,8 +141,8 @@ make it this one.
    snapshots are only for explicit requests.
 8. **One blocking question.** For nontrivial builds, ask at most one blocking
    question or present one short plan. A concrete Skillhub directive or
-   user-referenced skill/method plus topic means plan once after retrieval,
-   then build.
+   user-referenced skill/method plus topic means plan once after retrieval, then
+   build.
 9. **References own depth.** Top-level sections tell you what the capability is,
    what rule is easy to miss, and which file to open. Long examples, commands,
    and checklists live in the linked reference.
@@ -153,8 +151,8 @@ Two consequences are worth making explicit. First, a useful Alva answer can be
 small: a financial-analysis question should not become a playbook unless the
 user asks for a durable surface. Second, a useful Alva build can be large: once
 the user does ask for a playbook, the job is not done at "HTML exists"; it is
-done when data provenance, release metadata, README, lint, screenshot, and
-share URL all match the user's goal.
+done when data provenance, release metadata, README, lint, screenshot, and share
+URL all match the user's goal.
 
 ## Session Start
 
@@ -170,11 +168,11 @@ Before doing Alva work, open [preflight.md](references/preflight.md). It owns:
 
 Use [user-facing-prose.md](references/user-facing-prose.md) for product
 vocabulary and voice before writing Financial Analysis answers, playbook copy,
-README prose, visible HTML text, alpi prompts, digests, or release
-descriptions. User-facing words include **automation**, **playbook**,
-**alert/notification**, **Agent**, and **script**. Treat **feed** as internal
-unless the user is looking at logs, raw data, API fields, release references,
-or an Automation detail that exposes it.
+README prose, visible HTML text, alpi prompts, digests, or release descriptions.
+User-facing words include **automation**, **playbook**, **alert/notification**,
+**Agent**, and **script**. Treat **feed** as internal unless the user is looking
+at logs, raw data, API fields, release references, or an Automation detail that
+exposes it.
 
 Use [creators-note.md](references/creators-note.md) when composing a pinned
 post-release author note.
@@ -185,23 +183,23 @@ Open [request-routing.md](references/request-routing.md) whenever the task is
 not an obvious single-fetch answer. It owns route selection, Skillhub, Guided
 Planning, capability verification, and completion gates.
 
-Open [operational-pitfalls.md](references/operational-pitfalls.md) step by
-step whenever the route enters runtime, feed, ALFS, playbook HTML, deploy,
-release, chart, or cron work. Read only the relevant section before each step,
-but treat that section as mandatory, not optional debugging material.
+Open [operational-pitfalls.md](references/operational-pitfalls.md) step by step
+whenever the route enters runtime, feed, ALFS, playbook HTML, deploy, release,
+chart, or cron work. Read only the relevant section before each step, but treat
+that section as mandatory, not optional debugging material.
 
-| User asks for | Route | Must not miss |
-| --- | --- | --- |
-| price, valuation, holdings, "why did it move", compare peers, explain a thesis, rank in text | Financial Analysis / Ask Question | Fetch fresh data/search evidence; comparison baselines need provenance too. Every answer must pass the ask evidence gate below. |
-| fintwit / KOL / leaderboard — top accounts or ranking, is @handle tracked, what an account thinks about a ticker or theme, track record | Platform Data: Fintwit Intelligence | Use the Platform Data section below, then read [fintwit.md](references/fintwit.md); cite the snapshot date; read-only, never fabricate rankings. |
-| FinTwit digest SDK, alpha radar automation, custom digest module, `@alva/fintwit-digest` | Platform Data: Fintwit Digest SDK | Use the Platform Data section below, then read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md); follow the SDK API and ability contracts instead of copying runtime internals. |
-| dashboard, screener app, thesis tracker, hosted report, shareable surface | Playbook Creation | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md). |
-| `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method | Skillhub Blueprint | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`. |
-| backtest, strategy, signal, rebalance, portfolio simulation | Strategy / Trading Analysis | Use Altra; package as answer, feed, or playbook only as the user goal requires. |
-| recurring digest, threshold tracker, alert, stream watch | Automation / Push | Build a push-capable feed and verify subscription plus sidecar output. |
-| `<remix ...>` or "remix this playbook" | Remix | Read source files; preserve lineage and source UDFs. |
-| `<annotation ...>` or "change this element" | Edit / Debug | Edit the generator behind the element, not rendered feed values. |
-| "does Alva have X?" | Capability Verification | Run `alva data-skills list | grep -i <topic>` before saying no. |
+| User asks for                                                                                                                           | Route                               | Must not miss                                                                                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| price, valuation, holdings, "why did it move", compare peers, explain a thesis, rank in text                                            | Financial Analysis / Ask Question   | Fetch fresh data/search evidence; comparison baselines need provenance too. Every answer must pass the ask evidence gate below.                                                          |
+| fintwit / KOL / leaderboard — top accounts or ranking, is @handle tracked, what an account thinks about a ticker or theme, track record | Platform Data: Fintwit Intelligence | Use the Platform Data section below, then read [fintwit.md](references/fintwit.md); cite the snapshot date; read-only, never fabricate rankings.                                         |
+| FinTwit digest SDK, alpha radar automation, custom digest module, `@alva/fintwit-digest`                                                | Platform Data: Fintwit Digest SDK   | Use the Platform Data section below, then read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md); follow the SDK API and ability contracts instead of copying runtime internals. |
+| dashboard, screener app, thesis tracker, hosted report, shareable surface                                                               | Playbook Creation                   | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md).                                                                                               |
+| `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
+| backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
+| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Build a push-capable feed and verify alert or group subscription plus sidecar output.                                                                                                    |
+| `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
+| `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
+| "does Alva have X?"                                                                                                                     | Capability Verification             | Run `alva data-skills list` and search for `<topic>` before saying no.                                                                                                                   |
 
 ## Capability Boundaries
 
@@ -215,14 +213,14 @@ source-cited answer, but they do not become raw chart data by being pasted into
 HTML.
 
 **Runtime vs local agent.** Runtime code runs on Alva Cloud, not on the agent's
-machine. It cannot use local filesystem paths, shell commands, Node builtins,
-or environment variables. If a task must be durable, scheduled, public, or
+machine. It cannot use local filesystem paths, shell commands, Node builtins, or
+environment variables. If a task must be durable, scheduled, public, or
 feed-backed, verify it in Alva runtime rather than only locally.
 
 **Feed vs playbook.** A feed is the data contract; a playbook is the UI and
-distribution surface. A beautiful playbook with stale or unreleased feeds is
-not complete. A good feed with no user-facing surface may be enough for an
-internal automation or direct data product.
+distribution surface. A beautiful playbook with stale or unreleased feeds is not
+complete. A good feed with no user-facing surface may be enough for an internal
+automation or direct data product.
 
 **alpi vs data.** alpi can turn real upstream data into narrative and
 categories, but it cannot invent financial facts. Its output belongs in clearly
@@ -241,11 +239,10 @@ before non-dry-run execution, and [api/trading.md](references/api/trading.md).
 
 The map is organized as one shared layer plus two decision trees. **Shared Data
 And Execution** is the common substrate: Data Skills, search, BYOD, `alva run`,
-jagent runtime, and provenance rules. **Financial Analysis / Ask Question**
-uses that layer for sourced chat answers. **Durable Artifacts / Playbook** uses
-that layer, then persists or publishes work through feeds, automations,
-signals, playbooks, or release flows. Choose the smallest tree that satisfies
-the verb.
+jagent runtime, and provenance rules. **Financial Analysis / Ask Question** uses
+that layer for sourced chat answers. **Durable Artifacts / Playbook** uses that
+layer, then persists or publishes work through feeds, automations, signals,
+playbooks, or release flows. Choose the smallest tree that satisfies the verb.
 
 ### Shared Data And Execution Layer
 
@@ -260,11 +257,10 @@ becoming a feed, cronjob, signal, or playbook.
 Data Skills are the primary source for structured financial facts: prices,
 klines, fundamentals, estimates, insider and senator trades, ownership, options
 chains and Greeks, macro, on-chain metrics, exchange flows, prediction markets,
-news, and indexed Twitter/X. The mandatory discovery path is `list` ->
-`summary` -> `endpoint`.
-Use `Authorization: Bearer <ARRAYS_JWT>`, not `X-API-Key`. For curated thematic
-or sector baskets, verify ticker fit with live company-detail data such as
-`getStockCompanyDetail`; do not trust memory.
+news, and indexed Twitter/X. The mandatory discovery path is `list` -> `summary`
+-> `endpoint`. Use `Authorization: Bearer <ARRAYS_JWT>`, not `X-API-Key`. For
+curated thematic or sector baskets, verify ticker fit with live company-detail
+data such as `getStockCompanyDetail`; do not trust memory.
 
 Source routing:
 
@@ -288,10 +284,10 @@ without rebuilding the upstream ingestion. Treat it as a first-party data
 product: inspect the current reference and live fields, cite freshness, and do
 not copy private runtime internals into user scripts.
 
-| Surface | Use for | Must not miss |
-| --- | --- | --- |
-| Fintwit Intelligence / KOL data | Top accounts, leaderboard rankings, tracked-handle checks, account theses, ticker sentiment, and track record questions. | Read [fintwit.md](references/fintwit.md); live-read the public platform feeds, cite the snapshot timestamp, and keep the source read-only. |
-| Fintwit Digest SDK | Alpha radar automation, custom digest modules, and `@alva/fintwit-digest` scripts over platform KOL tracker feeds. | Read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md); use the public API and ability contracts instead of copying runtime internals or adding ad hoc profile config. |
+| Surface                         | Use for                                                                                                                  | Must not miss                                                                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Fintwit Intelligence / KOL data | Top accounts, leaderboard rankings, tracked-handle checks, account theses, ticker sentiment, and track record questions. | Read [fintwit.md](references/fintwit.md); live-read the public platform feeds, cite the snapshot timestamp, and keep the source read-only.                                     |
+| Fintwit Digest SDK              | Alpha radar automation, custom digest modules, and `@alva/fintwit-digest` scripts over platform KOL tracker feeds.       | Read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md); use the public API and ability contracts instead of copying runtime internals or adding ad hoc profile config. |
 
 #### Data Access: Content Search And BYOD
 
@@ -304,10 +300,9 @@ and [content-legitimacy.md](references/content-legitimacy.md) before presenting
 any sourced financial value.
 
 BYOD is appropriate when the user supplies a source or Alva coverage cannot
-answer the task after capability verification. Wire the source into runtime
-code or feed logic; do not paste discovered values into HTML or direct answers.
-Use [secret-manager.md](references/secret-manager.md) if credentials are
-needed.
+answer the task after capability verification. Wire the source into runtime code
+or feed logic; do not paste discovered values into HTML or direct answers. Use
+[secret-manager.md](references/secret-manager.md) if credentials are needed.
 
 BYOD still has to behave like an Alva source: validate it, state freshness and
 blind spots, and route durable outputs through feeds.
@@ -321,19 +316,19 @@ Alva runtime scripts execute JavaScript in a sandboxed V8 isolate through
 Open [jagent-runtime.md](references/jagent-runtime.md) before writing runtime
 code. Common modules:
 
-| Need | Module / reference |
-| --- | --- |
-| ALFS files and shared modules | `require("alfs")`; `~/library`; [api/filesystem.md](references/api/filesystem.md) |
-| user id, username, args | `require("env")` |
-| third-party secrets | `require("secret-manager")`; [secret-manager.md](references/secret-manager.md) |
-| HTTP | `require("net/http")` |
-| statistics / indicators | `@alva/algorithm` or runtime `alva sdk` modules |
-| persistent feed output | `@alva/feed`; [feed-sdk.md](references/feed-sdk.md) |
-| Platform Data digest module | `@alva/fintwit-digest`; see Platform Data above and [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md) |
-| trading engine | `FeedAltra`; [altra-trading.md](references/altra-trading.md) |
-| scheduled LLM reasoning | `@alva/pi`; [alpi.md](references/alpi.md) |
-| ONNX model inference | `@alva/onnx`; [onnx.md](references/onnx.md) |
-| runtime tests | `@test/suite` |
+| Need                          | Module / reference                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| ALFS files and shared modules | `require("alfs")`; `~/library`; [api/filesystem.md](references/api/filesystem.md)                             |
+| user id, username, args       | `require("env")`                                                                                              |
+| third-party secrets           | `require("secret-manager")`; [secret-manager.md](references/secret-manager.md)                                |
+| HTTP                          | `require("net/http")`                                                                                         |
+| statistics / indicators       | `@alva/algorithm` or runtime `alva sdk` modules                                                               |
+| persistent feed output        | `@alva/feed`; [feed-sdk.md](references/feed-sdk.md)                                                           |
+| Platform Data digest module   | `@alva/fintwit-digest`; see Platform Data above and [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md) |
+| trading engine                | `FeedAltra`; [altra-trading.md](references/altra-trading.md)                                                  |
+| scheduled LLM reasoning       | `@alva/pi`; [alpi.md](references/alpi.md)                                                                     |
+| ONNX model inference          | `@alva/onnx`; [onnx.md](references/onnx.md)                                                                   |
+| runtime tests                 | `@test/suite`                                                                                                 |
 
 Runtime code should be boring and inspectable: small shape checks before full
 feeds, explicit precondition errors, no silent fallback records, and no local
@@ -354,9 +349,9 @@ sourced current data next to memory-derived baselines.
 
 Financial analysis is the default for user questions about markets, assets,
 portfolios, valuation, catalysts, rankings, comparisons, and "why" narratives.
-It may be a single fresh data fetch, an `alva run` computation over live data,
-a sourced explanation, a peer comparison, a thesis check, or a concise table.
-It is not merely "Data Query": data access and execution are steps inside an
+It may be a single fresh data fetch, an `alva run` computation over live data, a
+sourced explanation, a peer comparison, a thesis check, or a concise table. It
+is not merely "Data Query": data access and execution are steps inside an
 analysis answer.
 
 Common subroutes are latest fact, contextual explanation, comparison/valuation,
@@ -383,46 +378,47 @@ Enter this tree when the user asks Alva to keep something running, reusable,
 shareable, inspectable, or actionable. The tree is broader than playbooks: a
 script, feed, alert, signal, model output, or trading analysis may be the right
 artifact without a hosted UI. Enter the playbook branch only for hosted apps,
-share URLs, remixes, annotation edits, release/version updates, or playbook
-subscription setup.
+   share URLs, remixes, annotation edits, release/version updates, or playbook
+   alert/group-subscription setup.
 
 #### Data Product Layer: Feed Lifecycle And Automation
 
-Feeds persist data under ALFS and are the normal backing store for live
-analysis products, playbooks, dashboards, signals, alerts, and reusable
-outputs. A feed is not automatically a playbook; it can also back an alert,
-digest, signal, reusable dataset, or future answer.
+Feeds persist data under ALFS and are the normal backing store for live analysis
+products, playbooks, dashboards, signals, alerts, and reusable outputs. A feed
+is not automatically a playbook; it can also back an alert, digest, signal,
+reusable dataset, or future answer.
 
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic to ALFS, `alva run`, grant
-public read if needed, deploy, then `alva release feed`.
+short lifecycle is: write schema and logic to ALFS, `alva run`, grant public
+read if needed, deploy, then `alva automation publish`.
 
-Before feed release, satisfy `before-feed-release`: fresh run, expected shape,
-needed grants, public read verification, and non-empty data for HTML
-dependencies. Feed scripts fail fast on missing data; the detailed release and
-grant contract lives in the feed references. Read the matching
+Before automation publish, satisfy `before-automation-publish`: fresh run,
+expected shape, needed grants, public read verification, and non-empty data for
+HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
+and grant contract lives in the feed references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before
-each feed, ALFS, deploy, and release step.
+each feed, ALFS, deploy, and publish step.
 
 #### Publication Layer: Playbook Creation Tree
 
 Playbooks are hosted investing apps: dashboards, screeners, thesis trackers,
 backtest surfaces, what-if studies, event studies, or custom interactive tools.
 Enter this branch only when the user wants a hosted/shareable surface, remix,
-annotation edit, release/version update, or playbook subscription setup.
+annotation edit, release/version update, or playbook alert/group-subscription
+setup.
 
-Read [playbook-creation.md](references/playbook-creation.md) before creating
-or changing the hosted surface. It owns the build order, Browser-safe feed
-reads, README, draft/release gates, screenshot verification, tier/visibility
-flow, and push-after-release handoff. Read [api/release.md](references/api/release.md)
-for README, tags, trading-symbol, and `--skill-id` details; read
+Read [playbook-creation.md](references/playbook-creation.md) before creating or
+changing the hosted surface. It owns the build order, Browser-safe feed reads,
+README, draft/release gates, screenshot verification, tier/visibility flow, and
+push-after-release handoff. Read [api/release.md](references/api/release.md) for
+README, tags, trading-symbol, and `--skill-id` details; read
 [remix-workflow.md](references/remix-workflow.md) or
 [annotation-edits.md](references/annotation-edits.md) for those subroutes.
 
-The top-level boundary is feed-first and live-read: build feeds before HTML,
-and visible numbers must be read from feed outputs in the viewer's browser.
-Before HTML work, satisfy `before-build-html`; before draft/release satisfy
+The top-level boundary is feed-first and live-read: build feeds before HTML, and
+visible numbers must be read from feed outputs in the viewer's browser. Before
+HTML work, satisfy `before-build-html`; before draft/release satisfy
 `before-playbook-draft` and `before-playbook-release` in the reference. Keep
 procedure, release, screenshot, and tier details in the owning references.
 
@@ -433,8 +429,8 @@ question inherit playbook gates.
 #### Strategy Layer: Altra
 
 Altra is the trading and backtesting engine. Always use Altra for backtesting.
-Use it for any strategy, simulation, portfolio logic, signal feed, equity
-curve, target record, position tracking, order stream, drawdown, Sharpe, or
+Use it for any strategy, simulation, portfolio logic, signal feed, equity curve,
+target record, position tracking, order stream, drawdown, Sharpe, or
 rebalancing.
 
 Open [altra-trading.md](references/altra-trading.md) before implementation. It
@@ -443,18 +439,18 @@ target/signal structure, PIT compliance, testing, debug patterns, and supported
 OHLCV intervals.
 
 Stock intraday window guardrail: do not directly request multi-year US stock
-intraday backtests as one full window. Narrow the window, use daily/weekly
-bars, or choose a provider path that explicitly chunks requests.
+intraday backtests as one full window. Narrow the window, use daily/weekly bars,
+or choose a provider path that explicitly chunks requests.
 
 #### Reasoning Layer: alpi
 
 alpi embeds a fixed LLM reasoning/tool loop inside a deterministic scheduled
 pipeline. Use `@alva/pi` `Agent.ask()` for result-only classification,
-summarization, TLDRs, why-it-matters, and tool-loop reasoning over real
-upstream data.
+summarization, TLDRs, why-it-matters, and tool-loop reasoning over real upstream
+data.
 
-Do **not** use it for one-off research the user asks interactively, and do
-not use it to produce numbers or events that should come from real data. Read
+Do **not** use it for one-off research the user asks interactively, and do not
+use it to produce numbers or events that should come from real data. Read
 [alpi.md](references/alpi.md) for API, tool calling, memory patterns,
 user-editable agent instructions (release with `--agent-type alpi`, then append
 the owner's `AGENTS.md` (read `${feed.path}/AGENTS.md` yourself)), and
@@ -473,8 +469,8 @@ The design system is a release gate, not decoration. Read
 [design.md](references/design.md) first for tokens, typography, theme, layout,
 and the canonical stylesheet. Then read:
 
-- [design-widgets.md](references/design-widgets.md) for charts, widget
-  layouts, and tables (the authoritative Table Card spec lives here, not in
+- [design-widgets.md](references/design-widgets.md) for charts, widget layouts,
+  and tables (the authoritative Table Card spec lives here, not in
   design-components.md).
 - [design-components.md](references/design-components.md) for buttons, tabs,
   tags, dropdowns, and component details.
@@ -495,31 +491,31 @@ Pages using ECharts must satisfy the contract rule requiring
 #### Interface Layer: UDF Runtime
 
 User-Defined Functions let a playbook owner register shareable functions that
-viewers can invoke from the playbook UI. This is strict opt-in: only use it
-when the user asks for a registerable function or a button that calls their
-analysis function.
+viewers can invoke from the playbook UI. This is strict opt-in: only use it when
+the user asks for a registerable function or a button that calls their analysis
+function.
 
 Open [api/udf-runtime.md](references/api/udf-runtime.md). It owns PBSV browser
 authentication, `alva functions` creator registration and allowance tools,
 `window.alva.udf`, allowance consent, `UdfButton`, caller identity,
 `allow_charges=false` defaults, and release checks.
 
-#### Action Layer: Push Notifications
+#### Action Layer: Alerts
 
-Push is a feed/playbook subscription flow. A feed may emit `signal/targets` or
-`notify/message`; both dispatch `feed_alert_ready`. `--push-notify` only marks
-the publisher capable of alerts. It does not subscribe users or bypass
-preferences.
+Alerts are personal notification opt-ins for automations or playbooks. A feed
+may emit `signal/targets` or `notify/message`; both dispatch `feed_alert_ready`.
+`--push-notify` only marks the publisher capable of alerts. It does not
+subscribe users or bypass preferences.
 
 Open [push-notifications.md](references/push-notifications.md) for sidecar
-creation, release, subscription, and verification. Quiet runs use
-`<|SKIP_NOTIFICATION|>`.
+creation, automation publish, personal alert setup, group subscription setup,
+and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
 
-After releasing or keeping a playbook as draft, scan whether any backing feed
-is push-worthy. Recommend specific feeds, not generic "notifications". A push
-setup is not complete until the feed sidecar exists, the feed is released after
-that sidecar was added, the publisher has `--push-notify`, the user or group is
-subscribed, and a real run writes a fresh sidecar record.
+After releasing or keeping a playbook as draft, scan whether any backing feed is
+push-worthy. Recommend specific feeds, not generic "notifications". A push setup
+is not complete until the feed sidecar exists, `alva automation publish` ran
+after that sidecar was added, the publisher has `--push-notify`, the user has an
+alert or the group is subscribed, and a real run writes a fresh sidecar record.
 
 #### Playbook Subroute: Remix
 
@@ -534,9 +530,9 @@ user asks to browse examples, use `alva playbooks trending` after help.
 
 #### Playbook Subroute: Annotation Edits
 
-Annotation edits target rendered playbook elements through `<annotation>`
-tags. Locate the generator behind the element, usually a render function or CSS
-rule, and edit that. Never freeze rendered feed values into static text.
+Annotation edits target rendered playbook elements through `<annotation>` tags.
+Locate the generator behind the element, usually a render function or CSS rule,
+and edit that. Never freeze rendered feed values into static text.
 
 Open [annotation-edits.md](references/annotation-edits.md). HTML edits re-enter
 `before-build-html`.
@@ -545,8 +541,8 @@ Open [annotation-edits.md](references/annotation-edits.md). HTML edits re-enter
 
 Alva memory is file-based and user-visible under `~/memory/`. Read
 [memory.md](references/memory.md) before writing it. Store durable preferences,
-identity facts, investment style, and useful context; never store secrets,
-raw API keys, or unverified claims as truth.
+identity facts, investment style, and useful context; never store secrets, raw
+API keys, or unverified claims as truth.
 
 #### Support Layer: Secret Manager
 
@@ -570,8 +566,8 @@ feedback flow before closing.
 Open [content-legitimacy.md](references/content-legitimacy.md) before surfacing
 financial values. The quick checks:
 
-- Charts, tables, metric cards, and query answers need real Data Skills,
-  feed, or validated BYOD provenance.
+- Charts, tables, metric cards, and query answers need real Data Skills, feed,
+  or validated BYOD provenance.
 - HTML values are fetched from feed outputs at runtime. Never hardcode data as
   inline JavaScript literals for financial values.
 - If `alva release playbook --feeds '[]'` is used, the HTML must render zero
@@ -579,8 +575,8 @@ financial values. The quick checks:
 - WebSearch can discover docs or BYOD endpoints; it cannot become the data.
 - LLM/alpi output can synthesize real upstream data; it cannot invent facts,
   figures, events, or sourced-looking reports.
-- More than 20% failed symbol lookups is a data-quality blocker, not a prompt
-  to fabricate or mark rows `live: false`.
+- More than 20% failed symbol lookups is a data-quality blocker, not a prompt to
+  fabricate or mark rows `live: false`.
 - Feed Scope Isolation: build new feeds unless the user explicitly asks for
   reuse.
 - For fundamentals periods, YoY/QoQ, or cross-company comparisons, open
@@ -595,11 +591,11 @@ reference before doing the task.
 
 ### Ask Question / Financial Analysis
 
-For "what is the latest price / P/E / funding rate / holdings / CPI print",
-"why did it move", "is it cheap vs peers", or "rank these in text", start with
+For "what is the latest price / P/E / funding rate / holdings / CPI print", "why
+did it move", "is it cheap vs peers", or "rank these in text", start with
 financial analysis. Run preflight if needed, verify the relevant Data Skills or
-search route, use `alva run` when live computation or joins are needed, fetch
-or qualify any comparison baseline, read
+search route, use `alva run` when live computation or joins are needed, fetch or
+qualify any comparison baseline, read
 [user-facing-prose.md](references/user-facing-prose.md), apply the answer gate
 in the Financial Analysis tree, classify complex asks with
 [request-routing.md](references/request-routing.md), and answer with inline
@@ -612,9 +608,9 @@ alert, or playbook.
 
 ### Hosted Playbook Workflow
 
-Enter this tree when the user wants a hosted app, share URL, dashboard,
-screener app, report surface, remix, annotation edit, release/version update,
-or playbook subscription setup. First choose the artifact shape: direct answer,
+Enter this tree when the user wants a hosted app, share URL, dashboard, screener
+app, report surface, remix, annotation edit, release/version update, or playbook
+alert/group-subscription setup. First choose the artifact shape: direct answer,
 feed, signal, model output, or hosted playbook. For hosted/shareable surfaces,
 turn the request into a data contract before UI work: universe, metrics,
 freshness, output groups, widgets, and release path. Then open
@@ -629,31 +625,31 @@ A thesis tracker combines structured metrics, content search, and alpi narrative
 over real upstream data. It may be a direct answer, a scheduled feed, an alert,
 or a playbook depending on the requested artifact. Keep the alpi prompt fixed,
 keep source records separate from AI analysis, and make push lines match actual
-thesis deltas. If the user gives `/use-skill:alva/thesis` or asks to use a
-named thesis blueprint, fetch it fresh and let its method drive the build.
+thesis deltas. If the user gives `/use-skill:alva/thesis` or asks to use a named
+thesis blueprint, fetch it fresh and let its method drive the build.
 
 ### Strategy And Trading Analysis
 
 Use Altra from the start. Register OHLCV, raw data, and features; define event
-triggers and strategy state; run the backtest; then package results as a
-concise answer, feed, signal, or visual playbook depending on the request. If
-the strategy emits live signals, the output belongs in a feed and push/trading
+triggers and strategy state; run the backtest; then package results as a concise
+answer, feed, signal, or visual playbook depending on the request. If the
+strategy emits live signals, the output belongs in a feed and push/trading
 routes may apply. Read [altra-trading.md](references/altra-trading.md) and
 [api/trading.md](references/api/trading.md) before execution.
 
 ### Remix Or Annotated Edit
 
-Do not regenerate from memory. Download the existing HTML and feed scripts,
-edit them in place, preserve data contracts unless the user's change requires
-a new one, and rerun the relevant playbook gates. For annotations, change the
+Do not regenerate from memory. Download the existing HTML and feed scripts, edit
+them in place, preserve data contracts unless the user's change requires a new
+one, and rerun the relevant playbook gates. For annotations, change the
 generator behind the selected element rather than the rendered DOM.
 
 ### Push Monitor
 
 For a recurring alert, design the feed output first: signal target or message,
-quiet-run sentinel, cadence, and subscriber. Release the feed after adding the
-sidecar, then verify a real run. A cronjob with `--push-notify` and no
-subscription is not a completed push setup.
+quiet-run sentinel, cadence, and subscriber. Publish the automation after adding
+the sidecar, then verify a real run. A cronjob with `--push-notify` and no alert
+or group subscription is not a completed push setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 
@@ -669,30 +665,32 @@ scheduled digest.
 Always run command help before use. These rows point to extra rules the help
 text does not fully cover.
 
-| Command / surface | Purpose and extra reference |
-| --- | --- |
-| `whoami` / `user` | Identity, subscription tier, channels, username. See [preflight.md](references/preflight.md). |
-| `auth` / `configure` | Sign in, API key, profile configuration. |
-| `arrays` | Provision / refresh `ARRAYS_JWT`. See [preflight.md](references/preflight.md). |
-| `data-skills` | Structured Arrays endpoint discovery. See [data-skills.md](references/data-skills.md). |
-| `sdk` | Runtime library discovery. See [data-skills.md](references/data-skills.md#runtime-libraries-are-separate). |
-| `fs` | ALFS reads/writes/grants/time-series suffixes and shared modules under `~/library`. Must read [api/filesystem.md](references/api/filesystem.md) for synth suffixes and grant gotchas. |
-| `run` | Execute jagent JS. See [jagent-runtime.md](references/jagent-runtime.md). |
-| `deploy` | Cronjob lifecycle. See [deployment.md](references/deployment.md). |
-| `release` | Feed release, playbook draft/release. Must read [api/release.md](references/api/release.md). |
-| `lint playbook` | Design-system linter, same gate as release. See [design-contract.yaml](references/design-contract.yaml). |
-| `skillhub` | Curated methodology blueprints. See [request-routing.md](references/request-routing.md#skillhub-blueprint). |
-| `playbooks` | Trending discovery and `set-visibility`. |
-| `comments` | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md). |
-| `subscriptions` | Personal feed/playbook push subscription. See [push-notifications.md](references/push-notifications.md). |
-| `channel` | Group push subscriptions. See [push-notifications.md](references/push-notifications.md). |
-| `trading` | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md). |
-| `screenshot` | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot). |
-| `remix` | Lineage registration only. See [remix-workflow.md](references/remix-workflow.md). |
-| `functions` | Playbook UDF registration, invoke smoke tests, and allowance management. Must read [api/udf-runtime.md](references/api/udf-runtime.md). |
-| `credits` | Current viewer credit wallet and self-scoped consumption rows. Must read [api/credits.md](references/api/credits.md). |
-| `secrets` | Secret CRUD for agent-managed setup. See [secret-manager.md](references/secret-manager.md). |
-| `feedback` | Submit user-confirmed Alva platform feedback. Must read [api/feedback.md](references/api/feedback.md). |
+| Command / surface    | Purpose and extra reference                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `whoami` / `user`    | Identity, subscription tier, channels, username. See [preflight.md](references/preflight.md).                                                                                         |
+| `auth` / `configure` | Sign in, API key, profile configuration.                                                                                                                                              |
+| `arrays`             | Provision / refresh `ARRAYS_JWT`. See [preflight.md](references/preflight.md).                                                                                                        |
+| `data-skills`        | Structured Arrays endpoint discovery. See [data-skills.md](references/data-skills.md).                                                                                                |
+| `sdk`                | Runtime library discovery. See [data-skills.md](references/data-skills.md#runtime-libraries-are-separate).                                                                            |
+| `fs`                 | ALFS reads/writes/grants/time-series suffixes and shared modules under `~/library`. Must read [api/filesystem.md](references/api/filesystem.md) for synth suffixes and grant gotchas. |
+| `run`                | Execute jagent JS. See [jagent-runtime.md](references/jagent-runtime.md).                                                                                                             |
+| `deploy`             | Cronjob lifecycle. See [deployment.md](references/deployment.md).                                                                                                                     |
+| `automation`         | Product-facing feed publish/lifecycle (`publish`, `list`, `stop`, `resume`, `delete`). Must read [feed-lifecycle.md](references/feed-lifecycle.md).                                   |
+| `release`            | Playbook draft/release; the release reference also covers automation publish metadata extras. Must read [api/release.md](references/api/release.md).                                   |
+| `lint playbook`      | Design-system linter, same gate as release. See [design-contract.yaml](references/design-contract.yaml).                                                                              |
+| `skillhub`           | Curated methodology blueprints. See [request-routing.md](references/request-routing.md#skillhub-blueprint).                                                                           |
+| `playbooks`          | Trending discovery and `set-visibility`.                                                                                                                                              |
+| `comments`           | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md).                                                                                      |
+| `alert`              | Personal automation/playbook alert opt-ins and history. See [push-notifications.md](references/push-notifications.md).                                                                |
+| `subscriptions`      | Legacy alert/follow surface. Prefer `alert`; use only for follows. See [push-notifications.md](references/push-notifications.md).                                                     |
+| `channel`            | Group push subscriptions. See [push-notifications.md](references/push-notifications.md).                                                                                              |
+| `trading`            | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md).                                                                         |
+| `screenshot`         | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot).                                                               |
+| `remix`              | Lineage registration only. See [remix-workflow.md](references/remix-workflow.md).                                                                                                     |
+| `functions`          | Playbook UDF registration, invoke smoke tests, and allowance management. Must read [api/udf-runtime.md](references/api/udf-runtime.md).                                               |
+| `credits`            | Current viewer credit wallet and self-scoped consumption rows. Must read [api/credits.md](references/api/credits.md).                                                                 |
+| `secrets`            | Secret CRUD for agent-managed setup. See [secret-manager.md](references/secret-manager.md).                                                                                           |
+| `feedback`           | Submit user-confirmed Alva platform feedback. Must read [api/feedback.md](references/api/feedback.md).                                                                                |
 
 Non-CLI references:
 
@@ -705,51 +703,51 @@ Non-CLI references:
 
 Use this index to open only the file needed for the current task.
 
-| File | Owns |
-| --- | --- |
-| [preflight.md](references/preflight.md) | Session start, Rule 0, CLI, auth, profile, Arrays JWT, memory load, user scope. |
-| [request-routing.md](references/request-routing.md) | Route choice, Skillhub, Guided Planning, capability verification, completion gate. |
-| [content-legitimacy.md](references/content-legitimacy.md) | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions. |
-| [data-skills.md](references/data-skills.md) | Data Skills discovery, endpoint calls, Arrays auth, search/data routing. |
-| [feed-lifecycle.md](references/feed-lifecycle.md) | Feed build/release lifecycle, modeling summary, push sidecars, `before-feed-release`. |
-| [playbook-creation.md](references/playbook-creation.md) | HTML build, browser-safe reads, README, draft, release, screenshot, tier flow. |
-| [push-notifications.md](references/push-notifications.md) | Push-worthy feeds, sidecars, subscriptions, delivery verification. |
-| [operational-pitfalls.md](references/operational-pitfalls.md) | Runtime, ALFS, chart, watermark, and resource pitfalls. |
-| [jagent-runtime.md](references/jagent-runtime.md) | V8 runtime, modules, async model, constraints, built-ins. |
-| [feed-sdk.md](references/feed-sdk.md) | Feed SDK API, schemas, time series, grouped records, upstreams, examples. |
-| [altra-trading.md](references/altra-trading.md) | Altra strategy engine, features, signals, tests, PIT compliance. |
-| [alpi.md](references/alpi.md) | Scheduled LLM reasoning/tool-loop API and examples. |
-| [onnx.md](references/onnx.md) | ONNX artifact, inference, FeedAltra integration, release checks. |
-| [deployment.md](references/deployment.md) | Cronjob create/list/pause/resume/trigger/runs/run-logs. |
-| [search.md](references/search.md) | `unified_search`, finance search, Twitter/X, Reddit, YouTube, web gotchas. |
-| [fintwit.md](references/fintwit.md) | Platform Data / Fintwit Intelligence: curated fintwit/KOL account data — views, signals, profiles; query recipes by account, ticker, ranking. |
-| [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md) | Platform Data / Fintwit Digest SDK: `@alva/fintwit-digest` public API, run profiles, pipeline state, ability contracts, and override rules. |
-| [secret-manager.md](references/secret-manager.md) | Secret upload, naming, CRUD, runtime access, guardrails. |
-| [memory.md](references/memory.md) | Memory storage layout, write policy, user profile template. |
-| [user-facing-prose.md](references/user-facing-prose.md) | Product vocabulary, voice rules, and alpi prose prompt block. |
-| [design.md](references/design.md) | Design entrypoint, canonical CSS link, tokens, layout. |
-| [design-widgets.md](references/design-widgets.md) | Widget and chart layouts. |
-| [design-components.md](references/design-components.md) | Component specs. |
-| [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md) | Strategy/backtest playbook UI. |
-| [annotation-edits.md](references/annotation-edits.md) | `<annotation>` edit procedure. |
-| [remix-workflow.md](references/remix-workflow.md) | Remix extraction, source reads, lineage. |
-| [creators-note.md](references/creators-note.md) | Pinned author comment after release. |
-| [fundamentals-periods.md](references/fundamentals-periods.md) | Fiscal/calendar period alignment. |
-| [api/filesystem.md](references/api/filesystem.md) | ALFS synth suffixes and feed grant gotcha. |
-| [api/release.md](references/api/release.md) | Release extras: README, tags, trading symbols, skill id, descriptions. |
-| [api/trading.md](references/api/trading.md) | Trading signal schema, symbol naming, dry-run rules. |
-| [api/udf-runtime.md](references/api/udf-runtime.md) | Playbook UDF CLI setup, allowance management, and browser invocation. |
-| [api/credits.md](references/api/credits.md) | User-scoped credit wallet and consumption history queries. |
-| [api/feedback.md](references/api/feedback.md) | User-confirmed Alva platform feedback for Alva-owned blockers. |
-| [api/error-responses.md](references/api/error-responses.md) | HTTP status to error-code table. |
+| File                                                                                  | Owns                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [preflight.md](references/preflight.md)                                               | Session start, Rule 0, CLI, auth, profile, Arrays JWT, memory load, user scope.                                                               |
+| [request-routing.md](references/request-routing.md)                                   | Route choice, Skillhub, Guided Planning, capability verification, completion gate.                                                            |
+| [content-legitimacy.md](references/content-legitimacy.md)                             | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions.                                                           |
+| [data-skills.md](references/data-skills.md)                                           | Data Skills discovery, endpoint calls, Arrays auth, search/data routing.                                                                      |
+| [feed-lifecycle.md](references/feed-lifecycle.md)                                     | Feed build and automation publish lifecycle, modeling summary, push sidecars, `before-automation-publish`.                                    |
+| [playbook-creation.md](references/playbook-creation.md)                               | HTML build, browser-safe reads, README, draft, release, screenshot, tier flow.                                                                |
+| [push-notifications.md](references/push-notifications.md)                             | Push-worthy feeds, sidecars, alerts, delivery verification.                                                                                   |
+| [operational-pitfalls.md](references/operational-pitfalls.md)                         | Runtime, ALFS, chart, watermark, and resource pitfalls.                                                                                       |
+| [jagent-runtime.md](references/jagent-runtime.md)                                     | V8 runtime, modules, async model, constraints, built-ins.                                                                                     |
+| [feed-sdk.md](references/feed-sdk.md)                                                 | Feed SDK API, schemas, time series, grouped records, upstreams, examples.                                                                     |
+| [altra-trading.md](references/altra-trading.md)                                       | Altra strategy engine, features, signals, tests, PIT compliance.                                                                              |
+| [alpi.md](references/alpi.md)                                                         | Scheduled LLM reasoning/tool-loop API and examples.                                                                                           |
+| [onnx.md](references/onnx.md)                                                         | ONNX artifact, inference, FeedAltra integration, release checks.                                                                              |
+| [deployment.md](references/deployment.md)                                             | Cronjob create/list/pause/resume/trigger/runs/run-logs.                                                                                       |
+| [search.md](references/search.md)                                                     | `unified_search`, finance search, Twitter/X, Reddit, YouTube, web gotchas.                                                                    |
+| [fintwit.md](references/fintwit.md)                                                   | Platform Data / Fintwit Intelligence: curated fintwit/KOL account data — views, signals, profiles; query recipes by account, ticker, ranking. |
+| [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md)                             | Platform Data / Fintwit Digest SDK: `@alva/fintwit-digest` public API, run profiles, pipeline state, ability contracts, and override rules.   |
+| [secret-manager.md](references/secret-manager.md)                                     | Secret upload, naming, CRUD, runtime access, guardrails.                                                                                      |
+| [memory.md](references/memory.md)                                                     | Memory storage layout, write policy, user profile template.                                                                                   |
+| [user-facing-prose.md](references/user-facing-prose.md)                               | Product vocabulary, voice rules, and alpi prose prompt block.                                                                                 |
+| [design.md](references/design.md)                                                     | Design entrypoint, canonical CSS link, tokens, layout.                                                                                        |
+| [design-widgets.md](references/design-widgets.md)                                     | Widget and chart layouts.                                                                                                                     |
+| [design-components.md](references/design-components.md)                               | Component specs.                                                                                                                              |
+| [design-playbook-trading-strategy.md](references/design-playbook-trading-strategy.md) | Strategy/backtest playbook UI.                                                                                                                |
+| [annotation-edits.md](references/annotation-edits.md)                                 | `<annotation>` edit procedure.                                                                                                                |
+| [remix-workflow.md](references/remix-workflow.md)                                     | Remix extraction, source reads, lineage.                                                                                                      |
+| [creators-note.md](references/creators-note.md)                                       | Pinned author comment after release.                                                                                                          |
+| [fundamentals-periods.md](references/fundamentals-periods.md)                         | Fiscal/calendar period alignment.                                                                                                             |
+| [api/filesystem.md](references/api/filesystem.md)                                     | ALFS synth suffixes and feed grant gotcha.                                                                                                    |
+| [api/release.md](references/api/release.md)                                           | Release extras: README, tags, trading symbols, skill id, descriptions.                                                                        |
+| [api/trading.md](references/api/trading.md)                                           | Trading signal schema, symbol naming, dry-run rules.                                                                                          |
+| [api/udf-runtime.md](references/api/udf-runtime.md)                                   | Playbook UDF CLI setup, allowance management, and browser invocation.                                                                         |
+| [api/credits.md](references/api/credits.md)                                           | User-scoped credit wallet and consumption history queries.                                                                                    |
+| [api/feedback.md](references/api/feedback.md)                                         | User-confirmed Alva platform feedback for Alva-owned blockers.                                                                                |
+| [api/error-responses.md](references/api/error-responses.md)                           | HTTP status to error-code table.                                                                                                              |
 
 Runtime artifacts:
 
-| Artifact | Use |
-| --- | --- |
+| Artifact                                                  | Use                                                                    |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- |
 | [css/design-system.css](references/css/design-system.css) | Bundled CSS loaded by playbook HTML; rules live in design `.md` files. |
-| [design-contract.yaml](references/design-contract.yaml) | Linter/release contract. |
-| [design-tokens.css](references/design-tokens.css) | Token source used by the CSS bundle. |
+| [design-contract.yaml](references/design-contract.yaml)   | Linter/release contract.                                               |
+| [design-tokens.css](references/design-tokens.css)         | Token source used by the CSS bundle.                                   |
 
 ## User-Facing Communication
 
@@ -759,8 +757,8 @@ internal function names, or scaffold details unless the user is debugging or
 asks for them.
 
 When giving direct answers with financial figures, attribute each number to a
-fresh Data Skills/BYOD/feed/search source, or clearly say the fetch failed.
-Do not present estimates from memory as live facts.
+fresh Data Skills/BYOD/feed/search source, or clearly say the fetch failed. Do
+not present estimates from memory as live facts.
 
 For multi-step builds, give short milestone updates. For final answers, include
 the canonical share URL for released playbooks and use `published_url` only for
@@ -779,13 +777,14 @@ Before finishing an Alva task, ask:
   answered?
 - Did I avoid WebSearch/LLM/memory/user-pasted data as factual values?
 - Did I run Data Skills `list` -> `summary` -> `endpoint` before coding calls?
-- Did feed release pass `before-feed-release`?
+- Did automation publish pass `before-automation-publish`?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)
   and pass the relevant hard gates?
 - Did design work read [design.md](references/design.md) and lint where needed?
 - Did Skillhub work fetch the blueprint fresh and set `--skill-id` if used?
 - Did backtesting or signal work use Altra?
-- Did push work verify both publisher sidecar and subscriber target?
+- Did push work verify the publisher sidecar plus the personal alert or group
+  subscription target?
 - If Alva-owned behavior blocked the task, did I offer the confirmed feedback
   flow after reading [api/feedback.md](references/api/feedback.md)?
 - Did the final response describe the delivered result without leaking

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -20,8 +20,8 @@ Altra consists of four processing stages:
    features (indicators)
 2. **SignalEngine** -- Runs your strategy function on each trigger event,
    producing targets (buy/sell signals)
-3. **SimEngine** -- Simulates order execution, portfolio management, and position
-   tracking
+3. **SimEngine** -- Simulates order execution, portfolio management, and
+   position tracking
 4. **PerfEngine** -- Computes performance metrics (returns, Sharpe, drawdown,
    etc.)
 
@@ -224,9 +224,9 @@ altra.setStrategy(strategyFn, {
 
 ## Imports
 
-Altra is accessed through the `FeedAltraModule` export from `@alva/feed`.
-Field type helpers (`num`, `str`, etc.) and `createArraysOhlcvProvider` are at
-the `@alva/feed` top level:
+Altra is accessed through the `FeedAltraModule` export from `@alva/feed`. Field
+type helpers (`num`, `str`, etc.) and `createArraysOhlcvProvider` are at the
+`@alva/feed` top level:
 
 ```javascript
 const {
@@ -240,28 +240,20 @@ const {
   makeDoc,
   createArraysOhlcvProvider,
 } = require("@alva/feed");
-const {
-  FeedAltra,
-  e,
-  Amount,
-  TIME,
-  allocate,
-  order,
-  orders,
-} = FeedAltraModule;
+const { FeedAltra, e, Amount, TIME, allocate, order, orders } = FeedAltraModule;
 ```
 
-| Export                                    | Source                     | Description                                      |
-| ----------------------------------------- | -------------------------- | ------------------------------------------------ |
-| `FeedAltra`                               | `FeedAltraModule`          | Main backtesting engine class                    |
-| `e`                                       | `FeedAltraModule`          | Event trigger expression builder                 |
-| `Amount`                                  | `FeedAltraModule`          | Order amount constructors                        |
-| `TIME`                                    | `FeedAltraModule`          | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
-| `allocate`                                | `FeedAltraModule`          | Helper to create allocate target                 |
-| `order` / `orders`                        | `FeedAltraModule`          | Helper to create order targets                   |
-| `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level)   | Field type helpers (same as Feed SDK)            |
-| `makeDoc`                                 | `@alva/feed` (top level)   | Type document helper                             |
-| `createArraysOhlcvProvider`               | `@alva/feed` (top level)    | Builds the OHLCV provider used by Altra          |
+| Export                                    | Source                   | Description                                      |
+| ----------------------------------------- | ------------------------ | ------------------------------------------------ |
+| `FeedAltra`                               | `FeedAltraModule`        | Main backtesting engine class                    |
+| `e`                                       | `FeedAltraModule`        | Event trigger expression builder                 |
+| `Amount`                                  | `FeedAltraModule`        | Order amount constructors                        |
+| `TIME`                                    | `FeedAltraModule`        | Time constants (SECOND, MINUTE, HOUR, DAY, WEEK) |
+| `allocate`                                | `FeedAltraModule`        | Helper to create allocate target                 |
+| `order` / `orders`                        | `FeedAltraModule`        | Helper to create order targets                   |
+| `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level) | Field type helpers (same as Feed SDK)            |
+| `makeDoc`                                 | `@alva/feed` (top level) | Type document helper                             |
+| `createArraysOhlcvProvider`               | `@alva/feed` (top level) | Builds the OHLCV provider used by Altra          |
 
 ---
 
@@ -288,10 +280,9 @@ const altra = new FeedAltra(config, ohlcvProvider);
 - US stocks: `"1min"`, `"2min"`, `"3min"`, `"5min"`, `"10min"`, `"15min"`,
   `"30min"`, `"1h"`, `"2h"`, `"4h"`, `"1d"`, `"1w"`, `"1m"`.
 - Crypto spot/perp: `"1min"`, `"2min"`, `"3min"`, `"5min"`, `"10min"`,
-  `"15min"`, `"30min"`, `"45min"`, `"1h"`, `"2h"`, `"4h"`, `"1d"`,
-  `"1w"`, `"1m"`, plus locally aggregated minute/hour/day multiples that
-  divide cleanly into a supported base interval (for example `"6h"`, `"8h"`,
-  `"12h"`, `"3d"`).
+  `"15min"`, `"30min"`, `"45min"`, `"1h"`, `"2h"`, `"4h"`, `"1d"`, `"1w"`,
+  `"1m"`, plus locally aggregated minute/hour/day multiples that divide cleanly
+  into a supported base interval (for example `"6h"`, `"8h"`, `"12h"`, `"3d"`).
 - Do not use stock `"45min"`; the provider rejects it. Do not assume arbitrary
   strings between `"1min"` and `"1w"` are valid for stocks.
 
@@ -334,17 +325,17 @@ const altra = new FeedAltra(
 );
 ```
 
-| Field                          | Description                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------- |
-| `path`                         | ALFS feed path (e.g. `'~/feeds/my-strategy/v1'`). All output data stored here.   |
-| `startDate`                    | Backtest start timestamp (ms UTC). Use the exact date, never adjust for warmup, but still respect provider data-window limits. |
-| `portfolioOptions.initialCash` | Starting cash (default: 100,000)                                                |
-| `portfolioOptions.currency`    | Quote currency (default: "USD")                                                 |
+| Field                          | Description                                                                                                                              |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`                         | ALFS feed path (e.g. `'~/feeds/my-strategy/v1'`). All output data stored here.                                                           |
+| `startDate`                    | Backtest start timestamp (ms UTC). Use the exact date, never adjust for warmup, but still respect provider data-window limits.           |
+| `portfolioOptions.initialCash` | Starting cash (default: 100,000)                                                                                                         |
+| `portfolioOptions.currency`    | Quote currency (default: "USD")                                                                                                          |
 | `simOptions.simTick`           | Simulation resolution. Prefer valid tick strings like `"1min"`, `"15min"`, or `"1d"`; numeric ms values must map to a valid tick string. |
-| `simOptions.feeRate`           | Fee per trade as fraction (e.g. 0.001 = 0.1%)                                   |
-| `simOptions.slippage`          | Slippage as fraction                                                            |
-| `perfOptions.timezone`         | `"UTC"` for crypto/mix, `"America/New_York"` for us_stock                       |
-| `perfOptions.marketType`       | `"crypto"`, `"us_stock"`, or `"mix"` (multi-asset)                              |
+| `simOptions.feeRate`           | Fee per trade as fraction (e.g. 0.001 = 0.1%)                                                                                            |
+| `simOptions.slippage`          | Slippage as fraction                                                                                                                     |
+| `perfOptions.timezone`         | `"UTC"` for crypto/mix, `"America/New_York"` for us_stock                                                                                |
+| `perfOptions.marketType`       | `"crypto"`, `"us_stock"`, or `"mix"` (multi-asset)                                                                                       |
 
 ### TIME Constants
 
@@ -519,7 +510,7 @@ dataGraph.registerRawData({
   fn: (fromExclusive, toInclusive) => {
     const resp = http.syncFetch(
       `${ARRAYS_BASE}/api/v1/crypto/open-interest?symbol=BTCUSDT&start_time=${fromExclusive}&end_time=${toInclusive}&interval=1d`,
-      { headers: { Authorization: "Bearer " + ARRAYS_JWT } }
+      { headers: { Authorization: "Bearer " + ARRAYS_JWT } },
     );
     const result = JSON.parse(resp.text());
 
@@ -571,7 +562,10 @@ e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d"); // Daily bar close
 e.raw("sentiment_score"); // Raw data update
 e.feature("rsi"); // Feature computed
 
-e.all(e.ohlcv("XNAS_SPOT_AAPL_USD", "1d"), e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d")); // AND
+e.all(
+  e.ohlcv("XNAS_SPOT_AAPL_USD", "1d"),
+  e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d"),
+); // AND
 e.any(e.ohlcv("BINANCE_SPOT_BTC_USDT", "1h"), e.raw("funding")); // OR
 ```
 
@@ -637,10 +631,10 @@ if (bars.length === 0) return { target: null, state }; // warmup
 
 **Feature lookback** and **strategy lookback** are set in different scopes:
 
-| Type              | Where Set                | Controls                                                    |
-| ----------------- | ------------------------ | ----------------------------------------------------------- |
+| Type              | Where Set                | Controls                                                                |
+| ----------------- | ------------------------ | ----------------------------------------------------------------------- |
 | Feature lookback  | Feature's `inputConfig`  | How many OHLCV, raw, or feature dependency records the feature receives |
-| Strategy lookback | Strategy's `inputConfig` | How many OHLCV, raw, or feature records the strategy sees              |
+| Strategy lookback | Strategy's `inputConfig` | How many OHLCV, raw, or feature records the strategy sees               |
 
 Strategy lookback can also extend upstream raw/feature computation ranges so the
 requested records are available to the strategy.
@@ -685,12 +679,12 @@ trades.
 
 **Weight values**:
 
-| Weight | Meaning                     |
-| ------ | --------------------------- |
-| `0`    | Close entire position (exit) |
-| `0.5`  | 50% of equity in this asset |
-| `1.0`  | 100% long (fully invested)  |
-| `-1.0` | 100% short                  |
+| Weight | Meaning                                    |
+| ------ | ------------------------------------------ |
+| `0`    | Close entire position (exit)               |
+| `0.5`  | 50% of equity in this asset                |
+| `1.0`  | 100% long (fully invested)                 |
+| `-1.0` | 100% short                                 |
 | `2.0`  | 200% long target, subject to margin limits |
 
 - Existing positions omitted from `weights` are also targeted to `0` and closed
@@ -726,9 +720,9 @@ Amount.ofPosition(0.5); // 50% of current position size
 Amount.ofEquity(0.05); // 5% of portfolio equity
 ```
 
-Use either an `allocate` instruction or an `orders` instruction in a target.
-Do not put `orders` inside an `allocate` instruction; current execution only
-uses the `weights` for `allocate` targets.
+Use either an `allocate` instruction or an `orders` instruction in a target. Do
+not put `orders` inside an `allocate` instruction; current execution only uses
+the `weights` for `allocate` targets.
 
 ---
 
@@ -749,7 +743,8 @@ The `RunResult` contains:
 - `orders` -- All executed orders with fill details
 - `perf` -- Performance metrics (total return, Sharpe ratio, max drawdown, etc.)
 
-All output data is also persisted under the feed's ALFS path (quote in CLI, e.g. `'~/feeds/my-strategy/v1/data/'`):
+All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
+`'~/feeds/my-strategy/v1/data/'`):
 
 ```
 ~/feeds/my-strategy/v1/data/
@@ -761,10 +756,11 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 ```
 
 `signal/targets` makes the feed push-capable, but delivery still requires the
-cronjob to be created or updated with `--push-notify` and the feed release to be
-bound to that cronjob. Actual delivery also requires an explicit personal or
-group subscription to the feed or to a playbook that references it. See
-`references/deployment.md` for the deploy/release flow.
+cronjob to be created or updated with `--push-notify` and
+`alva automation publish` to bind the feed to that cronjob. Actual delivery also
+requires an explicit personal alert or group subscription to the automation or
+to a playbook that references it. See `references/deployment.md` for the
+deploy/publish flow.
 
 ---
 
@@ -924,7 +920,9 @@ describe("Feature: discount_30d", () => {
   it("returns empty when insufficient bars", () => {
     const mockData = {
       ohlcvs: {
-        [SYMBOL]: { [STRATEGY_INTERVAL]: createMockBars(29, 100000, 1733011200000) },
+        [SYMBOL]: {
+          [STRATEGY_INTERVAL]: createMockBars(29, 100000, 1733011200000),
+        },
       },
     };
     const result = discountFeatureFn(mockData, {
@@ -992,9 +990,7 @@ function createFundingRateRawData(options) {
   return {
     name: "funding_rate",
     fn: (fromExclusive, toInclusive) => {
-      const res = fetcher({
-        /* params */
-      });
+      const res = fetcher({/* params */});
       // ...
     },
   };

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -1,45 +1,47 @@
-# Release — extras not in CLI help
+# Release And Automation Publish — extras not in CLI help
 
-Run `alva release --help` first for the full workflow, all subcommands,
-flags, display-name conventions, and examples. This file covers only:
+Run `alva release --help` for playbook workflows and `alva automation --help` for
+automation publish flags before acting. CLI help is authoritative for
+subcommands, flags, display-name conventions, and examples. This file covers
+only:
 
-1. Feed `--description` wording rules
-2. Playbook README content shape (the big one — referenced by SKILL.md
-   and the `--readme-url` flag)
-3. `--trading-symbols` and `--tags` semantics, person-name discovery tags,
-   and the required overlap between trading symbols and tags
+1. Automation publish `--description` wording rules
+2. Playbook README content shape (the big one — referenced by SKILL.md and the
+   `--readme-url` flag)
+3. `--trading-symbols` and `--tags` semantics, person-name discovery tags, and
+   the required overlap between trading symbols and tags
 4. `--skill-id` — when it is required
 5. `--agent-type` — marking a feed as a prompt-editable agent
 
-## Feed `--description` conventions
+## Automation Publish `--description` conventions
 
-- Write a complete statement covering the feed's **data source**, **what
-  it computes**, and the **output it produces**.
-- Prefer concrete specifics (symbol, interval, exchange, indicator
-  parameters) over vague labels.
+- Write a complete statement covering the feed's **data source**, **what it
+  computes**, and the **output it produces**.
+- Prefer concrete specifics (symbol, interval, exchange, indicator parameters)
+  over vague labels.
 - Avoid bare labels like `"BTC EMA"` — they read as names, not descriptions.
 
-Good: `"Fetches BTC/USDT 1h klines from Binance and emits the 20-period EMA as a time series"`
+Good:
+`"Fetches BTC/USDT 1h klines from Binance and emits the 20-period EMA as a time series"`
 Bad: `"BTC EMA"`
 
 ## Trading symbols and tags
 
-- `--trading-symbols` — base asset tickers, e.g. `["BTC"]`, `["NVDA",
-  "AAPL"]`. The backend resolves each to a trading-pair object; this
-  drives asset routing.
+- `--trading-symbols` — base asset tickers, e.g. `["BTC"]`, `["NVDA", "AAPL"]`.
+  The backend resolves each to a trading-pair object; this drives asset routing.
 - `--tags` — discovery tags. Drives `/explore` surfacing. Re-running
   `playbook-draft` with `--tags` replaces the prior set (no merge).
 
 **Required overlap.** Every entity in `--trading-symbols` must appear in
-`--tags` **verbatim, uppercase**, alongside lowercase topical themes.
-Omit the entities and the playbook is invisible to `/explore` searches
-for that asset — asset-routing and discovery read different fields.
+`--tags` **verbatim, uppercase**, alongside lowercase topical themes. Omit the
+entities and the playbook is invisible to `/explore` searches for that asset —
+asset-routing and discovery read different fields.
 
 **Related people.** If the playbook's thesis, screen, or catalyst logic depends
 on named people, include those names in `--tags` using the most recognizable
 public name. Cover investors, company executives / market-famous company
-figures, government-linked officials or policymakers, and Twitter / X KOLs
-whose posts or views materially affect the playbook.
+figures, government-linked officials or policymakers, and Twitter / X KOLs whose
+posts or views materially affect the playbook.
 
 Examples:
 
@@ -48,40 +50,39 @@ Examples:
 
 ## Skill id
 
-`--skill-id` is required whenever a Skillhub skill informed the build —
-i.e. the request carried a `/use-skill:<username>/<name>` directive, or
-the agent ran `alva skillhub get` / `alva skillhub file` during building.
+`--skill-id` is required whenever a Skillhub skill informed the build — i.e. the
+request carried a `/use-skill:<username>/<name>` directive, or the agent ran
+`alva skillhub get` / `alva skillhub file` during building.
 
 ## Agent type
 
-`alva release feed --agent-type <kind>` marks the feed as a prompt-editable
-agent. `<kind>` must be in the catalog (the backend rejects unknown values with
-`InvalidArgument`); `alpi` is the only kind in v1:
+`alva automation publish --agent-type <kind>` marks the feed as a
+prompt-editable agent. `<kind>` must be in the catalog (the backend rejects
+unknown values with `InvalidArgument`); `alpi` is the only kind in v1:
 
-| `agent_type` | Meaning |
-|--------------|---------|
-| `alpi` | `@alva/pi` agent; its script reads & appends the owner's `AGENTS.md` instructions (`${feed.path}/AGENTS.md`) |
-| *(omitted)* | ordinary feed, no editable prompt |
+| `agent_type` | Meaning                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------ |
+| `alpi`       | `@alva/pi` agent; its script reads & appends the owner's `AGENTS.md` instructions (`${feed.path}/AGENTS.md`) |
+| _(omitted)_  | ordinary feed, no editable prompt                                                                            |
 
-The owner edits the feed's `AGENTS.md` (`~/feeds/<name>/v<major>/AGENTS.md`) — no
-redeploy. The path is backend-derived (no `--prompt-path` flag). See
+The owner edits the feed's `AGENTS.md` (`~/feeds/<name>/v<major>/AGENTS.md`) —
+no redeploy. The path is backend-derived (no `--prompt-path` flag). See
 [feed-sdk.md](../feed-sdk.md#user-instructions-agentsmd).
 
 ## Playbook README
 
-Every released playbook ships a README at `~/playbooks/<name>/README.md`.
-This is the canonical specification for what that file must contain. The
-HTML's "How does this work?" / methodology modal renders the same content,
-so there is one source of truth — the README — not a separate per-template
-copy.
+Every released playbook ships a README at `~/playbooks/<name>/README.md`. This
+is the canonical specification for what that file must contain. The HTML's "How
+does this work?" / methodology modal renders the same content, so there is one
+source of truth — the README — not a separate per-template copy.
 
 ### Freshness and version updates
 
 Every `alva release playbook` call needs a freshly reviewed README for the
 version being released. Initial releases, version bumps, and re-releases all
-follow the same rule: regenerate the README from the current HTML, feed
-scripts, feed ids, cron cadences, metadata, and known blind spots, then
-write it again to `~/playbooks/<name>/README.md` before release.
+follow the same rule: regenerate the README from the current HTML, feed scripts,
+feed ids, cron cadences, metadata, and known blind spots, then write it again to
+`~/playbooks/<name>/README.md` before release.
 
 Do not point `--readme-url` at a README copied from a prior version. A README
 may keep the same wording only if you have re-checked it against the current
@@ -90,16 +91,16 @@ implementation and re-written the reviewed file for this release.
 ### Path and `--readme-url` form
 
 The flow is: **first** write the README to ALFS at
-`~/playbooks/<name>/README.md`, **then** pass the **absolute** ALFS path
-as `--readme-url`. The server does not write the file — it only validates
-that the value matches the canonical README location.
+`~/playbooks/<name>/README.md`, **then** pass the **absolute** ALFS path as
+`--readme-url`. The server does not write the file — it only validates that the
+value matches the canonical README location.
 
 `--readme-url` accepts exactly one form:
 
 - `/alva/home/<username>/playbooks/<name>/README.md` — e.g.
-  `/alva/home/alice/playbooks/btc-dashboard/README.md`. Resolve
-  `<username>` once via `alva whoami` and pass the path verbatim
-  (no `~` expansion, no relative shorthand).
+  `/alva/home/alice/playbooks/btc-dashboard/README.md`. Resolve `<username>`
+  once via `alva whoami` and pass the path verbatim (no `~` expansion, no
+  relative shorthand).
 
 The previously-accepted relative form `<name>/README.md` (and any `~/...`
 shorthand) is **no longer accepted**. Any other value is rejected with
@@ -108,72 +109,70 @@ shorthand) is **no longer accepted**. Any other value is rejected with
 ### Content shape
 
 The README is a markdown file. It is a standalone document — not a copy of
-`display_name` or `description`. The reader is someone deciding whether
-to trust this playbook's numbers, not someone browsing for ideas.
+`display_name` or `description`. The reader is someone deciding whether to trust
+this playbook's numbers, not someone browsing for ideas.
 
-Structure: required sections (every playbook), then conditional sections
-keyed to playbook shape (screener / thesis / what-if), then optional
-sections.
+Structure: required sections (every playbook), then conditional sections keyed
+to playbook shape (screener / thesis / what-if), then optional sections.
 
 #### Required (every playbook)
 
-- **One-paragraph overview** — plain English: what the playbook computes,
-  on what universe, the question it answers. Same scope bound as the
-  in-app methodology modal's overview.
-- **Data sources & freshness** — every feed / SDK / BYOD source the
-  playbook reads, with the relevant specifics (symbol, interval, exchange,
-  indicator parameters), plus the cron cadence (in ET) and what "fresh"
-  means for this playbook. Match the sources actually called by the feed
-  scripts and the deployed cronjobs — do not list aspirational sources or
-  cadences the cronjob does not enforce.
+- **One-paragraph overview** — plain English: what the playbook computes, on
+  what universe, the question it answers. Same scope bound as the in-app
+  methodology modal's overview.
+- **Data sources & freshness** — every feed / SDK / BYOD source the playbook
+  reads, with the relevant specifics (symbol, interval, exchange, indicator
+  parameters), plus the cron cadence (in ET) and what "fresh" means for this
+  playbook. Match the sources actually called by the feed scripts and the
+  deployed cronjobs — do not list aspirational sources or cadences the cronjob
+  does not enforce.
 - **Blind spots** — honest list of what this does NOT capture (sample-size
-  caveats, survivorship issues, regime sensitivity, data gaps, anything
-  that would change how a reader weighs the output). If there are none,
-  write "None known" — do not omit the section.
+  caveats, survivorship issues, regime sensitivity, data gaps, anything that
+  would change how a reader weighs the output). If there are none, write "None
+  known" — do not omit the section.
 
 #### Conditional — Screener / filter shape
 
-- **Filter rules** (basket / hard filters) — every threshold, every
-  excluded category. Senate example level of specificity: "excludes ETFs;
-  requires ≥ 2 distinct senators + ≥ $50K total".
-- **Factor weights + scoring formula** (scored only) — factor name, raw
-  measure, normalization, weight. State the formula exactly.
+- **Filter rules** (basket / hard filters) — every threshold, every excluded
+  category. Senate example level of specificity: "excludes ETFs; requires ≥ 2
+  distinct senators + ≥ $50K total".
+- **Factor weights + scoring formula** (scored only) — factor name, raw measure,
+  normalization, weight. State the formula exactly.
 - **Score bands** (scored only) — score ranges → tier label.
-- **Flag definitions** (when flags exist) — for each flag: label, tier,
-  exact threshold.
-- **Worked example** (scored only) — re-derive the current #1 from raw
-  inputs. Header (id + name + rank + band) plus per-factor rows
-  (`name | raw / 100 × weight% = pts`) plus a total. State the actual
-  display relationship: if the displayed score equals the factor-weighted
-  sum, say so; if it is a rescaling (e.g. `45 + 50 * normalized composite`),
-  state that honestly. Don't claim equality you can't deliver.
+- **Flag definitions** (when flags exist) — for each flag: label, tier, exact
+  threshold.
+- **Worked example** (scored only) — re-derive the current #1 from raw inputs.
+  Header (id + name + rank + band) plus per-factor rows
+  (`name | raw / 100 × weight% = pts`) plus a total. State the actual display
+  relationship: if the displayed score equals the factor-weighted sum, say so;
+  if it is a rescaling (e.g. `45 + 50 * normalized composite`), state that
+  honestly. Don't claim equality you can't deliver.
 
 #### Conditional — Thesis shape
 
-- **How this playbook works** — quant + alpi pipelines, post-processing
-  matcher, exact list of inputs fed to the narrative agent.
+- **How this playbook works** — quant + alpi pipelines, post-processing matcher,
+  exact list of inputs fed to the narrative agent.
 - **Thesis pillars** (multi-pillar only) — for each pillar: id, name,
   one-sentence claim, the daily signal that would verify or contradict it.
-- **News matching** — ticker overlap + keyword similarity rules; how
-  unmatched items flow.
-- **TLDR generation** — four-question framework, grounding rule, thrown
-  errors, how `pushLine` is written. Include 1-2 gold few-shot TLDRs
-  (each a `{thesis, pushLine}` pair).
-- **Basket selection** — every name by layer; inclusion criteria;
-  change-log policy. If composite scoring: factor table, composite formula,
-  band thresholds, flag definitions, worked example re-deriving the
-  current #1.
-- **Computation rules** — every derived field: alpha definition, risk
-  priority matrix, delta surfacing rules, etc.
+- **News matching** — ticker overlap + keyword similarity rules; how unmatched
+  items flow.
+- **TLDR generation** — four-question framework, grounding rule, thrown errors,
+  how `pushLine` is written. Include 1-2 gold few-shot TLDRs (each a
+  `{thesis, pushLine}` pair).
+- **Basket selection** — every name by layer; inclusion criteria; change-log
+  policy. If composite scoring: factor table, composite formula, band
+  thresholds, flag definitions, worked example re-deriving the current #1.
+- **Computation rules** — every derived field: alpha definition, risk priority
+  matrix, delta surfacing rules, etc.
 
 #### Conditional — What-if / event-study shape
 
 - **How we picked events** — the trigger definition: exact rule, lookback,
   exclusions.
-- **How we measured returns** — the cutting dimension and the horizon set
-  (e.g. 1W / 1M / 3M / 1Y), aggregation rule (mean / median), benchmark.
-- **References** — links to the source for the trigger and the source for
-  the return measurement.
+- **How we measured returns** — the cutting dimension and the horizon set (e.g.
+  1W / 1M / 3M / 1Y), aggregation rule (mean / median), benchmark.
+- **References** — links to the source for the trigger and the source for the
+  return measurement.
 
 #### Optional
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -5,13 +5,13 @@ downstream feed / playbook resources they produce. This is essential for feeds
 that need regular updates (e.g. hourly price data), recurring tasks, and for
 cleaning up when a deployment is retired or replaced.
 
-The three lifecycle CLI groups:
+The product-facing lifecycle CLI groups:
 
-| Group           | Manages                              | Common commands                  |
-| --------------- | ------------------------------------ | -------------------------------- |
-| `alva deploy`   | Cronjobs (schedule + entry script)   | `create`, `list`, `update`, `delete`, `runs` |
-| `alva feed`     | Released feed records + active majors | `list`, `delete`                |
-| `alva playbook` | Published playbook records           | `list`, `delete`                 |
+| Group             | Manages                                      | Common commands                              |
+| ----------------- | -------------------------------------------- | -------------------------------------------- |
+| `alva deploy`     | Cronjobs (schedule + entry script)           | `create`, `list`, `update`, `delete`, `runs` |
+| `alva automation` | Published automation records + active majors | `publish`, `list`, `delete`                  |
+| `alva playbook`   | Published playbook records                   | `list`, `delete`                             |
 
 ---
 
@@ -26,8 +26,8 @@ The deployment workflow:
 5. **Monitor** the cronjob status via `alva deploy list` / `alva deploy get`
 6. **Debug** execution history via `alva deploy runs` / `alva deploy run-logs`
 
-Cronjobs execute the script through the same jagent runtime as `alva run`.
-The script receives the same environment (`require("env").args` contains the
+Cronjobs execute the script through the same jagent runtime as `alva run`. The
+script receives the same environment (`require("env").args` contains the
 cronjob's args).
 
 ---
@@ -42,23 +42,23 @@ All cronjob operations use `alva deploy <subcommand>`.
 alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *" --args '{"symbol": "BTC"}' --push-notify
 ```
 
-| Flag            | Type   | Required | Description                                            |
-| --------------- | ------ | -------- | ------------------------------------------------------ |
-| --path          | string | yes      | Path to entry script (home-relative or absolute)       |
-| --cron          | string | yes      | Standard cron expression                               |
-| --name          | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
-| --args          | JSON   | no       | JSON passed to `require("env").args` on each execution |
-| --push-notify   | flag   | no       | Let this cronjob emit feed alert events after successful feed runs |
+| Flag          | Type   | Required | Description                                                                   |
+| ------------- | ------ | -------- | ----------------------------------------------------------------------------- |
+| --path        | string | yes      | Path to entry script (home-relative or absolute)                              |
+| --cron        | string | yes      | Standard cron expression                                                      |
+| --name        | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
+| --args        | JSON   | no       | JSON passed to `require("env").args` on each execution                        |
+| --push-notify | flag   | no       | Let this cronjob emit feed alert events after successful feed runs            |
 
 When `--push-notify` is set, every successful cronjob execution checks the
 feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
 canonical `feed_alert_ready` event with different feed-alert sources. The push
-body is read from the *released* feed: a cronjob with `--push-notify` but no
-`alva release feed` dispatches an empty body. Delivery also requires an
-explicit personal or group subscription to the feed or to a playbook that
-references the feed; `--push-notify` does not subscribe the owner, any user, or
-any group. For `notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text`
-skips the user-visible push while advancing fanout.
+body is read from the _published_ automation: a cronjob with `--push-notify` but
+no `alva automation publish` dispatches an empty body. Delivery also requires an
+explicit personal alert or group subscription to the automation or to a playbook
+that references the feed; `--push-notify` does not subscribe the owner, any
+user, or any group. For `notify/message`, `<|SKIP_NOTIFICATION|>` in
+`body`/`text` skips the user-visible push while advancing fanout.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.
@@ -104,7 +104,8 @@ Partial update -- only include flags you want to change.
 alva deploy update --id 42 --cron "0 */2 * * *" --args '{"symbol":"ETH"}'
 ```
 
-Updatable fields: `--name`, `--cron`, `--args`, `--push-notify` / `--no-push-notify`.
+Updatable fields: `--name`, `--cron`, `--args`, `--push-notify` /
+`--no-push-notify`.
 
 ### Delete Cronjob
 
@@ -123,9 +124,9 @@ Both return the updated cronjob object.
 
 ### Trigger an Out-of-Schedule Run
 
-Fire the cronjob once, immediately. Returns the Hatchet workflow run id
-at enqueue — async; the `cronjob_runs` row appears only after the worker
-finishes the run.
+Fire the cronjob once, immediately. Returns the Hatchet workflow run id at
+enqueue — async; the `cronjob_runs` row appears only after the worker finishes
+the run.
 
 ```bash
 alva deploy trigger --id 42
@@ -143,13 +144,13 @@ done
 echo "$ROW" | jq '{id, status, error}'
 ```
 
-Use *after* deploy to confirm the full cronjob path is wired correctly.
-For iterating on script logic without Hatchet, use `alva run` instead.
+Use _after_ deploy to confirm the full cronjob path is wired correctly. For
+iterating on script logic without Hatchet, use `alva run` instead.
 
 ### Debugging Runs
 
-When a cronjob fails or produces unexpected output, use `runs` and `run-logs`
-to diagnose the problem.
+When a cronjob fails or produces unexpected output, use `runs` and `run-logs` to
+diagnose the problem.
 
 **List run history** — shows each execution's status, duration, and error
 message. The response also includes aggregate stats (total/success/fail counts).
@@ -168,45 +169,44 @@ alva deploy run-logs --id 42 --run-id 123
 
 ---
 
-## Feed / Playbook lifecycle — extras not in CLI help
+## Automation / Playbook Lifecycle — Extras Not In CLI Help
 
-Run `alva feed --help` and `alva playbook --help` for subcommands,
-flags, and response shapes. This section only covers the conceptual
-boundaries and the deletion gotcha — the help text is authoritative
-on flags.
+Run `alva automation --help` and `alva playbook --help` for subcommands, flags,
+and response shapes. This section only covers the conceptual boundaries and the
+deletion gotcha — the help text is authoritative on flags.
 
 **What each group manages.**
 
-- `alva deploy` — the **cronjob** (schedule + entry script + args). Lives
-  in the `cronjobs` table.
-- `alva feed` — the **released feed record + active majors** (the row
-  written by `alva release feed`, consumed by the push-fanout path).
+- `alva deploy` — the **cronjob** (schedule + entry script + args). Lives in the
+  `cronjobs` table.
+- `alva automation` — the **published automation record + active majors** (the
+  row written by `alva automation publish`, consumed by the push-fanout path).
   Lives in `feeds` / `feed_majors`.
-- `alva playbook` — the **published playbook** (rendered HTML +
-  display_name + visibility + ACL). Lives in `playbooks` and is
-  surfaced at `https://alva.ai/u/<username>/playbooks/<name>`.
+- `alva playbook` — the **published playbook** (rendered HTML + display_name +
+  visibility + ACL). Lives in `playbooks` and is surfaced at
+  `https://alva.ai/u/<username>/playbooks/<name>`.
 
 These three move in lockstep at create time (`alva deploy create` →
-`alva release feed` → `alva release playbook`) but each has its own
-lifecycle row. Deleting one does **not** automatically delete the
-others — see the cascade notes in each `--help`.
+`alva automation publish` → `alva release playbook`) but each has its own
+lifecycle row. Deleting one does **not** automatically delete the others — see
+the cascade notes in each `--help`.
 
-`alva release feed` also accepts `--agent-type alpi` to mark a feed whose
+`alva automation publish` also accepts `--agent-type alpi` to mark a feed whose
 alpi agent appends the owner's editable `AGENTS.md` instructions — see
 [api/release.md](api/release.md#agent-type).
 
-**Don't use `alva fs remove` to delete a feed or playbook.** It clears
-the ALFS files (the rendered HTML, the data mount), but the
-`playbooks` / `feeds` DB row stays alive. The platform still:
+**Don't use `alva fs remove` to delete a feed or playbook.** It clears the ALFS
+files (the rendered HTML, the data mount), but the `playbooks` / `feeds` DB row
+stays alive. The platform still:
 
 - counts the playbook against the free-tier 1-playbook cap
 - serves the (now empty) public URL with stale metadata
 - fires push fanout for the (now empty) feed
 
-The cap-gate symptom is "the platform still has a playbook record for
-me even after I cleaned the ALFS files". The fix is `alva playbook
-delete --name <X>` (or `alva feed delete --id <X>`), which
-soft-deletes the DB row and frees the quota / ACL immediately.
+The cap-gate symptom is "the platform still has a playbook record for me even
+after I cleaned the ALFS files". The fix is `alva playbook delete --name <X>`
+(or `alva automation delete --id <X>`), which soft-deletes the DB row and frees
+the quota / ACL immediately.
 
 ---
 
@@ -249,11 +249,11 @@ The script has full access to:
 
 ## Limits
 
-| Limit                 | Value                 |
-| --------------------- | --------------------- |
-| Min cron interval     | 1 minute              |
-| Execution timeout     | Same as `alva run`    |
-| Heap per execution    | 2 GB                  |
+| Limit              | Value              |
+| ------------------ | ------------------ |
+| Min cron interval  | 1 minute           |
+| Execution timeout  | Same as `alva run` |
+| Heap per execution | 2 GB               |
 
 ---
 
@@ -284,7 +284,11 @@ const feed = new Feed({ path: feedPath("btc-hourly") });
 
 feed.def("market", {
   ohlcv: makeDoc("BTC OHLCV", "Hourly BTC price data", [
-    num("open"), num("high"), num("low"), num("close"), num("volume"),
+    num("open"),
+    num("high"),
+    num("low"),
+    num("close"),
+    num("volume"),
   ]),
 });
 
@@ -303,12 +307,20 @@ feed.def("market", {
       interval: "1h",
     });
 
-    if (!result.success) throw new Error("Failed to fetch: " + JSON.stringify(result));
+    if (!result.success)
+      throw new Error("Failed to fetch: " + JSON.stringify(result));
 
-    const records = result.response.data.slice().reverse().map(b => ({
-      date: b.date,
-      open: b.open, high: b.high, low: b.low, close: b.close, volume: b.volume,
-    }));
+    const records = result.response.data
+      .slice()
+      .reverse()
+      .map((b) => ({
+        date: b.date,
+        open: b.open,
+        high: b.high,
+        low: b.low,
+        close: b.close,
+        volume: b.volume,
+      }));
 
     if (records.length > 0) {
       await ctx.self.ts("market", "ohlcv").append(records);
@@ -355,12 +367,12 @@ alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@las
 - **Use `ctx.kv` for incremental processing**: Track the last processed
   timestamp with `ctx.kv.put()`/`ctx.kv.load()` to avoid re-fetching all
   historical data on each run.
-- **Test thoroughly before deploying**: Run the script manually via
-  `alva run` and verify the output before creating a cronjob.
+- **Test thoroughly before deploying**: Run the script manually via `alva run`
+  and verify the output before creating a cronjob.
 - **Use descriptive names**: The cronjob name helps you identify jobs when
   listing them.
 - **Pause before updating**: If you need to update the script, pause the cronjob
   first, update the script file, test it, then resume.
 - **Debug failed runs**: `alva deploy runs --id <id>` shows execution history
-  and stats; `alva deploy run-logs --id <id> --run-id <rid>` shows the full
-  log output from a specific run.
+  and stats; `alva deploy run-logs --id <id> --run-id <rid>` shows the full log
+  output from a specific run.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -18,7 +18,8 @@ Every feed follows the same path:
 4. Grant the feed root for public reads when a playbook or public user needs it:
    `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
 5. Deploy the script with `alva deploy create`.
-6. Release the feed with `alva release feed` using the cronjob id from deploy.
+6. Publish the automation with `alva automation publish` using the cronjob id
+   from deploy.
 
 `alva run` is a test step. It does not replace deploy or release and does not
 guarantee public `@last` data for a playbook.
@@ -53,13 +54,13 @@ if (!equityRecords.length) {
 }
 ```
 
-If a run fails with out-of-memory, retry with a larger `--max-heap-size-mb`
-(up to 2048) before editing logic.
+If a run fails with out-of-memory, retry with a larger `--max-heap-size-mb` (up
+to 2048) before editing logic.
 
-## HARD-GATE: before-feed-release
+## HARD-GATE: before-automation-publish
 
-<HARD-GATE id="before-feed-release">
-Before `alva release feed`, verify:
+<HARD-GATE id="before-automation-publish">
+Before `alva automation publish`, verify:
 
 1. The exact feed script ran successfully in this session after the latest
    source write.
@@ -71,7 +72,7 @@ Before `alva release feed`, verify:
 6. If the feed backs HTML, at least one public `@last` path the HTML reads has
    non-empty data after grant.
 
-If any evidence is missing or stale, do not release. Fix the feed, rerun, and
+If any evidence is missing or stale, do not publish. Fix the feed, rerun, and
 re-enter the gate.
 </HARD-GATE>
 
@@ -79,9 +80,9 @@ re-enter the gate.
 
 Push-capable feeds write one of these streams:
 
-| Output stream | Use |
-| --- | --- |
-| `signal/targets` | Playbook signals, trading targets, actionable alerts. |
+| Output stream    | Use                                                                |
+| ---------------- | ------------------------------------------------------------------ |
+| `signal/targets` | Playbook signals, trading targets, actionable alerts.              |
 | `notify/message` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts. |
 
 Both dispatch `feed_alert_ready`. Do not use legacy names such as
@@ -92,5 +93,5 @@ does not subscribe any user or group and does not bypass notification
 preferences. For `notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
 without sending a visible push.
 
-See [push-notifications.md](push-notifications.md) for the subscription and
-verification workflow.
+See [push-notifications.md](push-notifications.md) for the personal alert,
+group subscription, and verification workflow.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -164,38 +164,53 @@ Read `@last/N` (where N >= batch size) to get the most recent batch.
 
 ### Pattern D: Signal / Playbook Push Notification
 
-For feeds that produce actionable signals worth pushing to users or groups
-that explicitly subscribed to the feed, or to a playbook that references the
-feed. Write signal records to the **`signal`** group with a **`targets`**
-output -- the resulting path
-`~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
-when dispatching the canonical `feed_alert_ready` notification event.
+For feeds that produce actionable signals worth pushing to users with alerts or
+groups subscribed to the feed, or to a playbook that references the feed.
+Write signal records to the **`signal`** group with a **`targets`** output --
+the resulting path `~/feeds/{name}/v{major}/data/signal/targets` is one source
+the platform reads when dispatching the canonical `feed_alert_ready`
+notification event.
 
 The target format follows the same structure used by Altra trading strategies:
 
 ```javascript
-const { Feed, feedPath, makeDoc, str, num, obj, arr, fld } = require("@alva/feed");
+const {
+  Feed,
+  feedPath,
+  makeDoc,
+  str,
+  num,
+  obj,
+  arr,
+  fld,
+} = require("@alva/feed");
 
 const feed = new Feed({ path: feedPath("my-signal") });
 
 feed.def("signal", {
-  targets: makeDoc("Signal Targets", "Actionable signals for playbook notifications", [
-    obj("instruction", [
-      str("type"),       // "allocate" | "orders"
-      arr("weights", [   // for type: "allocate"
-        str("symbol"),
-        num("weight"),
+  targets: makeDoc(
+    "Signal Targets",
+    "Actionable signals for playbook notifications",
+    [
+      obj("instruction", [
+        str("type"), // "allocate" | "orders"
+        arr("weights", [
+          // for type: "allocate"
+          str("symbol"),
+          num("weight"),
+        ]),
+        arr("orders", [
+          // for type: "orders"
+          str("symbol"),
+          str("side"), // "buy" | "sell"
+          fld("amount", "object"),
+        ]),
       ]),
-      arr("orders", [    // for type: "orders"
-        str("symbol"),
-        str("side"),     // "buy" | "sell"
-        fld("amount", "object"),
+      obj("meta", [
+        str("reason"), // Markdown push-notification body
       ]),
-    ]),
-    obj("meta", [
-      str("reason"),     // Markdown push-notification body
-    ]),
-  ]),
+    ],
+  ),
 });
 
 await feed.run(async (ctx) => {
@@ -219,33 +234,33 @@ await feed.run(async (ctx) => {
 
 When this feed runs as a cronjob with `--push-notify`, the platform reads
 `/data/signal/targets` and dispatches the signal content as `feed_alert_ready`
-to eligible feed/playbook notification subscriptions. Telegram delivery chunks
-long messages at the platform's per-message limit; the feed SDK does not
-require a 500-character summary.
+to eligible automation/playbook alerts and group subscriptions. Telegram
+delivery chunks long messages at the platform's per-message limit; the feed SDK
+does not require a 500-character summary.
 
 **Key points:**
 
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
-- `--push-notify` and `alva release feed --cronjob-id ...` only make the feed
-  publisher capable of emitting alerts. They do **not** subscribe any user or
-  group.
-- Real delivery requires an explicit subscription: personal
-  `alva subscriptions subscribe-feed` / `subscribe-playbook`, group
-  `/alva subscribe feed <id>` / `/alva subscribe playbook <id>`, or — from
-  inside a playbook iframe — a parent-confirmed `window.alva.subscribe.propose()`
-  (see `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook
-  must never call a subscribe API directly.
+- `--push-notify` and `alva automation publish --cronjob-id ...` only make the
+  feed publisher capable of emitting alerts. They do **not** subscribe any user
+  or group.
+- Real delivery requires an explicit alert/subscription: personal
+  `alva alert enable --automation <owner>/<feed>` /
+  `--playbook <owner>/<playbook>`, group `/alva subscribe feed <id>` /
+  `/alva subscribe playbook <id>`, or — from inside a playbook iframe — a
+  parent-confirmed `window.alva.subscribe.propose()` (see
+  `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
+  never call a subscribe API directly.
 - Use `meta.reason` to provide the push-notification body -- this is what
   recipients see when the signal is delivered.
 - `meta.reason` is **Markdown**. Write it as the push body itself, using
-  Markdown for emphasis, lists, and links; the platform renders Markdown on
-  the delivery side (Telegram, in-app surfaces). Keep it short and
-  push-friendly -- headings and heavy formatting don't translate well to a
-  notification.
+  Markdown for emphasis, lists, and links; the platform renders Markdown on the
+  delivery side (Telegram, in-app surfaces). Keep it short and push-friendly --
+  headings and heavy formatting don't translate well to a notification.
 - Keep `meta.reason` close to the user-facing feed output when the feed is
-  notification-native. Use a push-safe projection only when a channel has a
-  real hard limit or cannot render the feed's richer format.
+  notification-native. Use a push-safe projection only when a channel has a real
+  hard limit or cannot render the feed's richer format.
 - One record per run is typical; the platform reads `@last/1`.
 - Altra strategies write to this path automatically. Use this pattern only for
   non-Altra feeds that want to produce push-worthy signals.
@@ -262,9 +277,9 @@ as a feed completion notification. Common use cases: scheduled market reports,
 periodic research summaries, heartbeat monitoring, and proactive alerts.
 
 Write the agent's response to the **`notify`** group with a **`message`**
-output. When the cronjob completes with `--push-notify`, the platform reads
-this path and dispatches `feed_alert_ready` to users or groups that explicitly
-subscribed to the feed, or to a playbook that references the feed.
+output. When the cronjob completes with `--push-notify`, the platform reads this
+path and dispatches `feed_alert_ready` to users with alerts or groups subscribed
+to the feed, or to a playbook that references the feed.
 
 ```javascript
 const { ask } = require("@alva/alvaask");
@@ -303,9 +318,9 @@ alva deploy create --name daily-briefing \
   --path '~/feeds/daily-briefing/v1/src/index.js' \
   --cron "0 8 * * *" --push-notify
 
-# 2. Register the feed (REQUIRED for push content to work)
+# 2. Publish the automation (REQUIRED for push content to work)
 # Without this, notifications arrive without title/text content.
-alva release feed --name daily-briefing --version 1.0.0 \
+alva automation publish --name daily-briefing --version 1.0.0 \
   --cronjob-id <ID_FROM_STEP_1> \
   --description "Generates a morning briefing each day at 08:00 summarizing overnight crypto market moves and pushes it as a notification"
 ```
@@ -316,25 +331,24 @@ alva release feed --name daily-briefing --version 1.0.0 \
   `message` — this is the path the notification system looks for.
 - `title` is optional — if provided, the notification renders as
   `**title**\n\nbody`.
-- `body` is the notification body (required for content push). The
-  legacy field name `text` is still accepted for backwards compatibility,
-  but `body` is the canonical name and matches FCM / APNS / Web Push
-  / HTTP / email convention — prefer `body` in new feeds. If both
-  `body` and `text` are set on the same record, `body` wins.
+- `body` is the notification body (required for content push). The legacy field
+  name `text` is still accepted for backwards compatibility, but `body` is the
+  canonical name and matches FCM / APNS / Web Push / HTTP / email convention —
+  prefer `body` in new feeds. If both `body` and `text` are set on the same
+  record, `body` wins.
 - If `body`/`text` contains `<|SKIP_NOTIFICATION|>`, fanout state advances but
   no user-visible notification is sent. Teach AlvaAsk to output this sentinel
   when there is no material update.
-- **`alva release feed` is required** — without it, the push is still
+- **`alva automation publish` is required** — without it, the push is still
   dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
-  personal or group subscriptions.
-- Real delivery requires an explicit subscription: personal
-  `alva subscriptions subscribe-feed --username <owner> --name <feed>`
-  or `subscribe-playbook`, or group `/alva subscribe feed <feed_id>` /
-  `/alva subscribe playbook <playbook_id>`. For inventory and
-  unsubscribe (including ghost rows of deleted targets), see
-  [push-notifications.md](push-notifications.md) § Inventory And
-  Unsubscribe.
+  personal alerts or group subscriptions.
+- Real delivery requires an explicit alert/subscription: personal
+  `alva alert enable --automation <owner>/<feed>` or
+  `alva alert enable --playbook <owner>/<playbook>`, or group
+  `/alva subscribe feed <feed_id>` / `/alva subscribe playbook <playbook_id>`.
+  For inventory and unsubscribe (including ghost rows of deleted targets), see
+  [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and
   signal-style notifications.
 
@@ -435,8 +449,8 @@ feed.path; // "/alva/home/alice/feeds/btc-ema/v1"
 
 Read the feed owner's **user instructions** from the feed's `AGENTS.md` —
 `${feed.path}/AGENTS.md`, e.g. `~/feeds/market-pulse/v1/AGENTS.md`. It is
-editable only on feeds released with an `agent_type` (`--agent-type alpi`).
-Read it yourself via `alfs`; a missing file is not an error — treat it as empty.
+editable only on feeds released with an `agent_type` (`--agent-type alpi`). Read
+it yourself via `alfs`; a missing file is not an error — treat it as empty.
 
 **Append the user instructions to your base prompt; never let them replace it.**
 Keep your real instructions in `BASE_PROMPT`:
@@ -456,8 +470,8 @@ const systemPrompt = userInstructions
 ```
 
 The owner edits `AGENTS.md` (plain-text instructions); the next run picks it up,
-no redeploy. Read it yourself and append — a missing/empty file then *extends*
-nothing rather than *replacing* your base instructions.
+no redeploy. Read it yourself and append — a missing/empty file then _extends_
+nothing rather than _replacing_ your base instructions.
 
 ---
 
@@ -678,32 +692,32 @@ const points = JSON.parse(data);
 ```html
 <script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>
 <script>
-function createAlvaClientConfig() {
-  const params = new URLSearchParams(window.location.search);
-  const pbsvToken = window.alva?.udf?.getViewerToken?.();
-  const apiOrigin = params.get("api_origin");
-  return {
-    ...(pbsvToken ? { pbsvToken } : {}),
-    ...(apiOrigin ? { baseUrl: apiOrigin.replace(/\/$/, "") } : {}),
-  };
-}
+  function createAlvaClientConfig() {
+    const params = new URLSearchParams(window.location.search);
+    const pbsvToken = window.alva?.udf?.getViewerToken?.();
+    const apiOrigin = params.get("api_origin");
+    return {
+      ...(pbsvToken ? { pbsvToken } : {}),
+      ...(apiOrigin ? { baseUrl: apiOrigin.replace(/\/$/, "") } : {}),
+    };
+  }
 
-function createAlvaClient() {
-  return new AlvaToolkit.AlvaClient(createAlvaClientConfig());
-}
+  function createAlvaClient() {
+    return new AlvaToolkit.AlvaClient(createAlvaClientConfig());
+  }
 
-const points = await createAlvaClient().fs.read({
-  path: "/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/720",
-});
-// points = [{date: 1772658000000, close: 73309.72, ema10: 72447.65}, ...]
+  const points = await createAlvaClient().fs.read({
+    path: "/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/720",
+  });
+  // points = [{date: 1772658000000, close: 73309.72, ema10: 72447.65}, ...]
 </script>
 ```
 
 Use `createAlvaClient().fs.read(...)` (the SDK), not a raw `fetch`: it carries
 the viewer's PBSV token, so the page reads its feed data whether the playbook is
 public or private. An unauthenticated `fetch` to `/api/v1/fs/read` is a
-public-only fallback that breaks when the playbook is set private. See
-SKILL.md §6.
+public-only fallback that breaks when the playbook is set private. See SKILL.md
+§6.
 
 ---
 
@@ -801,7 +815,9 @@ const bars = getCryptoKline({
   start_time: now - 30 * 86400,
   end_time: now,
   interval: "1h",
-}).response.data.slice().reverse();
+})
+  .response.data.slice()
+  .reverse();
 
 const closes = bars.map((b) => b.close);
 const ema10 = indicators.ema(closes, { period: 10 });
@@ -866,8 +882,9 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 - **Re-appending overwrites**. Appending a record with an existing timestamp
   replaces the old value (`ON CONFLICT DO UPDATE`). Use this for cross-run
   accumulation: read existing + merge + re-append.
-- **`feedPath()` requires `env.username`**. It reads from `require("env").username`
-  internally, which is available in the jagent runtime.
+- **`feedPath()` requires `env.username`**. It reads from
+  `require("env").username` internally, which is available in the jagent
+  runtime.
 - **Top-level `await` is not supported**. Wrap feed logic in
   `(async () => { ... })();`.
 - **`@last` returns chronological (oldest-first) order**, consistent with
@@ -877,8 +894,8 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 
 ## Resetting Feed Data
 
-During development, clear stale data via the CLI. **This is for development
-only -- do not use in production.**
+During development, clear stale data via the CLI. **This is for development only
+-- do not use in production.**
 
 ```bash
 # Clear a specific time series output (e.g. market/ohlcv)

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -3,7 +3,7 @@
 This is the concrete task guide for building, drafting, releasing, verifying,
 and updating Alva playbooks. Read it for hosted app/share URL, screener app,
 report surface, strategy UI, remix, annotation edit, release, version update,
-and playbook subscription tasks.
+and playbook alert/group-subscription tasks.
 
 The playbook tree has subroutes: new build, Skillhub-guided build, remix,
 annotation/edit, release/version update, and push after release. Use this guide
@@ -17,12 +17,13 @@ surface; ordinary financial-analysis questions should answer directly.
 2. Verify data coverage with [data-skills.md](data-skills.md) or BYOD.
 3. Build feeds through [feed-lifecycle.md](feed-lifecycle.md).
 4. Read [design.md](design.md), then the relevant design companion:
-   [design-widgets.md](design-widgets.md), [design-components.md](design-components.md),
-   or [design-playbook-trading-strategy.md](design-playbook-trading-strategy.md).
+   [design-widgets.md](design-widgets.md),
+   [design-components.md](design-components.md), or
+   [design-playbook-trading-strategy.md](design-playbook-trading-strategy.md).
 5. Build HTML that reads feed outputs at runtime.
 6. Write HTML and README to ALFS.
-7. Draft, lint, publish, then screenshot the deployed `published_url` unless
-   the user explicitly asks to stop at draft/private.
+7. Draft, lint, publish, then screenshot the deployed `published_url` unless the
+   user explicitly asks to stop at draft/private.
 8. Evaluate push setup with [push-notifications.md](push-notifications.md).
 
 ## HARD-GATE: before-build-html
@@ -32,16 +33,16 @@ Before writing or rewriting playbook HTML, verify:
 
 - [design.md](design.md) has been read first.
 - The needed companion design reference has been read.
-- If a `/use-skill:` blueprint is active, its layout and data contract have
-  been read.
+- If a `/use-skill:` blueprint is active, its layout and data contract have been
+  read.
 - [content-legitimacy.md](content-legitimacy.md) has been applied.
 - The HTML follows the Browser request rule below for every Alva data request,
   including cloned blueprints, templates, and existing HTML.
 - The iframe HTML starts with useful playbook content by default, not a second
-  title/header area. The hosted shell already renders playbook-level chrome;
-  see [design.md#hosted-shell-boundary](design.md#hosted-shell-boundary).
-  Add custom in-iframe chrome only when the user explicitly asks for it or the
-  blueprint requires a distinct app-level header.
+  title/header area. The hosted shell already renders playbook-level chrome; see
+  [design.md#hosted-shell-boundary](design.md#hosted-shell-boundary). Add custom
+  in-iframe chrome only when the user explicitly asks for it or the blueprint
+  requires a distinct app-level header.
 
 Do not rely on memory of prior sessions.
 </HARD-GATE>
@@ -49,48 +50,48 @@ Do not rely on memory of prior sessions.
 ## Browser-Safe Feed Reads
 
 Published HTML runs in the viewer's browser. It must not use `$ALVA_ENDPOINT`,
-hard-coded API origins, raw browser `fetch()` calls to Alva APIs, or hand-written
-auth headers for feed data. Load the browser SDK and use
+hard-coded API origins, raw browser `fetch()` calls to Alva APIs, or
+hand-written auth headers for feed data. Load the browser SDK and use
 `AlvaToolkit.AlvaClient`:
 
 ```html
 <script src="https://unpkg.com/@alva-ai/toolkit/dist/browser.global.js"></script>
 <script>
-function createAlvaClientConfig() {
-  const params = new URLSearchParams(window.location.search);
-  const pbsvToken = window.alva?.udf?.getViewerToken?.();
-  const apiOrigin = params.get("api_origin");
-  return {
-    ...(pbsvToken ? { pbsvToken } : {}),
-    ...(apiOrigin ? { baseUrl: apiOrigin.replace(/\/$/, "") } : {}),
-  };
-}
+  function createAlvaClientConfig() {
+    const params = new URLSearchParams(window.location.search);
+    const pbsvToken = window.alva?.udf?.getViewerToken?.();
+    const apiOrigin = params.get("api_origin");
+    return {
+      ...(pbsvToken ? { pbsvToken } : {}),
+      ...(apiOrigin ? { baseUrl: apiOrigin.replace(/\/$/, "") } : {}),
+    };
+  }
 
-function createAlvaClient() {
-  return new AlvaToolkit.AlvaClient(createAlvaClientConfig());
-}
+  function createAlvaClient() {
+    return new AlvaToolkit.AlvaClient(createAlvaClientConfig());
+  }
 
-async function readAlfsJson(path) {
-  return createAlvaClient().fs.read({ path });
-}
+  async function readAlfsJson(path) {
+    return createAlvaClient().fs.read({ path });
+  }
 </script>
 ```
 
 All quantitative data in charts, tables, and metric cards must be fetched from
 feed output paths at runtime, not embedded as inline literals.
 
-Browser request rule: generated playbook HTML uses `AlvaToolkit.AlvaClient`
-SDK resource methods or `_request(...)` for Alva API requests. Initialize the
-client immediately before each request so refreshed PBSV is included, pass
-`api_origin` as `baseUrl` when present, and never pass `parent_origin` to
-`AlvaClient`. This single path works for public and private playbooks; an
-anonymous `/api/v1/fs/read` fetch is public-only and breaks after private
-visibility changes.
+Browser request rule: generated playbook HTML uses `AlvaToolkit.AlvaClient` SDK
+resource methods or `_request(...)` for Alva API requests. Initialize the client
+immediately before each request so refreshed PBSV is included, pass `api_origin`
+as `baseUrl` when present, and never pass `parent_origin` to `AlvaClient`. This
+single path works for public and private playbooks; an anonymous
+`/api/v1/fs/read` fetch is public-only and breaks after private visibility
+changes.
 
 ## UDFs
 
-User-Defined Functions are strict opt-in. Use them only when the user asks for
-a registerable/shareable interactive function such as "register a UDF", "let
+User-Defined Functions are strict opt-in. Use them only when the user asks for a
+registerable/shareable interactive function such as "register a UDF", "let
 viewers run this function", or "add a button that calls my analysis function".
 Do not introduce UDFs for ordinary dashboards, scheduled refresh, filters, or
 feed-backed charts.
@@ -111,14 +112,15 @@ surface. For every release, version bump, or rerelease, regenerate it from the
 current HTML, feeds, metadata, and blind spots, then write it to ALFS again
 before release. Do not reuse a prior-version README.
 
-The canonical content shape lives in [api/release.md](api/release.md#playbook-readme).
+The canonical content shape lives in
+[api/release.md](api/release.md#playbook-readme).
 
 ## Draft
 
 Before `alva release playbook-draft`, write:
 
-Use ALFS-native write/edit tools when available. The `--file` examples below
-are for shell-only CLI sessions; in PI/jagent agent tool mode, write the same
+Use ALFS-native write/edit tools when available. The `--file` examples below are
+for shell-only CLI sessions; in PI/jagent agent tool mode, write the same
 content directly to the target ALFS paths.
 
 ```bash
@@ -132,7 +134,7 @@ Before `alva release playbook-draft`, verify:
 - HTML exists at `~/playbooks/{name}/index.html`.
 - README exists at `~/playbooks/{name}/README.md`.
 - Target name and owner namespace match `alva whoami`.
-- Every feed in `--feeds` has passed `before-feed-release`.
+- Every feed in `--feeds` has passed `before-automation-publish`.
 - Draft metadata matches the approved plan.
 - `--tags` includes required asset overlap plus material related people:
   investors, company figures, officials/policymakers, Twitter/X KOLs.
@@ -168,7 +170,7 @@ alva release playbook ... \
 <HARD-GATE id="before-playbook-release">
 Before `alva release playbook`, verify:
 
-1. Every backing feed passed `before-feed-release`.
+1. Every backing feed passed `before-automation-publish`.
 2. Every feed the HTML reads at runtime has a successful deploy and appears in
    `--feeds`.
 3. Cronjobs for referenced feeds are active.
@@ -182,10 +184,10 @@ Before `alva release playbook`, verify:
    cronjobs.
 8. Target user namespace is correct.
 9. README exists, is current, and is passed via absolute `--readme-url`.
-10. Push-only feeds with `push_notify: true` have a current `alva release feed`
-    after the push sidecar was added.
-11. `alva lint playbook ./index.html` passes, or an intentional
-    `--bypass-lint` is documented.
+10. Push-only feeds with `push_notify: true` have a current
+    `alva automation publish` after the push sidecar was added.
+11. `alva lint playbook ./index.html` passes, or an intentional `--bypass-lint`
+    is documented.
 12. Header duplication has been reviewed. If the iframe repeats the outer
     playbook title, description, last-updated text, automation controls, or
     share/open controls, confirm that the user explicitly requested custom
@@ -210,10 +212,10 @@ If compressed capture fails with HTTP 500/403, `SCREENSHOT_FAILED`, or no file,
 retry once without compression.
 
 A PNG or page shell is not enough. Pass screenshot verification only when the
-image or targeted capture shows real feed-backed chart marks, table rows, or
-KPI values. Blank frames, headers-only tables, loading/error fallbacks, and
-fetch failures are data-rendering failures that must be fixed before claiming
-the playbook is done.
+image or targeted capture shows real feed-backed chart marks, table rows, or KPI
+values. Blank frames, headers-only tables, loading/error fallbacks, and fetch
+failures are data-rendering failures that must be fixed before claiming the
+playbook is done.
 
 ## Tier Flow
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -5,15 +5,15 @@ goal is a recurring digest, threshold tracker, stream watch, or alert.
 
 ## Identify Push-Worthy Feeds
 
-Recommend push when a feed produces actionable or time-sensitive content:
-price signals, crossovers, breakouts, anomaly alerts, trading instructions, or
+Recommend push when a feed produces actionable or time-sensitive content: price
+signals, crossovers, breakouts, anomaly alerts, trading instructions, or
 periodic research summaries.
 
 Skip static fundamentals, historical snapshots, and low-frequency reference
 data.
 
-For heartbeat/watchlist/monitor feeds, recommend quiet behavior: notify only
-on material changes and emit `<|SKIP_NOTIFICATION|>` otherwise.
+For heartbeat/watchlist/monitor feeds, recommend quiet behavior: notify only on
+material changes and emit `<|SKIP_NOTIFICATION|>` otherwise.
 
 ## Delivery Channel
 
@@ -33,36 +33,34 @@ A push is set up only after all of these succeed:
    - `notify/message` for feed completion, AlvaAsk reports, heartbeat checks,
      and proactive alerts.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
-   `before-feed-release`.
+   `before-automation-publish`.
 3. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-4. Subscribe the target:
-   `alva subscriptions subscribe-feed --username <owner> --name <feed>`
-   or
-   `alva subscriptions subscribe-playbook --username <owner> --name <playbook>`.
-   For groups, use `/alva subscribe feed <id>` or
-   `/alva subscribe playbook <id>` in the group.
+4. Enable the personal alert: `alva alert enable --automation <owner>/<feed>` or
+   `alva alert enable --playbook <owner>/<playbook>`. For groups, use
+   `/alva subscribe feed <id>` or `/alva subscribe playbook <id>` in the group.
 5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
    the record is fresh and the message is non-empty or contains
    `<|SKIP_NOTIFICATION|>` for a quiet run.
 
-If the feed is unreleased, has no sidecar record, or has an empty body, do not
-claim push is set up. Diagnose and fix first.
+If the automation is unpublished, the feed has no sidecar record, or the record
+has an empty body, do not claim push is set up. Diagnose and fix first.
 
-Confirm to the user with specifics: which feed/playbook is subscribed, what the
-next push will say, and when it will fire. For monitors, say quiet runs skip
-notifications.
+Confirm to the user with specifics: which automation/playbook alert is enabled,
+what the next push will say, and when it will fire. For monitors, say quiet runs
+skip notifications.
 
 ## Inventory And Unsubscribe
 
-- `alva subscriptions list --first 200` — rows carry `kind`, playbook
-  identity, `following`, `target_status`. If `items` < `total_count`, keep
-  paginating; never report a truncated page as the full inventory.
+- `alva alert list --first 200` — rows carry `kind`, playbook identity,
+  `following`, `target_status`. If `items` < `total_count`, keep paginating;
+  never report a truncated page as the full inventory.
 - `alva subscriptions follows` — the follow list.
-- Unsubscribe by name (`unsubscribe-playbook|unsubscribe-feed`) for live
-  targets; by id (`unsubscribe --playbook-ids a,b --feed-ids c`) for bulk
-  and for `TARGET_DELETED` ghosts (name-addressed 404s on deleted targets).
-- Resolve ids with `alva playbooks get --ids a,b` / `--ref owner/name`;
-  list a user's playbooks with `alva playbooks list --owner <username>`.
+- Disable by name (`alva alert disable --playbook owner/name` or
+  `--automation owner/name`) for live targets; by id
+  (`alva alert disable --playbook-ids a,b --automation-ids c`) for bulk and for
+  `TARGET_DELETED` ghosts (name-addressed 404s on deleted targets).
+- Resolve ids with `alva playbooks get --ids a,b` / `--ref owner/name`; list a
+  user's playbooks with `alva playbooks list --owner <username>`.
 - Never probe with mutating calls — the read surface answers all identity
   questions.

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -9,8 +9,8 @@ customizes them per the user's preferences, and deploys a new playbook.
 
 ## Prompt Format
 
-The Remix prompt arrives as a `<remix>` tag emitted by the Remix button.
-A typical message looks like:
+The Remix prompt arrives as a `<remix>` tag emitted by the Remix button. A
+typical message looks like:
 
 ```
 <remix title="energy-dashboard" type="playbook" url="/u/henryliu/playbooks/energy-dashboard" playbook-kind="dashboard">Remix Playbook: Deploy as a new playbook under my account</remix>
@@ -19,12 +19,12 @@ hi
 
 Parse the tag's attributes:
 
-| Attribute       | Description                                                            | Used For                                  |
-| --------------- | ---------------------------------------------------------------------- | ----------------------------------------- |
-| `url`           | Canonical web path: `/u/{owner}/playbooks/{name}`                      | **Authoritative** source of owner + name  |
-| `title`         | Filesystem name (URL-safe slug, same as `{name}` in `url`)             | Cross-check against `url`                 |
-| `type`          | Resource type — currently always `playbook`                            | Routing (skip if not `playbook`)          |
-| `playbook-kind` | Sub-kind of playbook (e.g. `dashboard`)                                | Context only; doesn't change the workflow |
+| Attribute       | Description                                                | Used For                                  |
+| --------------- | ---------------------------------------------------------- | ----------------------------------------- |
+| `url`           | Canonical web path: `/u/{owner}/playbooks/{name}`          | **Authoritative** source of owner + name  |
+| `title`         | Filesystem name (URL-safe slug, same as `{name}` in `url`) | Cross-check against `url`                 |
+| `type`          | Resource type — currently always `playbook`                | Routing (skip if not `playbook`)          |
+| `playbook-kind` | Sub-kind of playbook (e.g. `dashboard`)                    | Context only; doesn't change the workflow |
 
 Extract `owner` and `name` from the `url` attribute (between `/u/` and
 `/playbooks/`, and after `/playbooks/`). For the example above: owner =
@@ -39,15 +39,14 @@ Together they resolve to the ALFS base path (quote in CLI):
 **Behavior note**: The tag's inner text ("Remix Playbook: Deploy as a new
 playbook under my account") is a fixed instruction, **not** the user's
 customization request. The user's actual ask is whatever text they typed
-**outside** the tag (in the example above, just "hi"). If that text is
-empty, a greeting, or otherwise doesn't describe what to customize,
-**ask the user what they'd like to customize** before proceeding —
-do not start editing on the strength of the tag alone.
+**outside** the tag (in the example above, just "hi"). If that text is empty, a
+greeting, or otherwise doesn't describe what to customize, **ask the user what
+they'd like to customize** before proceeding — do not start editing on the
+strength of the tag alone.
 
 > Legacy: older sessions may still arrive as
-> `Use Alva skill to remix this Playbook(@{owner}/{name}) ...` plain
-> text. Same two fields (`owner`, `name`) apply; the rest of this
-> workflow is unchanged.
+> `Use Alva skill to remix this Playbook(@{owner}/{name}) ...` plain text. Same
+> two fields (`owner`, `name`) apply; the rest of this workflow is unchanged.
 
 ---
 
@@ -67,26 +66,23 @@ Returns JSON with structure:
   "releases": [
     {
       "version": "v1.0.0",
-      "feeds": [
-        { "feed_id": 100, "feed_name": "btc-ema", "feed_major": 1 }
-      ]
+      "feeds": [{ "feed_id": 100, "feed_name": "btc-ema", "feed_major": 1 }]
     }
   ]
 }
 ```
 
-`releases` is ordered newest-first, so `releases[0]` is the latest
-release. From `releases[0].feeds`, collect the feed refs you need to
-inspect — each entry carries both `feed_name` (for ALFS paths) and
-`feed_id` (for API calls).
+`releases` is ordered newest-first, so `releases[0]` is the latest release. From
+`releases[0].feeds`, collect the feed refs you need to inspect — each entry
+carries both `feed_name` (for ALFS paths) and `feed_id` (for API calls).
 
 If the source playbook has registered UDFs, collect each function's
 `function_name`, `entry_script_path`, and `params_schema` before editing. Read
-[udf-runtime.md](api/udf-runtime.md) for the `alva functions` registration flow. A remix
-must preserve source UDF methods unless the user explicitly asks to remove or
-replace them: copy every source UDF entry script into the new playbook's ALFS
-tree, rewrite its path to the new playbook namespace, and later register the
-same `function_name` and `params_schema` on the remixed playbook.
+[udf-runtime.md](api/udf-runtime.md) for the `alva functions` registration flow.
+A remix must preserve source UDF methods unless the user explicitly asks to
+remove or replace them: copy every source UDF entry script into the new
+playbook's ALFS tree, rewrite its path to the new playbook namespace, and later
+register the same `function_name` and `params_schema` on the remixed playbook.
 
 ---
 
@@ -106,9 +102,9 @@ that the user expects to inherit.
 alva fs read --path '/alva/home/{owner}/playbooks/{name}/index.html' > ./index.html
 ```
 
-This is the full HTML source of the playbook dashboard — the ECharts
-charts, metric cards, layout, and data-fetching logic. Edit this source
-directly in Step 5; do not rewrite it from scratch.
+This is the full HTML source of the playbook dashboard — the ECharts charts,
+metric cards, layout, and data-fetching logic. Edit this source directly in Step
+5; do not rewrite it from scratch.
 
 ---
 
@@ -121,9 +117,9 @@ script source the same way. In shell-only CLI sessions, download each source:
 alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/src/index.js' > ./{feed_name}.js
 ```
 
-This contains the strategy logic, data fetching, and indicator
-computations. As with the HTML, **modify the inspected source in place**
-rather than re-typing the script from your reading of it.
+This contains the strategy logic, data fetching, and indicator computations. As
+with the HTML, **modify the inspected source in place** rather than re-typing
+the script from your reading of it.
 
 If Step 1 found registered UDFs, inspect each UDF entry script from its
 `entry_script_path` as well. In shell-only CLI sessions, download it:
@@ -136,8 +132,8 @@ Treat these as inherited source code. Edit only the path-sensitive or
 topic-specific pieces required by the remix; do not recreate the methods from
 memory.
 
-Optionally, read sample feed output to understand the data schema (this
-one stays in stdout — it's reference, not a file you'll edit):
+Optionally, read sample feed output to understand the data schema (this one
+stays in stdout — it's reference, not a file you'll edit):
 
 ```bash
 alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/data/{group}/{output}/@last/5'
@@ -147,88 +143,93 @@ alva fs read --path '/alva/home/{owner}/feeds/{feed_name}/v1/data/{group}/{outpu
 
 ## Step 4 — Content Legitimacy Audit
 
-Remix inherits the source's provenance — don't propagate fabricated content
-into a new namespace. Apply the [Content Legitimacy Rules](content-legitimacy.md)
-to both the source HTML and feed scripts: any value the user will see must
-fetch from a feed at runtime. If the source has hardcoded arrays, inline
-analyst ratings, procedural/RNG output, or pasted-in literals, either
-refactor them into your own feed, strip the offending sections, or refuse
-the remix and tell the user why. Do not `sed`-replace the username and
-re-release a source whose data layer was never legitimate.
+Remix inherits the source's provenance — don't propagate fabricated content into
+a new namespace. Apply the [Content Legitimacy Rules](content-legitimacy.md) to
+both the source HTML and feed scripts: any value the user will see must fetch
+from a feed at runtime. If the source has hardcoded arrays, inline analyst
+ratings, procedural/RNG output, or pasted-in literals, either refactor them into
+your own feed, strip the offending sections, or refuse the remix and tell the
+user why. Do not `sed`-replace the username and re-release a source whose data
+layer was never legitimate.
 
 ---
 
 ## Scope of Changes — Default Is Data, Not Design
 
-A remix is a **data/topic swap on top of an existing design**, not a
-redesign. Before editing anything, classify what the user asked for:
+A remix is a **data/topic swap on top of an existing design**, not a redesign.
+Before editing anything, classify what the user asked for:
 
-| Layer                   | Default in a remix | When it's allowed to change                                       |
-| ----------------------- | ------------------ | ----------------------------------------------------------------- |
-| Data sources / symbols  | **Change**         | Always — this is the point of a remix                             |
-| Strategy parameters     | **Change**         | Always (thresholds, windows, cron frequency, namespace paths)     |
-| Topic / domain wording  | **Change**         | Always (titles, copy, README narrative — to fit the new subject)  |
-| **Tab names + order**   | **Preserve**       | Only if the user explicitly says so                               |
-| **Section structure**   | **Preserve**       | Only if the user explicitly says so                               |
-| **Card / chart layout** | **Preserve**       | Only if the user explicitly says so                               |
-| **README outline**      | **Preserve**       | Only if the user explicitly says so                               |
+| Layer                   | Default in a remix | When it's allowed to change                                      |
+| ----------------------- | ------------------ | ---------------------------------------------------------------- |
+| Data sources / symbols  | **Change**         | Always — this is the point of a remix                            |
+| Strategy parameters     | **Change**         | Always (thresholds, windows, cron frequency, namespace paths)    |
+| Topic / domain wording  | **Change**         | Always (titles, copy, README narrative — to fit the new subject) |
+| **Tab names + order**   | **Preserve**       | Only if the user explicitly says so                              |
+| **Section structure**   | **Preserve**       | Only if the user explicitly says so                              |
+| **Card / chart layout** | **Preserve**       | Only if the user explicitly says so                              |
+| **README outline**      | **Preserve**       | Only if the user explicitly says so                              |
 
-"Customize it based on my preferences", "make a semiconductor version",
-"do one for healthcare" are **topic swaps** — they do **not** authorize
-restructuring tabs, sections, or layout. Only explicit structural
-requests do, e.g. "drop the Risks tab", "add a Summary section at the
-bottom", "merge News and Social into one tab".
+"Customize it based on my preferences", "make a semiconductor version", "do one
+for healthcare" are **topic swaps** — they do **not** authorize restructuring
+tabs, sections, or layout. Only explicit structural requests do, e.g. "drop the
+Risks tab", "add a Summary section at the bottom", "merge News and Social into
+one tab".
 
-If the source structure conflicts with the new topic (e.g. source has a
-"News & Social" tab but the new topic has no usable news feed), **ask
-the user** whether to leave the tab empty/hidden or remove it. Do not
-silently restructure.
+If the source structure conflicts with the new topic (e.g. source has a "News &
+Social" tab but the new topic has no usable news feed), **ask the user** whether
+to leave the tab empty/hidden or remove it. Do not silently restructure.
 
 Concretely, before writing the edited HTML back to ALFS, diff its tab list and
-top-level section headings against the source. If they don't match and
-the user didn't ask for the change, revert the structure and re-apply
-only the data swap.
+top-level section headings against the source. If they don't match and the user
+didn't ask for the change, revert the structure and re-apply only the data swap.
 
 ---
 
 ## Step 5 — Deploy as New Playbook
 
 Follow the standard playbook creation flow (see SKILL.md), starting from the
-sources you inspected in Steps 2–3. With ALFS-native edit tools, edit those
-ALFS files directly. In shell-only CLI sessions, edit the downloaded local
-files in place with the `Edit` tool. Swap data paths to your own namespace,
-adjust strategy parameters, and apply the user's customization request **within
-the scope defined above** (data/topic by default; structure only on explicit
+sources you inspected in Steps 2–3. With ALFS-native edit tools, edit those ALFS
+files directly. In shell-only CLI sessions, edit the downloaded local files in
+place with the `Edit` tool. Swap data paths to your own namespace, adjust
+strategy parameters, and apply the user's customization request **within the
+scope defined above** (data/topic by default; structure only on explicit
 request). Do not write fresh files from scratch.
 
 1. **Write the edited feed script** to ALFS. Use the ALFS write/edit tool in
    agent tool mode; shell-only fallback:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
-3. **Grant** public read: `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
-4. **Deploy cronjob**: `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
-5. **Release feed**: `alva release feed --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
-6. **Write the edited HTML** to ALFS after updating data paths to point to
-   your own feed. Use the ALFS write/edit tool in agent tool mode; shell-only
+3. **Grant** public read:
+   `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
+4. **Deploy cronjob**:
+   `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
+5. **Publish automation**:
+   `alva automation publish --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
+6. **Write the edited HTML** to ALFS after updating data paths to point to your
+   own feed. Use the ALFS write/edit tool in agent tool mode; shell-only
    fallback:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
-7. **Copy inherited UDF entry scripts when present**: for each source UDF,
-   write the edited entry script to a path under the new playbook. Use the
-   ALFS write/edit tool in agent tool mode; shell-only fallback:
-   `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
-8. **Write README** (mandatory) — adapt the source playbook's README to
-   your data sources and methodology, then write it to ALFS. Use the ALFS
+7. **Copy inherited UDF entry scripts when present**: for each source UDF, write
+   the edited entry script to a path under the new playbook. Use the ALFS
    write/edit tool in agent tool mode; shell-only fallback:
+   `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
+8. **Write README** (mandatory) — adapt the source playbook's README to your
+   data sources and methodology, then write it to ALFS. Use the ALFS write/edit
+   tool in agent tool mode; shell-only fallback:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.
    See [release.md → Playbook README](api/release.md#playbook-readme).
-9. **Draft playbook**: `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
+9. **Draft playbook**:
+   `alva release playbook-draft --name {new-name} --display-name "..." --feeds '[{"feed_id":ID}]'`
 10. **Register inherited UDFs when present**: after the draft command returns
-   the remixed playbook ID, use `alva functions register` for each copied
-   method with the same `function_name` and `params_schema`, with
-   `entry_script_path` pointing at the new absolute ALFS path. Do not leave
-   inherited `window.alva.udf` UI controls pointing at an unregistered
-   function.
-11. **Release playbook**: `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'` (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative shorthand is no longer accepted)
+    the remixed playbook ID, use `alva functions register` for each copied
+    method with the same `function_name` and `params_schema`, with
+    `entry_script_path` pointing at the new absolute ALFS path. Do not leave
+    inherited `window.alva.udf` UI controls pointing at an unregistered
+    function.
+11. **Release playbook**:
+    `alva release playbook --name {new-name} --version v1.0.0 --feeds '[{"feed_id":ID}]' --changelog "..." --readme-url '/alva/home/<username>/playbooks/{new-name}/README.md'`
+    (absolute ALFS path; resolve `<username>` via `alva whoami` — the relative
+    shorthand is no longer accepted)
 
 **Important**: The new playbook must use a unique name in your user space. The
 feed scripts must use **your own** ALFS paths (not the original owner's) for
@@ -255,9 +256,9 @@ Given prompt:
 Add a summary section at the bottom.
 ```
 
-Extracted from the `url` attribute: owner = `alice`, name =
-`btc-momentum`. The user's customization request is the text after the
-tag: "Add a summary section at the bottom."
+Extracted from the `url` attribute: owner = `alice`, name = `btc-momentum`. The
+user's customization request is the text after the tag: "Add a summary section
+at the bottom."
 
 Agent inspects sources so they can be edited in place, not retyped. With
 ALFS-native tools, edit the ALFS sources directly; in shell-only CLI sessions,
@@ -282,7 +283,8 @@ script (Step 4), edits them in place to apply the user's customization, then
 writes them under the user's own namespace with a new name (e.g.
 `my-btc-strategy`) and releases.
 
-Save lineage (assuming current user is `bob`, new playbook name is `my-btc-strategy`):
+Save lineage (assuming current user is `bob`, new playbook name is
+`my-btc-strategy`):
 
 ```bash
 # 6. Save remix lineage
@@ -293,10 +295,10 @@ alva remix --child-username bob --child-name my-btc-strategy --parents '[{"usern
 
 ## Key Differences from Building from Scratch
 
-| Aspect         | From Scratch                 | Remix                                      |
-| -------------- | ---------------------------- | ------------------------------------------ |
-| SDK discovery  | Search partitions, read docs | Already chosen in source feed              |
-| Data modeling  | Design schema from scratch   | Reuse source feed's `def()` schema         |
+| Aspect         | From Scratch                 | Remix                                                                    |
+| -------------- | ---------------------------- | ------------------------------------------------------------------------ |
+| SDK discovery  | Search partitions, read docs | Already chosen in source feed                                            |
+| Data modeling  | Design schema from scratch   | Reuse source feed's `def()` schema                                       |
 | HTML structure | Build per design system      | **Preserve tabs/sections/layout**, change only data paths and topic copy |
-| Strategy logic | Write from requirements      | Modify existing logic per user preferences |
-| Feed name      | User decides                 | Must be unique, distinct from source       |
+| Strategy logic | Write from requirements      | Modify existing logic per user preferences                               |
+| Feed name      | User decides                 | Must be unique, distinct from source                                     |


### PR DESCRIPTION
## Summary
- align Alva skill docs with product-facing automation publish and alert CLI surfaces
- replace old feed-release/subscription CLI guidance with `alva automation publish` and `alva alert enable/list/disable`
- update push/playbook/feed lifecycle eval expectations and generated reports

## Tests
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva --out evals/alva-skill-docs/final-report.md`
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/automation-alert-surface/skills/alva`
- `git diff --check`