### PR TITLE
[jaxxjj] docs: publish feeds via 'alva feed set-access' not raw ALFS grant

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -392,13 +392,13 @@ Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
 short lifecycle is: write schema and logic to ALFS, `alva run`, deploy, then
 `alva automation publish` (which writes the `feeds` row), and finally make it
-public if needed with `alva feed set-access --id <feed_id> --access public` (the
+public if needed with `alva feed set-visibility --id <feed_id> --visibility public` (the
 id comes from `alva feed list` and only exists after publish; not a raw
 `special:user:*` grant).
 
 Satisfy `before-automation-publish`: before publish, confirm a fresh run,
 expected shape, and non-empty data; then publish, set public access with `alva
-feed set-access` (the feed id exists only after publish), and verify public
+feed set-visibility` (the feed id exists only after publish), and verify public
 reads for HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
 and grant contract lives in the feed references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -390,11 +390,13 @@ reusable dataset, or future answer.
 
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic to ALFS, `alva run`, grant public
-read if needed, deploy, then `alva automation publish`.
+short lifecycle is: write schema and logic to ALFS, `alva run`, publish for
+public reads if needed with `alva feed set-access --id <feed_id> --access public`
+(not a raw `special:user:*` grant), deploy, then `alva automation publish`.
 
 Before automation publish, satisfy `before-automation-publish`: fresh run,
-expected shape, needed grants, public read verification, and non-empty data for
+expected shape, public access set via `alva feed set-access`, public read
+verification, and non-empty data for
 HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
 and grant contract lives in the feed references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -390,14 +390,16 @@ reusable dataset, or future answer.
 
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic to ALFS, `alva run`, publish for
-public reads if needed with `alva feed set-access --id <feed_id> --access public`
-(not a raw `special:user:*` grant), deploy, then `alva automation publish`.
+short lifecycle is: write schema and logic to ALFS, `alva run`, deploy, then
+`alva automation publish` (which writes the `feeds` row), and finally make it
+public if needed with `alva feed set-access --id <feed_id> --access public` (the
+id comes from `alva feed list` and only exists after publish; not a raw
+`special:user:*` grant).
 
-Before automation publish, satisfy `before-automation-publish`: fresh run,
-expected shape, public access set via `alva feed set-access`, public read
-verification, and non-empty data for
-HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
+Satisfy `before-automation-publish`: before publish, confirm a fresh run,
+expected shape, and non-empty data; then publish, set public access with `alva
+feed set-access` (the feed id exists only after publish), and verify public
+reads for HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
 and grant contract lives in the feed references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before
 each feed, ALFS, deploy, and publish step.

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -65,13 +65,13 @@ under a group/output.
 
 ## Making a feed public
 
-To publish a feed for public reads, use `alva feed set-access` — do not write
+To publish a feed for public reads, use `alva feed set-visibility` — do not write
 the ALFS grant by hand:
 
 ```bash
 # Publish: writes is_public (DB source of truth) + the ALFS read grant together.
 # The id (from `alva feed list`) only exists after `alva automation publish`.
-alva feed set-access --id <feed_id> --access public
+alva feed set-visibility --id <feed_id> --visibility public
 ```
 
 Granting `special:user:*` on the feed directory directly bypasses `is_public`,
@@ -79,7 +79,7 @@ drifts from the DB intent, and can be reverted by reconciliation — do not do i
 
 Separately, you **cannot** grant permissions directly on a Feed synth `data/`
 path — it returns `PERMISSION_DENIED`. Grants belong on the feed directory (as
-`set-access` does); ALFS inherits them to every child path including the synth
+`set-visibility` does); ALFS inherits them to every child path including the synth
 data mount.
 
 ## Clearing feed data (development only)

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -63,19 +63,23 @@ consumers don't.
 `@kv` lives at the mount root (`~/feeds/<name>/v1/data/@kv/<key>`), not
 under a group/output.
 
-## Synth-mount grant gotcha
+## Making a feed public
 
-You **cannot** grant permissions directly on a Feed synth `data/` path —
-it returns `PERMISSION_DENIED`. Grant on the parent feed directory; the
-permission is inherited by every child path including the synth data mount:
+To publish a feed for public reads, use `alva feed set-access` — do not write
+the ALFS grant by hand:
 
 ```bash
-# Wrong — errors
-alva fs grant --path '~/feeds/my-feed/v1/data' --subject "special:user:*" --permission read
-
-# Right — grant on the feed root
-alva fs grant --path '~/feeds/my-feed' --subject "special:user:*" --permission read
+# Publish: writes is_public (DB source of truth) + the ALFS read grant together.
+alva feed set-access --id <feed_id> --access public   # id from `alva feed list`
 ```
+
+Granting `special:user:*` on the feed directory directly bypasses `is_public`,
+drifts from the DB intent, and can be reverted by reconciliation — do not do it.
+
+Separately, you **cannot** grant permissions directly on a Feed synth `data/`
+path — it returns `PERMISSION_DENIED`. Grants belong on the feed directory (as
+`set-access` does); ALFS inherits them to every child path including the synth
+data mount.
 
 ## Clearing feed data (development only)
 

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -70,7 +70,8 @@ the ALFS grant by hand:
 
 ```bash
 # Publish: writes is_public (DB source of truth) + the ALFS read grant together.
-alva feed set-access --id <feed_id> --access public   # id from `alva feed list`
+# The id (from `alva feed list`) only exists after `alva automation publish`.
+alva feed set-access --id <feed_id> --access public
 ```
 
 Granting `special:user:*` on the feed directory directly bypasses `is_public`,

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -339,8 +339,9 @@ alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 ### 3. Make the output public
 
 ```bash
-# Grant the non-versioned base: inherited by all versions + data/.
-alva fs grant --path '~/feeds/btc-hourly' --subject "special:user:*" --permission read
+# set-access writes is_public + the ALFS read grant together (single source of
+# truth). Get the id from `alva feed list`; do not grant special:user:* by hand.
+alva feed set-access --id <feed_id> --access public
 ```
 
 ### 4. Deploy as a cronjob

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -336,27 +336,35 @@ feed.def("market", {
 alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 ```
 
-### 3. Make the output public
-
-```bash
-# set-access writes is_public + the ALFS read grant together (single source of
-# truth). Get the id from `alva feed list`; do not grant special:user:* by hand.
-alva feed set-access --id <feed_id> --access public
-```
-
-### 4. Deploy as a cronjob
+### 3. Deploy as a cronjob
 
 ```bash
 alva deploy create --name btc-hourly-price-feed --path '~/feeds/btc-hourly/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
-### 5. Verify the cronjob
+### 4. Publish the automation
+
+```bash
+# Writes the `feeds` row (feeds / feed_majors) — the feed only gets a numeric
+# id after this step.
+alva automation publish --name btc-hourly --version 1.0.0 --cronjob-id <id> --description "BTC hourly OHLCV"
+```
+
+### 5. Make the output public
+
+```bash
+# Now the feed has an id. set-access writes is_public + the ALFS read grant
+# together (single source of truth); do not grant special:user:* by hand.
+alva feed set-access --id <feed_id> --access public
+```
+
+### 6. Verify the cronjob
 
 ```bash
 alva deploy list
 ```
 
-### 6. Read the data (from anywhere)
+### 7. Read the data (from anywhere)
 
 ```bash
 alva fs read --path '/alva/home/alice/feeds/btc-hourly/v1/data/market/ohlcv/@last/24'

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -353,9 +353,9 @@ alva automation publish --name btc-hourly --version 1.0.0 --cronjob-id <id> --de
 ### 5. Make the output public
 
 ```bash
-# Now the feed has an id. set-access writes is_public + the ALFS read grant
+# Now the feed has an id. set-visibility writes is_public + the ALFS read grant
 # together (single source of truth); do not grant special:user:* by hand.
-alva feed set-access --id <feed_id> --access public
+alva feed set-visibility --id <feed_id> --visibility public
 ```
 
 ### 6. Verify the cronjob

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -19,7 +19,7 @@ Every feed follows the same path:
 5. Publish the automation with `alva automation publish` using the cronjob id
    from deploy. This writes the `feeds` row, so the feed now has a numeric id.
 6. Make the feed public when a playbook or public user needs it:
-   `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
+   `alva feed set-visibility --id <feed_id> --visibility public` (get `<feed_id>` from
    `alva feed list` — it only appears after step 5). This writes the feed's
    `is_public` intent and the ALFS read grant together. Do **not** grant
    `special:user:*` on the feed directory by hand — that drifts from
@@ -77,13 +77,13 @@ re-enter the gate.
 Publishing writes the `feeds` row and gives the feed its numeric id.
 **Immediately after publish**, when public reads are needed:
 
-4. Make the feed public with `alva feed set-access --id <feed_id> --access public`
+4. Make the feed public with `alva feed set-visibility --id <feed_id> --visibility public`
    (id from `alva feed list`, which exists only after publish; this sets
    `is_public` and the ALFS read grant together — do not grant `special:user:*`
    by hand).
 5. Confirm an unauthenticated public read returns HTTP 200, not 403.
 6. If the feed backs HTML, confirm at least one public `@last` path the HTML
-   reads has non-empty data after `set-access`.
+   reads has non-empty data after `set-visibility`.
 </HARD-GATE>
 
 ## Push Sidecars

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -15,8 +15,11 @@ Every feed follows the same path:
    `ctx.self.ts().append()`.
 2. Upload source to `'~/feeds/<name>/v1/src/index.js'`.
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
-4. Grant the feed root for public reads when a playbook or public user needs it:
-   `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
+4. Make the feed public when a playbook or public user needs it:
+   `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
+   `alva feed list`). This writes the feed's `is_public` intent and the ALFS
+   read grant together. Do **not** grant `special:user:*` on the feed directory
+   by hand — that drifts from `is_public` and can be reverted by reconciliation.
 5. Deploy the script with `alva deploy create`.
 6. Publish the automation with `alva automation publish` using the cronjob id
    from deploy.
@@ -66,8 +69,9 @@ Before `alva automation publish`, verify:
    source write.
 2. Output groups and fields match the feed contract.
 3. Evidence is fresh; if source changed after the run, rerun.
-4. `special:user:*` read permission exists on the feed root when public reads
-   are needed.
+4. The feed is public via `alva feed set-access --id <feed_id> --access public`
+   when public reads are needed (this sets `is_public` and the ALFS read grant
+   together; do not grant `special:user:*` by hand).
 5. An unauthenticated public read returns HTTP 200, not 403.
 6. If the feed backs HTML, at least one public `@last` path the HTML reads has
    non-empty data after grant.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -15,14 +15,15 @@ Every feed follows the same path:
    `ctx.self.ts().append()`.
 2. Upload source to `'~/feeds/<name>/v1/src/index.js'`.
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
-4. Make the feed public when a playbook or public user needs it:
+4. Deploy the script with `alva deploy create`.
+5. Publish the automation with `alva automation publish` using the cronjob id
+   from deploy. This writes the `feeds` row, so the feed now has a numeric id.
+6. Make the feed public when a playbook or public user needs it:
    `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
-   `alva feed list`). This writes the feed's `is_public` intent and the ALFS
-   read grant together. Do **not** grant `special:user:*` on the feed directory
-   by hand — that drifts from `is_public` and can be reverted by reconciliation.
-5. Deploy the script with `alva deploy create`.
-6. Publish the automation with `alva automation publish` using the cronjob id
-   from deploy.
+   `alva feed list` — it only appears after step 5). This writes the feed's
+   `is_public` intent and the ALFS read grant together. Do **not** grant
+   `special:user:*` on the feed directory by hand — that drifts from
+   `is_public` and can be reverted by reconciliation.
 
 `alva run` is a test step. It does not replace deploy or release and does not
 guarantee public `@last` data for a playbook.
