### PR TITLE
docs(alva): update push notification CLI guidance

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -553,8 +553,22 @@
             "alva deploy update --id <ID> --push-notify",
             "alva alert enable --automation",
             "alva alert enable --playbook",
+            "alva channel group-subscriptions subscribe",
             "read `@last/1` of the sidecar",
+            "alva alert history",
             "do not claim push is set up"
+          ]
+        },
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Inventory And Unsubscribe",
+          "label": "alert inventory",
+          "includes": [
+            "personal alert opt-ins",
+            "lists playbook follows, not the alert inventory",
+            "`--feed-ids` is only a legacy alias for `--automation-ids`",
+            "alva channel group-subscriptions context",
+            "alva alert preferences"
           ]
         }
       ]

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -247,8 +247,9 @@ does not require a 500-character summary.
   or group.
 - Real delivery requires an explicit alert/subscription: personal
   `alva alert enable --automation <owner>/<feed>` /
-  `--playbook <owner>/<playbook>`, group `/alva subscribe feed <id>` /
-  `/alva subscribe playbook <id>`, or — from inside a playbook iframe — a
+  `--playbook <owner>/<playbook>`, group
+  `alva channel group-subscriptions subscribe ...`, or — from inside a playbook
+  iframe — a
   parent-confirmed `window.alva.subscribe.propose()` (see
   `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
   never call a subscribe API directly.
@@ -346,7 +347,7 @@ alva automation publish --name daily-briefing --version 1.0.0 \
 - Real delivery requires an explicit alert/subscription: personal
   `alva alert enable --automation <owner>/<feed>` or
   `alva alert enable --playbook <owner>/<playbook>`, or group
-  `/alva subscribe feed <feed_id>` / `/alva subscribe playbook <playbook_id>`.
+  `alva channel group-subscriptions subscribe ...`.
   For inventory and unsubscribe (including ghost rows of deleted targets), see
   [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -38,10 +38,14 @@ A push is set up only after all of these succeed:
    `alva deploy update --id <ID> --push-notify`.
 4. Enable the personal alert: `alva alert enable --automation <owner>/<feed>` or
    `alva alert enable --playbook <owner>/<playbook>`. For groups, use
-   `/alva subscribe feed <id>` or `/alva subscribe playbook <id>` in the group.
+   `alva channel group-subscriptions subscribe --session-id <id> --target-type feed --target-id <feed_id>`
+   or the same command with `--target-type playbook --target-id <playbook_id>`.
 5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
    the record is fresh and the message is non-empty or contains
    `<|SKIP_NOTIFICATION|>` for a quiet run.
+6. Check delivery history with `alva alert history --automation <owner>/<feed>`
+   or `alva alert history --playbook <owner>/<playbook>`; filter with
+   `--channel`, `--status`, or `--since` when diagnosing a missing push.
 
 If the automation is unpublished, the feed has no sidecar record, or the record
 has an empty body, do not claim push is set up. Diagnose and fix first.
@@ -52,15 +56,26 @@ skip notifications.
 
 ## Inventory And Unsubscribe
 
-- `alva alert list --first 200` — rows carry `kind`, playbook identity,
-  `following`, `target_status`. If `items` < `total_count`, keep paginating;
-  never report a truncated page as the full inventory.
-- `alva subscriptions follows` — the follow list.
-- Disable by name (`alva alert disable --playbook owner/name` or
-  `--automation owner/name`) for live targets; by id
-  (`alva alert disable --playbook-ids a,b --automation-ids c`) for bulk and for
-  `TARGET_DELETED` ghosts (name-addressed 404s on deleted targets).
+- `alva alert list --first 200` lists personal alert opt-ins. Rows carry
+  `kind`, `target`, `target_status`, feed or playbook identity, and pagination
+  fields. If `items` < `total_count`, keep paginating; never report a truncated
+  page as the full inventory. Use `--json` when ids or raw statuses matter.
+- `alva subscriptions follows` lists playbook follows, not the alert inventory.
+  Use it only when the user asks what they follow.
+- Disable live personal alerts by name: `alva alert disable --automation owner/name`
+  or `alva alert disable --playbook owner/name`.
+- Disable in bulk or clear `TARGET_DELETED` ghosts by target id:
+  `alva alert disable --automation-ids c --playbook-ids a,b`.
+  `--feed-ids` is only a legacy alias for `--automation-ids`; prefer
+  `--automation-ids` in new docs and examples.
 - Resolve ids with `alva playbooks get --ids a,b` / `--ref owner/name`; list a
   user's playbooks with `alva playbooks list --owner <username>`.
+- Group subscriptions are separate from personal alerts. Inspect them with
+  `alva channel group-subscriptions context --session-id <id>` and
+  `alva channel group-subscriptions list --session-id <id>`; remove one with
+  `alva channel group-subscriptions unsubscribe --session-id <id> --target-type feed --target-id <feed_id>`
+  or the playbook variant.
+- Use `alva alert preferences`, `alva alert enable-session-completed`, and
+  `alva alert disable-session-completed` only for global alert preferences.
 - Never probe with mutating calls — the read surface answers all identity
   questions.


### PR DESCRIPTION
## Summary
- update push notification guidance for the current `alva alert` and `alva channel group-subscriptions` CLI surfaces
- clarify alert inventory vs playbook follows, bulk disable ids, delivery history, and global alert preferences
- align Feed SDK push notes with the new group-subscriptions command and add eval coverage for the CLI surface

## Validation
- `alva alert --help`
- `alva channel group-subscriptions --help`
- `alva automation --help`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/push-notifications-cli/skills/alva`
- `git diff --check`
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva`
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva`
