### PR TITLE
docs(alva): require current online listing verification

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -261,11 +261,13 @@ metrics, exchange flows, prediction markets, news, and indexed Twitter/X. The
 mandatory discovery path is `list` -> `summary` -> `endpoint`. Use
 `Authorization: Bearer <ARRAYS_JWT>`, not `X-API-Key`.
 
-Listing status, ticker, exchange, and listing date are time-sensitive facts.
-Never answer them from model memory or infer a negative status from an empty
-lookup; read [data-skills.md](references/data-skills.md#market-identity-and-listing-status)
-for the positive-evidence fallback chain. That reference also owns live ticker
-fit checks for curated thematic or sector baskets.
+Whether a requested listing, ADR/ADS, ticker, exchange, or other security form
+exists is a time-sensitive fact. Never use training knowledge or model memory
+to skip current online verification, even when the remembered answer is
+"private", "unlisted", or "no ADR/ticker"; read
+[data-skills.md](references/data-skills.md#market-identity-and-listing-status)
+for the instrument-resolution and cross-source verification chain. That
+reference also owns live ticker-fit checks for thematic or sector baskets.
 
 Source routing:
 
@@ -785,8 +787,8 @@ Before finishing an Alva task, ask:
   gate, and the Complex Ask Router only for complex judgment asks, before I
   answered?
 - Did I avoid WebSearch/LLM/memory/user-pasted data as factual values?
-- Did I verify current market identity instead of treating a missing lookup as
-  evidence that an issuer is private, unlisted, or delisted?
+- Did I run current online verification before using training knowledge to
+  rule out a listing, ADR/ADS, ticker, or other requested security form?
 - Did I run Data Skills `list` -> `summary` -> `endpoint` before coding calls?
 - Did automation publish pass `before-automation-publish`?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -264,10 +264,10 @@ mandatory discovery path is `list` -> `summary` -> `endpoint`. Use
 Whether a requested listing, ADR/ADS, ticker, exchange, or other security form
 exists is a time-sensitive fact. Never use training knowledge or model memory
 to skip current online verification, even when the remembered answer is
-"private", "unlisted", or "no ADR/ticker"; read
-[data-skills.md](references/data-skills.md#market-identity-and-listing-status)
-for the instrument-resolution and cross-source verification chain. That
-reference also owns live ticker-fit checks for thematic or sector baskets.
+"private", "unlisted", or "no ADR/ticker". A missing or single-source negative
+result is not proof of nonexistence; check another current source or report the
+status as unverified. For thematic or sector baskets, verify ticker fit with
+live company-detail data; do not trust memory.
 
 Source routing:
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -254,13 +254,18 @@ becoming a feed, cronjob, signal, or playbook.
 
 #### Data Access: Data Sources
 
-Data Skills are the primary source for structured financial facts: prices,
-klines, fundamentals, estimates, insider and senator trades, ownership, options
-chains and Greeks, macro, on-chain metrics, exchange flows, prediction markets,
-news, and indexed Twitter/X. The mandatory discovery path is `list` -> `summary`
--> `endpoint`. Use `Authorization: Bearer <ARRAYS_JWT>`, not `X-API-Key`. For
-curated thematic or sector baskets, verify ticker fit with live company-detail
-data such as `getStockCompanyDetail`; do not trust memory.
+Data Skills are the primary source for structured financial facts: market
+identity and listing status, prices, klines, fundamentals, estimates, insider
+and senator trades, ownership, options chains and Greeks, macro, on-chain
+metrics, exchange flows, prediction markets, news, and indexed Twitter/X. The
+mandatory discovery path is `list` -> `summary` -> `endpoint`. Use
+`Authorization: Bearer <ARRAYS_JWT>`, not `X-API-Key`.
+
+Listing status, ticker, exchange, and listing date are time-sensitive facts.
+Never answer them from model memory or infer a negative status from an empty
+lookup; read [data-skills.md](references/data-skills.md#market-identity-and-listing-status)
+for the positive-evidence fallback chain. That reference also owns live ticker
+fit checks for curated thematic or sector baskets.
 
 Source routing:
 
@@ -780,6 +785,8 @@ Before finishing an Alva task, ask:
   gate, and the Complex Ask Router only for complex judgment asks, before I
   answered?
 - Did I avoid WebSearch/LLM/memory/user-pasted data as factual values?
+- Did I verify current market identity instead of treating a missing lookup as
+  evidence that an issuer is private, unlisted, or delisted?
 - Did I run Data Skills `list` -> `summary` -> `endpoint` before coding calls?
 - Did automation publish pass `before-automation-publish`?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -72,31 +72,37 @@ Direct latest-price routing:
 
 ## Market Identity And Listing Status
 
-Treat whether an issuer is public, private, unlisted, or delisted, plus its
-ticker, exchange, and listing date, as time-sensitive market facts. Never use
-model memory as the answer.
+Treat whether an issuer or requested security form is public, private,
+unlisted, or delisted, plus its ticker, exchange, and listing date, as
+time-sensitive market facts. Training knowledge may suggest search terms, but
+it must never decide that an online query is unnecessary or ineligible.
 
-1. Resolve the current entity and aliases. For US issuers, query company detail
-   by name when the symbol is unknown and by symbol when it is known. For
-   non-US issuers, try the exact dotted-suffix symbol against non-US company
-   detail.
-2. Read the returned identity fields, including `symbol`, `exchange`,
-   `is_listed`, and `ipo_date` when present. For non-US listings, remember that
-   company-detail coverage is only a curated subset.
-3. If the symbol is unknown, the listing may be recent, or Data Skills returns
-   no match, use `searchPerplexityFinance` with the legal/company name, aliases,
-   an explicit as-of date, and the requested identity fields. Inspect its
-   sources and prefer current exchange, regulator, or issuer/investor-relations
-   evidence.
-4. For a recent IPO, the IPO planning calendar is discovery evidence only. A
-   past `Expected` row is unknown; confirm the completed listing with positive
-   company-profile, quote/kline, exchange, regulator, or issuer evidence.
+1. Run current online verification before concluding that the requested
+   instrument does or does not exist. Resolve the issuer's current legal name
+   and aliases, then preserve the security form the user asked about, such as
+   primary or secondary ordinary shares, ADR/ADS, GDR, or an OTC-traded
+   security. Evidence for one form does not establish whether another exists.
+2. Query structured company detail by name when the symbol is unknown and by
+   symbol when it is known. Read identity fields such as `symbol`, `exchange`,
+   `is_listed`, and `ipo_date` when present, but remember that both US and
+   non-US datasets can have coverage or freshness gaps.
+3. Regardless of remembered status, search the exact issuer plus the requested
+   security form. Use `searchPerplexityFinance`, then general or domain-scoped
+   online search when finance search omits the instrument or makes an
+   unsupported negative claim. Search results are discovery only: include an
+   explicit as-of date, open the cited current exchange, regulator, issuer/IR,
+   or equivalent primary source, and evaluate it before using the fact.
+4. For a recent IPO or instrument launch, a planning calendar is discovery
+   evidence only. A past `Expected` row is unknown; confirm completed trading
+   with a current primary source, company profile, or quote/kline.
 
-An empty, 404, or unsupported lookup proves only that the queried source lacks
-coverage. It does not prove that the issuer is private, unlisted, or delisted.
-State the status as unverified unless current positive evidence supports the
-conclusion. If the user says a listing happened, treat that as a freshness
-signal and run this full fallback chain before answering.
+An empty, 404, unsupported, or single-source negative result proves only that
+the queried source did not establish the instrument. It does not prove that the
+issuer is private, unlisted, delisted, or lacks the requested instrument or
+ticker. Continue the cross-source chain or state that status is still
+unverified. Treat the user's claim that a listing exists as a freshness signal
+that requires verification, not as a reason to defend the model's remembered
+answer.
 
 ## Thematic Ticker Curation
 

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -70,6 +70,34 @@ Direct latest-price routing:
   `searchPerplexityFinance`
   before suggesting BYOD.
 
+## Market Identity And Listing Status
+
+Treat whether an issuer is public, private, unlisted, or delisted, plus its
+ticker, exchange, and listing date, as time-sensitive market facts. Never use
+model memory as the answer.
+
+1. Resolve the current entity and aliases. For US issuers, query company detail
+   by name when the symbol is unknown and by symbol when it is known. For
+   non-US issuers, try the exact dotted-suffix symbol against non-US company
+   detail.
+2. Read the returned identity fields, including `symbol`, `exchange`,
+   `is_listed`, and `ipo_date` when present. For non-US listings, remember that
+   company-detail coverage is only a curated subset.
+3. If the symbol is unknown, the listing may be recent, or Data Skills returns
+   no match, use `searchPerplexityFinance` with the legal/company name, aliases,
+   an explicit as-of date, and the requested identity fields. Inspect its
+   sources and prefer current exchange, regulator, or issuer/investor-relations
+   evidence.
+4. For a recent IPO, the IPO planning calendar is discovery evidence only. A
+   past `Expected` row is unknown; confirm the completed listing with positive
+   company-profile, quote/kline, exchange, regulator, or issuer evidence.
+
+An empty, 404, or unsupported lookup proves only that the queried source lacks
+coverage. It does not prove that the issuer is private, unlisted, or delisted.
+State the status as unverified unless current positive evidence supports the
+conclusion. If the user says a listing happened, treat that as a freshness
+signal and run this full fallback chain before answering.
+
 ## Thematic Ticker Curation
 
 When building sector or thematic dashboards with curated ticker lists, do not

--- a/skills/alva/references/data-skills.md
+++ b/skills/alva/references/data-skills.md
@@ -70,40 +70,6 @@ Direct latest-price routing:
   `searchPerplexityFinance`
   before suggesting BYOD.
 
-## Market Identity And Listing Status
-
-Treat whether an issuer or requested security form is public, private,
-unlisted, or delisted, plus its ticker, exchange, and listing date, as
-time-sensitive market facts. Training knowledge may suggest search terms, but
-it must never decide that an online query is unnecessary or ineligible.
-
-1. Run current online verification before concluding that the requested
-   instrument does or does not exist. Resolve the issuer's current legal name
-   and aliases, then preserve the security form the user asked about, such as
-   primary or secondary ordinary shares, ADR/ADS, GDR, or an OTC-traded
-   security. Evidence for one form does not establish whether another exists.
-2. Query structured company detail by name when the symbol is unknown and by
-   symbol when it is known. Read identity fields such as `symbol`, `exchange`,
-   `is_listed`, and `ipo_date` when present, but remember that both US and
-   non-US datasets can have coverage or freshness gaps.
-3. Regardless of remembered status, search the exact issuer plus the requested
-   security form. Use `searchPerplexityFinance`, then general or domain-scoped
-   online search when finance search omits the instrument or makes an
-   unsupported negative claim. Search results are discovery only: include an
-   explicit as-of date, open the cited current exchange, regulator, issuer/IR,
-   or equivalent primary source, and evaluate it before using the fact.
-4. For a recent IPO or instrument launch, a planning calendar is discovery
-   evidence only. A past `Expected` row is unknown; confirm completed trading
-   with a current primary source, company profile, or quote/kline.
-
-An empty, 404, unsupported, or single-source negative result proves only that
-the queried source did not establish the instrument. It does not prove that the
-issuer is private, unlisted, delisted, or lacks the requested instrument or
-ticker. Continue the cross-source chain or state that status is still
-unverified. Treat the user's claim that a listing exists as a freshness signal
-that requires verification, not as a reason to defend the model's remembered
-answer.
-
 ## Thematic Ticker Curation
 
 When building sector or thematic dashboards with curated ticker lists, do not


### PR DESCRIPTION
## What changed

- prohibit training knowledge or model memory from screening out current online verification
- classify listing, ADR/ADS, ticker, exchange, and other security-form existence as time-sensitive facts
- treat a missing or single-source negative result as insufficient evidence of nonexistence
- add a final completion check for query-first verification

## Why

The skill prohibited stale memory for financial values, but it did not stop a model from using remembered listing status as a pre-query eligibility filter. That allowed the agent to decide an issuer was private, unlisted, or lacked an ADR before running current online verification.

The failure reproduced across providers: finance search returned only SK hynix's Korean ordinary shares and concluded there was no ADR, while a current general search surfaced the July 2026 Nasdaq ADR launch and market records. A single provider's omission is not proof that the requested instrument does not exist.

The fix intentionally lives only in `SKILL.md`, which the agent always reads. SpaceX and SK hynix remain regression evidence rather than documentation examples; existing data-source references continue to own query mechanics.

## Validation

- `git diff --check`
- Alva Skill mechanical audit: no broken links or orphan references
- cold judgment audit: no bloat, duplication, cover/contain bleed, weak pointers, routing drift, gate breakage, or module-map drift
- verified the net PR diff changes only `skills/alva/SKILL.md`
- textual regression assertions for query-first verification and the single-source-negative guard
