### PR TITLE
docs(alva): route alert follows through alert CLI

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -556,6 +556,16 @@
             "read `@last/1` of the sidecar",
             "do not claim push is set up"
           ]
+        },
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Inventory And Unsubscribe",
+          "label": "push inventory",
+          "includes": [
+            "alva alert list --first 200",
+            "alva alert follows --limit 100",
+            "has_next"
+          ]
         }
       ]
     },

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/automation-alert-surface/skills/alva`
+Source: `/Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/alert-follows-docs/skills/alva`
 
 SKILL.md lines: 791
 
 Cases: 50/50
 
-Checks: 455/455 (100.00%)
+Checks: 458/458 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -325,7 +325,7 @@ KOL data and the KOL digest SDK are routed together as Alva-maintained Platform 
 
 ## issue592
 
-5/5 cases, 65/65 checks
+5/5 cases, 68/68 checks
 
 ### PASS issue592.scoped-eval-checks
 
@@ -416,6 +416,9 @@ Push setup is evaluated as a full delivery path instead of a single publisher fl
 - [x] push setup: references/push-notifications.md#Configure And Verify includes alva alert enable --playbook
 - [x] push setup: references/push-notifications.md#Configure And Verify includes read `@last/1` of the sidecar
 - [x] push setup: references/push-notifications.md#Configure And Verify includes do not claim push is set up
+- [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes alva alert list --first 200
+- [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes alva alert follows --limit 100
+- [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes has_next
 
 ## target
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -682,7 +682,7 @@ text does not fully cover.
 | `playbooks`          | Trending discovery and `set-visibility`.                                                                                                                                              |
 | `comments`           | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md).                                                                                      |
 | `alert`              | Personal automation/playbook alert opt-ins and history. See [push-notifications.md](references/push-notifications.md).                                                                |
-| `subscriptions`      | Legacy alert/follow surface. Prefer `alert`; use only for follows. See [push-notifications.md](references/push-notifications.md).                                                     |
+| `subscriptions`      | Legacy alert/follow compatibility surface. Prefer `alert`, including for follows. See [push-notifications.md](references/push-notifications.md).                                     |
 | `channel`            | Group push subscriptions. See [push-notifications.md](references/push-notifications.md).                                                                                              |
 | `trading`            | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md).                                                                         |
 | `screenshot`         | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot).                                                               |

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -55,7 +55,8 @@ skip notifications.
 - `alva alert list --first 200` — rows carry `kind`, playbook identity,
   `following`, `target_status`. If `items` < `total_count`, keep paginating;
   never report a truncated page as the full inventory.
-- `alva subscriptions follows` — the follow list.
+- `alva alert follows --limit 100` — the playbook follow list. Keep paginating
+  with `--cursor` when `has_next` is true.
 - Disable by name (`alva alert disable --playbook owner/name` or
   `--automation owner/name`) for live targets; by id
   (`alva alert disable --playbook-ids a,b --automation-ids c`) for bulk and for


### PR DESCRIPTION
## Summary
- update the Alva push notification inventory docs to use `alva alert follows --limit 100`
- align the top-level command index so `subscriptions` is legacy compatibility and `alert` remains the preferred surface
- add a regression eval check for the push inventory follow-list guidance and refresh the final report

## Validation
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva`
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`
- `git diff --check`

Note: the alva-skill-standard cold-reader subagent step was not run because this session's tool policy only allows spawning subagents when the user explicitly asks for delegation.