@@ -69,15 +70,20 @@ Before `alva automation publish`, verify:
    source write.
 2. Output groups and fields match the feed contract.
 3. Evidence is fresh; if source changed after the run, rerun.
-4. The feed is public via `alva feed set-access --id <feed_id> --access public`
-   when public reads are needed (this sets `is_public` and the ALFS read grant
-   together; do not grant `special:user:*` by hand).
-5. An unauthenticated public read returns HTTP 200, not 403.
-6. If the feed backs HTML, at least one public `@last` path the HTML reads has
-   non-empty data after grant.
 
 If any evidence is missing or stale, do not publish. Fix the feed, rerun, and
 re-enter the gate.
+
+Publishing writes the `feeds` row and gives the feed its numeric id.
+**Immediately after publish**, when public reads are needed:
+
+4. Make the feed public with `alva feed set-access --id <feed_id> --access public`
+   (id from `alva feed list`, which exists only after publish; this sets
+   `is_public` and the ALFS read grant together — do not grant `special:user:*`
+   by hand).
+5. Confirm an unauthenticated public read returns HTTP 200, not 403.
+6. If the feed backs HTML, confirm at least one public `@last` path the HTML
+   reads has non-empty data after `set-access`.
 </HARD-GATE>
 
 ## Push Sidecars

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -782,17 +782,17 @@ records if some timestamps have multiple items.
 
 ## Making Feeds Public
 
