### PR TITLE
[jaxxjj] docs(feed): grant public read on non-versioned feed base (fixes group subscribe)

### DIFF
--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -339,7 +339,8 @@ alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 ### 3. Make the output public
 
 ```bash
-alva fs grant --path '~/feeds/btc-hourly/v1' --subject "special:user:*" --permission read
+# Grant the non-versioned base: inherited by all versions + data/.
+alva fs grant --path '~/feeds/btc-hourly' --subject "special:user:*" --permission read
 ```
 
 ### 4. Deploy as a cronjob

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -782,10 +782,13 @@ records if some timestamps have multiple items.
 
 ## Making Feeds Public
 
-Grant public read access so anyone can read the data:
+Grant public read access so anyone can read the data. **Grant the
+non-versioned feed base** (`~/feeds/<name>`, not `~/feeds/<name>/v1`) — ALFS
+inherits parent → child, so the base grant covers every version and its
+`data/`:
 
 ```bash
-alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
+alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
 ```
 
 Public reads must use absolute paths:
@@ -849,7 +852,8 @@ alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
 ### Step 3: Make it public
 
 ```bash
-alva fs grant --path '~/feeds/btc-ema/v1' --subject "special:user:*" --permission read
+# Grant the non-versioned base — inherited by all versions + data/.
+alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
 ```
 
 ### Step 4: Read from any client


### PR DESCRIPTION
Grant public read on the **non-versioned** feed base (`~/feeds/<name>`) instead of `~/feeds/<name>/v1`.

ALFS inherits parent → child, so the base grant covers every version and its `data/`. Aligns with `api/filesystem.md`, which already documents base grants.

Updates `feed-sdk.md` (×2) and `deployment.md`.