### PR TITLE
docs(alva): clarify automation deploy boundary

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -39,7 +39,7 @@ The main objects are:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | Data Skills        | 250+ structured Arrays endpoints for equities, options, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
 | Runtime script     | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs.                                                                          | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK.                                            |
-| Feed               | A persistent data pipeline that writes time-series or grouped outputs to ALFS and can back playbooks or alerts.                                              | Data needs freshness, history, public reads, charts, release, or push.                                         |
+| Feed               | The persistent data pipeline and identity (`feed_id`) that writes outputs to ALFS. `alva automation` is its product-facing lifecycle CLI; `alva deploy` cronjobs produce its data. | Data needs freshness, history, public reads, charts, release, or push.                                         |
 | Playbook           | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`.                                                                                   | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface.                          |
 | Skillhub blueprint | A catalog methodology addressed by `/use-skill:<username>/<name>` or discovered from a user skill/method reference.                                          | The user references a skill/method, or a task matches an official template family.                             |
 | Altra              | The Feed SDK trading engine for event-driven backtesting and signal feeds.                                                                                   | Any strategy, simulation, signal target, portfolio, order, equity curve, or rebalancing logic.                 |
@@ -391,7 +391,8 @@ reusable dataset, or future answer.
 Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
 short lifecycle is: write schema and logic to ALFS, `alva run`, grant public
-read if needed, deploy, then `alva automation publish`.
+read if needed, create the producer cronjob with `alva deploy`, then publish
+the user-facing automation data source with `alva automation publish`.
 
 Before automation publish, satisfy `before-automation-publish`: fresh run,
 expected shape, needed grants, public read verification, and non-empty data for
@@ -674,8 +675,8 @@ text does not fully cover.
 | `sdk`                | Runtime library discovery. See [data-skills.md](references/data-skills.md#runtime-libraries-are-separate).                                                                            |
 | `fs`                 | ALFS reads/writes/grants/time-series suffixes and shared modules under `~/library`. Must read [api/filesystem.md](references/api/filesystem.md) for synth suffixes and grant gotchas. |
 | `run`                | Execute jagent JS. See [jagent-runtime.md](references/jagent-runtime.md).                                                                                                             |
-| `deploy`             | Cronjob lifecycle. See [deployment.md](references/deployment.md).                                                                                                                     |
-| `automation`         | Product-facing feed publish/lifecycle (`publish`, `list`, `stop`, `resume`, `delete`). Must read [feed-lifecycle.md](references/feed-lifecycle.md).                                   |
+| `deploy`             | Cronjob lifecycle for producer scripts: schedule, args, trigger, runs, logs. See [deployment.md](references/deployment.md).                                                           |
+| `automation`         | Product-facing lifecycle CLI for feeds (`list`, `inspect`, `publish`, `stop`, `resume`, `delete`). Must read [feed-lifecycle.md](references/feed-lifecycle.md).                         |
 | `release`            | Playbook draft/release; the release reference also covers automation publish metadata extras. Must read [api/release.md](references/api/release.md).                                   |
 | `lint playbook`      | Design-system linter, same gate as release. See [design-contract.yaml](references/design-contract.yaml).                                                                              |
 | `skillhub`           | Curated methodology blueprints. See [request-routing.md](references/request-routing.md#skillhub-blueprint).                                                                           |

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -9,7 +9,7 @@ The deploy CLI manages producer cronjobs:
 
 | Group         | Manages                                                | Common commands                                             |
 | ------------- | ------------------------------------------------------ | ----------------------------------------------------------- |
-| `alva deploy` | Cronjob producers (schedule + entry script + run logs) | `create`, `list`, `update`, `delete`, `pause`, `resume`, `trigger`, `runs`, `run-logs` |
+| `alva deploy` | Cronjob producers (schedule + entry script + run logs) | `create`, `list`, `get`, `update`, `delete`, `pause`, `resume`, `trigger`, `runs`, `run-logs` |
 
 ---
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -1,17 +1,15 @@
 # Deployment Guide
 
-Deploy scripts as cronjobs for scheduled, automated execution and manage the
-downstream feed / playbook resources they produce. This is essential for feeds
-that need regular updates (e.g. hourly price data), recurring tasks, and for
-cleaning up when a deployment is retired or replaced.
+Deploy scripts as cronjobs for scheduled, automated execution. A deploy cronjob
+is the subordinate producer for a feed: it runs the source script, creates or
+refreshes feed data, and exposes run history/logs. The feed's lifecycle is
+managed through `alva automation`; see [feed-lifecycle.md](feed-lifecycle.md).
 
-The product-facing lifecycle CLI groups:
+The deploy CLI manages producer cronjobs:
 
-| Group             | Manages                                      | Common commands                              |
-| ----------------- | -------------------------------------------- | -------------------------------------------- |
-| `alva deploy`     | Cronjobs (schedule + entry script)           | `create`, `list`, `update`, `delete`, `runs` |
-| `alva automation` | Published automation records + active majors | `publish`, `list`, `delete`                  |
-| `alva playbook`   | Published playbook records                   | `list`, `delete`                             |
+| Group         | Manages                                                | Common commands                                             |
+| ------------- | ------------------------------------------------------ | ----------------------------------------------------------- |
+| `alva deploy` | Cronjob producers (schedule + entry script + run logs) | `create`, `list`, `update`, `delete`, `pause`, `resume`, `trigger`, `runs`, `run-logs` |
 
 ---
 
@@ -178,18 +176,19 @@ deletion gotcha — the help text is authoritative on flags.
 **What each group manages.**
 
 - `alva deploy` — the **cronjob** (schedule + entry script + args). Lives in the
-  `cronjobs` table.
-- `alva automation` — the **published automation record + active majors** (the
-  row written by `alva automation publish`, consumed by the push-fanout path).
-  Lives in `feeds` / `feed_majors`.
+  `cronjobs` table and belongs to a feed.
+- `alva automation` — the product-facing lifecycle CLI for the same underlying
+  feed object; ids are feed ids, and `stop` / `resume` delegate to the feed's
+  producer cronjob. Feed publication state lives in `feeds` / `feed_majors`.
 - `alva playbook` — the **published playbook** (rendered HTML + display_name +
   visibility + ACL). Lives in `playbooks` and is surfaced at
   `https://alva.ai/u/<username>/playbooks/<name>`.
 