-Publish a feed with `alva feed set-access` — never by writing the ALFS grant
+Publish a feed with `alva feed set-visibility` — never by writing the ALFS grant
 by hand:
 
 ```bash
-alva feed set-access --id <feed_id> --access public    # publish
-alva feed set-access --id <feed_id> --access private   # unpublish
+alva feed set-visibility --id <feed_id> --visibility public    # publish
+alva feed set-visibility --id <feed_id> --visibility private   # unpublish
 ```
 
-`set-access` takes the feed's **numeric id** (from `alva feed list`), not a
+`set-visibility` takes the feed's **numeric id** (from `alva feed list`), not a
 path. The id only exists once `alva automation publish` has written the feed's
-`feeds` row, so publish the automation before calling `set-access`. It writes
+`feeds` row, so publish the automation before calling `set-visibility`. It writes
 the feed's `is_public` intent (the DB source of truth) **and** the ALFS
 `special:user:*` read grant on the feed directory together, so the two never
 drift. The grant covers every version and its `data/` via ALFS parent → child
@@ -878,10 +878,10 @@ alva automation publish --name btc-ema --version 1.0.0 --cronjob-id <id> --descr
 ### Step 5: Make it public
 
 ```bash
-# Now the feed has an id. set-access writes is_public + the ALFS read grant
+# Now the feed has an id. set-visibility writes is_public + the ALFS read grant
 # together — do not grant special:user:* by hand.
 alva feed list
-alva feed set-access --id <feed_id> --access public
+alva feed set-visibility --id <feed_id> --visibility public
 ```
 
 ### Step 6: Read from any client

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -782,14 +782,25 @@ records if some timestamps have multiple items.
 
 ## Making Feeds Public
 
