### PR TITLE
docs(alva): clarify alert and trigger verification

### DIFF
--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -126,7 +126,8 @@ Both return the updated cronjob object.
 
 Fire the cronjob once, immediately. Returns the Hatchet workflow run id at
 enqueue — async; the `cronjob_runs` row appears only after the worker finishes
-the run.
+the run. A missing row during the first few minutes means the run is still
+queued or executing, not that scheduling failed.
 
 ```bash
 alva deploy trigger --id 42
@@ -143,6 +144,11 @@ while ! ROW=$(alva deploy runs --id 42 --first 5 \
 done
 echo "$ROW" | jq '{id, status, error}'
 ```
+
+If the matching row has not appeared within a short poll window, say that
+completion is still pending and keep the `workflow_run_id`; do not tell the
+user delivery or scheduling failed. Use `alva deploy runs` later to confirm the
+terminal row.
 
 Use _after_ deploy to confirm the full cronjob path is wired correctly. For
 iterating on script logic without Hatchet, use `alva run` instead.

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -53,8 +53,10 @@ skip notifications.
 ## Inventory And Unsubscribe
 
 - `alva alert list --first 200` — rows carry `kind`, playbook identity,
-  `following`, `target_status`. If `items` < `total_count`, keep paginating;
-  never report a truncated page as the full inventory.
+  `playbook_followed`/`following` only for PLAYBOOK rows, and
+  `target_status`. `FEED_ALERT` rows omit playbook-follow fields; an `ACTIVE`
+  FEED alert row is the alert opt-in state. If `items` < `total_count`, keep
+  paginating; never report a truncated page as the full inventory.
 - `alva alert follows --limit 100` — the playbook follow list. Keep paginating
   with `--cursor` when `has_next` is true.
 - Disable by name (`alva alert disable --playbook owner/name` or


### PR DESCRIPTION
## Summary
- clarify that FEED_ALERT rows omit playbook-follow fields and ACTIVE FEED_ALERT means alert opt-in
- clarify that a deploy trigger row can appear only after completion and short polling misses are pending, not scheduling failure

Links alva-ai/mono-meta#713.

## Tests
- git diff --check
- bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh /Users/ming/workspace/alva/mono-meta/code/public/skills/.worktrees/alert-verifiability-fix/skills/alva