-These three move in lockstep at create time (`alva deploy create` →
-`alva automation publish` → `alva release playbook`) but each has its own
-lifecycle row. Deleting one does **not** automatically delete the others — see
-the cascade notes in each `--help`.
+Creation usually moves in order (`alva deploy create` →
+`alva automation publish` → `alva release playbook`), but the producer
+cronjob, feed publication rows, and playbook row are stored separately.
+Deleting one does **not** automatically delete the others — see the cascade
+notes in each `--help`.
 
 `alva automation publish` also accepts `--agent-type alpi` to mark a feed whose
 alpi agent appends the owner's editable `AGENTS.md` instructions — see

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -2,6 +2,9 @@
 
 Feeds are persistent data pipelines. Use them whenever data needs freshness,
 history, public reads, charts, playbook backing, push sidecars, or release.
+The feed is the object and identity; `alva automation` is the product-facing
+lifecycle CLI for that same feed, while an `alva deploy` cronjob is its
+subordinate data producer.
 
 For API detail and examples, read [feed-sdk.md](feed-sdk.md). For scheduled
 jobs, read [deployment.md](deployment.md). For runtime constraints, read


### PR DESCRIPTION
## Summary
- clarify that `alva automation` is the user-facing automation/feed data-source lifecycle, including `inspect`
- frame `alva deploy` as the cronjob producer layer that creates or refreshes automation data
- update the feed lifecycle and deployment references so the priority is less ambiguous

## Validation
- `git diff --check`
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`
- `alva automation --help`