-Grant public read access so anyone can read the data. **Grant the
-non-versioned feed base** (`~/feeds/<name>`, not `~/feeds/<name>/v1`) — ALFS
-inherits parent → child, so the base grant covers every version and its
-`data/`:
+Publish a feed with `alva feed set-access` — never by writing the ALFS grant
+by hand:
 
 ```bash
-alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
+alva feed set-access --id <feed_id> --access public    # publish
+alva feed set-access --id <feed_id> --access private   # unpublish
 ```
+
+`set-access` takes the feed's **numeric id** (from `alva feed list`), not a
+path. It writes the feed's `is_public` intent (the DB source of truth) **and**
+the ALFS `special:user:*` read grant on the feed directory together, so the two
+never drift. The grant covers every version and its `data/` via ALFS parent →
+child inheritance.
+
+Do **not** grant `special:user:*` on the feed directory directly (e.g. `alva fs
+grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`).
+That sets the ALFS grant without `is_public`, producing drift the reconciler
+cannot heal for standalone feeds, and a referencing playbook can silently revert
+it on its next reconcile.
 
 Public reads must use absolute paths:
 `/alva/home/<username>/feeds/btc-ema/v1/data/...`
@@ -852,8 +863,10 @@ alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
 ### Step 3: Make it public
 
 ```bash
-# Grant the non-versioned base — inherited by all versions + data/.
-alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
+# Look up the feed's numeric id, then publish. set-access writes is_public +
+# the ALFS read grant together — do not grant special:user:* by hand.
+alva feed list
+alva feed set-access --id <feed_id> --access public
 ```
 
 ### Step 4: Read from any client

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -791,10 +791,12 @@ alva feed set-access --id <feed_id> --access private   # unpublish
 ```
 
 `set-access` takes the feed's **numeric id** (from `alva feed list`), not a
-path. It writes the feed's `is_public` intent (the DB source of truth) **and**
-the ALFS `special:user:*` read grant on the feed directory together, so the two
-never drift. The grant covers every version and its `data/` via ALFS parent →
-child inheritance.
+path. The id only exists once `alva automation publish` has written the feed's
+`feeds` row, so publish the automation before calling `set-access`. It writes
+the feed's `is_public` intent (the DB source of truth) **and** the ALFS
+`special:user:*` read grant on the feed directory together, so the two never
+drift. The grant covers every version and its `data/` via ALFS parent → child
+inheritance.
 
 Do **not** grant `special:user:*` on the feed directory directly (e.g. `alva fs
 grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`).
@@ -860,25 +862,32 @@ feed.def("metrics", {
 alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
 ```
 
