### PR TITLE
[jaxxjj] docs(alva): document channel-scoped memory

### DIFF
--- a/skills/alva/references/memory.md
+++ b/skills/alva/references/memory.md
@@ -31,6 +31,24 @@ line linking to a topic file:
 Topic files (like `user.md`) hold the actual content. They are read on demand
 when relevant to the user's request.
 
+### Channel-scoped memory
+
+`~/memory/` is your **user-global** memory — shared across every channel and
+conversation. A **channel** can also have its own memory, kept separate so
+channel-specific facts don't leak across topics.
+
+When a turn runs in a channel, the session prefill includes a
+`<session-prefill-channel-memory root="...">` block naming that channel's
+memory dir (`~/channels/<slug>/memory/`). It uses the same layout — a
+`MEMORY.md` index plus topic files.
+
+- **User-global facts** (identity, cross-channel preferences, investment
+  style) → `~/memory/`.
+- **Channel-specific facts** (this channel's topic, running thesis, decisions
+  made here) → the channel memory root from the prefill.
+- Read both at the start of a channel turn. When there is no channel-memory
+  block, there is no channel scope — use `~/memory/` only.
+
 ## user.md — Who is this user
 
 Persistent facts about the user. Update when you learn something new.

--- a/skills/alva/references/memory.md
+++ b/skills/alva/references/memory.md
@@ -33,21 +33,15 @@ when relevant to the user's request.
 
 ### Channel-scoped memory
 
-`~/memory/` is your **user-global** memory — shared across every channel and
-conversation. A **channel** can also have its own memory, kept separate so
-channel-specific facts don't leak across topics.
+`~/memory/` is **user-global** (shared across all channels). A **channel** can
+also have its own memory at `~/channels/<slug>/memory/`, named in the session
+prefill as a `<session-prefill-channel-memory root="...">` block. Same layout —
+a `MEMORY.md` index plus topic files.
 
-When a turn runs in a channel, the session prefill includes a
-`<session-prefill-channel-memory root="...">` block naming that channel's
-memory dir (`~/channels/<slug>/memory/`). It uses the same layout — a
-`MEMORY.md` index plus topic files.
-
-- **User-global facts** (identity, cross-channel preferences, investment
-  style) → `~/memory/`.
-- **Channel-specific facts** (this channel's topic, running thesis, decisions
-  made here) → the channel memory root from the prefill.
-- Read both at the start of a channel turn. When there is no channel-memory
-  block, there is no channel scope — use `~/memory/` only.
+- User-global facts (identity, cross-channel preferences) → `~/memory/`.
+- Channel-specific facts (this channel's topic, decisions) → the prefill root.
+- Read both at the start of a channel turn. No prefill block → no channel
+  scope; use `~/memory/` only.
 
 ## user.md — Who is this user
 

--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -112,3 +112,10 @@ If the index exists, read the files it names, at minimum `user.md`. If
 `~/memory/` is absent or empty, skip. Memory is a claim, not truth: verify any
 feed, cronjob, preference, or parameter before acting on it in a new session.
 Read [memory.md](memory.md) before writing memory.
+
+**Channel sessions:** if the session prefill includes a
+`<session-prefill-channel-memory root="...">` block, this channel has its own
+memory *in addition to* `~/memory/`. Read that root's `MEMORY.md` (and the
+files it names) too — do it even when `~/memory/` is empty, since the channel
+index is separate. Write channel-specific facts to that root; keep user-global
+facts in `~/memory/`. See [memory.md](memory.md).

--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -113,9 +113,8 @@ If the index exists, read the files it names, at minimum `user.md`. If
 feed, cronjob, preference, or parameter before acting on it in a new session.
 Read [memory.md](memory.md) before writing memory.
 
-**Channel sessions:** if the session prefill includes a
-`<session-prefill-channel-memory root="...">` block, this channel has its own
-memory *in addition to* `~/memory/`. Read that root's `MEMORY.md` (and the
-files it names) too — do it even when `~/memory/` is empty, since the channel
-index is separate. Write channel-specific facts to that root; keep user-global
-facts in `~/memory/`. See [memory.md](memory.md).
+**Channel sessions:** if the prefill includes a
+`<session-prefill-channel-memory root="...">` block, the channel has its own
+memory alongside `~/memory/`. Read that root's `MEMORY.md` too (even when
+`~/memory/` is empty — the index is separate). Write channel-specific facts
+there; keep user-global facts in `~/memory/`. See [memory.md](memory.md).


### PR DESCRIPTION
Documents channel-scoped memory in the `alva` skill `memory.md`: `~/memory/` is user-global; a channel also has `~/channels/<slug>/memory/`, named in the session prefill. User-global facts → `~/memory/`; channel-specific facts → the channel root.

Prompt-side companion to alva-backend#1717 (per-channel agent memory). No code change.