### PR TITLE
docs(alva): robinhood single-leg options and signals/filtered dossier output

### DIFF
--- a/skills/alva/references/api/broker.md
+++ b/skills/alva/references/api/broker.md
@@ -50,7 +50,7 @@ markets` per venue. Do not assume; check. Notably:
 | Venue | Assets | Paper (`testnet`) | Idempotency | Notes |
 | ----- | ------ | ----------------- | ----------- | ----- |
 | `alpaca` | US equities + crypto + options | yes | coid wired | |
-| `robinhood` | US equities (long only) | **no** | **`noCoidLookup`** | a paper-provisioned account is rejected; a lost order id can't be reconciled — treat writes conservatively |
+| `robinhood` | US equities + single-leg options (long only) | **no** | **`noCoidLookup`** | a paper-provisioned account is rejected; a lost order id can't be reconciled — treat writes conservatively |
 | `binance` `okx` `bybit` `gate` `bitget` `coinbase` `hyperliquid` | crypto | per venue testnet | coid wired | ccxt-served |
 
 ## Symbols, account, paper

--- a/skills/alva/references/fintwit.md
+++ b/skills/alva/references/fintwit.md
@@ -98,7 +98,7 @@ Substitute the account's `feed_slug` into
 | --- | --- | --- |
 | `directory/summary`, `info/profile` | Identity | bio, archetype, style, focus, asset class, benchmark, "Alva's take", lifetime win rates, best calls — the one-shot account card |
 | `tweets/views` | Market views | extracted finance views/theses (categorized, stance, bilingual summary + thesis) — qualitative commentary, not only trade calls |
-| `signals/raw`, `quality/live_signals`, `quality/live_mentions` | Signals | classified calls (ticker, direction, intent, tradeability, current stance) |
+| `signals/filtered`, `signals/raw`, `quality/live_signals`, `quality/live_mentions` | Signals | classified calls (ticker, direction, intent, tradeability, current stance); `signals/filtered` is the filtered series trackers read first |
 | `portfolio/summary`, `portfolio/equity`, `portfolio/trades` | Performance | per-profile stats (win rate, ROI, Sharpe, alpha vs SPY), equity curve, trade log |
 | `tweets/raw` | Raw tweets | every ingested tweet + engagement |
 


### PR DESCRIPTION
## Summary
- broker.md venue table: robinhood assets updated to "US equities + single-leg options (long only)" — the table predated trex #106 which added single-leg options (and OHLCV) to the robinhood venue plugin.
- fintwit.md per-KOL dossier table: added `signals/filtered` to the Signals row — the output exists on live feeds (verified via `alva fs read` against a production feed_slug) and is the primary classified surface tracker tooling reads first; it was missing from the table.

Found during a cross-repo consistency audit of skill docs vs implementation (trex plugin source + live feed reads). Related context: alva-ai/skills-internal#3.

## Breaking Changes
None — docs only.

## Database Migrations
None.

## Test Plan
- [x] trex `pkg/venue/robinhood/plugin.go` declares `AssetClassEquity, AssetClassOption` (PR #106)
- [x] Live read of `/alva/home/zet/feeds/<slug>/v1/data/signals/filtered/@last/1` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)