-### Step 3: Make it public
+### Step 3: Deploy as a cronjob (required for live playbooks)
 
 ```bash
-# Look up the feed's numeric id, then publish. set-access writes is_public +
-# the ALFS read grant together — do not grant special:user:* by hand.
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
+```
+
+### Step 4: Publish the automation
+
+```bash
+# Writes the `feeds` row — the feed only gets a numeric id after this step.
+alva automation publish --name btc-ema --version 1.0.0 --cronjob-id <id> --description "BTC close + EMA10"
+```
+
+### Step 5: Make it public
+
+```bash
+# Now the feed has an id. set-access writes is_public + the ALFS read grant
+# together — do not grant special:user:* by hand.
 alva feed list
 alva feed set-access --id <feed_id> --access public
 ```
 
-### Step 4: Read from any client
+### Step 6: Read from any client
 
 ```bash
 alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100'
-```
-
-### Step 5: Deploy as a cronjob (required for live playbooks)
-
-```bash
-alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
 ---

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -205,7 +205,7 @@ request). Do not write fresh files from scratch.
    `alva automation publish --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
    — this writes the `feeds` row, so the feed now has a numeric id.
 5. **Make public** (only after step 4 — the id does not exist before publish):
-   `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
+   `alva feed set-visibility --id <feed_id> --visibility public` (get `<feed_id>` from
    `alva feed list`). This sets `is_public` and the ALFS read grant together —
    do not grant `special:user:*` on the feed directory by hand.
 6. **Write the edited HTML** to ALFS after updating data paths to point to your

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -199,8 +199,10 @@ request). Do not write fresh files from scratch.
    agent tool mode; shell-only fallback:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
-3. **Grant** public read:
-   `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
+3. **Publish** (make public):
+   `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
+   `alva feed list`). This sets `is_public` and the ALFS read grant together —
+   do not grant `special:user:*` on the feed directory by hand.
 4. **Deploy cronjob**:
    `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
 5. **Publish automation**:

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -199,14 +199,15 @@ request). Do not write fresh files from scratch.
    agent tool mode; shell-only fallback:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
-3. **Publish** (make public):
+3. **Deploy cronjob**:
+   `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
+4. **Publish automation**:
+   `alva automation publish --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
+   — this writes the `feeds` row, so the feed now has a numeric id.
+5. **Make public** (only after step 4 — the id does not exist before publish):
    `alva feed set-access --id <feed_id> --access public` (get `<feed_id>` from
    `alva feed list`). This sets `is_public` and the ALFS read grant together —
    do not grant `special:user:*` on the feed directory by hand.
-4. **Deploy cronjob**:
-   `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
-5. **Publish automation**:
-   `alva automation publish --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
 6. **Write the edited HTML** to ALFS after updating data paths to point to your
    own feed. Use the ALFS write/edit tool in agent tool mode; shell-only
    fallback:


### PR DESCRIPTION
## Summary

The feed skill docs taught agents to make a feed public by writing the ALFS grant directly (`alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`). That bypasses `feeds.is_public` (the DB source of truth), creating drift: ALFS says public while the DB/UI say private. The reconciler can't heal it for a standalone feed and can silently revert it when a referencing playbook reconciles.

Replaced every such publish instruction with `alva feed set-access --id <feed_id> --access public|private`, which flips `is_public` and the ALFS grant together. Each site gets a brief why-not-raw-grant note.

## Files

`feed-sdk.md`, `feed-lifecycle.md`, `deployment.md`, `remix-workflow.md`, `api/filesystem.md`, `SKILL.md` (publish steps + HARD-GATE / lifecycle summaries).

Legitimate `user:<id>` file-share grants are kept; only the `special:user:*`/`+` publish-a-feed instructions were removed. `setPublicRead` as a generic SDK primitive reference is left as-is (not a feed-publish instruction).

Pairs with the toolkit-ts `feed set-access` command and the gateway route + `/fs/grant` fence.