### PR TITLE
docs(alva): teach bounded channel loop lifecycle

### DIFF
--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -157,6 +157,26 @@
       }
     },
     {
+      "id": "scenario.channel-loop-bounds",
+      "group": "scenarios.loop",
+      "prompt": "Starting tomorrow morning, re-check NVDA in this channel every 15 minutes and stop at 09:30 ET or after 20 runs.",
+      "description": "Continued scheduled Agent work in the same channel routes to a bounded Channel Loop instead of a feed-backed push automation.",
+      "expect": {
+        "route": "Channel Loop",
+        "references": [
+          "deployment.md"
+        ],
+        "behaviors": [
+          "alva loop create",
+          "--start",
+          "RFC3339 timestamps must include a timezone",
+          "At least one of `--until` or `--runs` is required",
+          "`--expires-in` is removed",
+          "preserves the cronjob row with status `completed`"
+        ]
+      }
+    },
+    {
       "id": "scenario.backtest-strategy",
       "group": "scenarios.strategy",
       "prompt": "Backtest a weekly NVDA momentum strategy and show drawdowns.",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -39,6 +39,7 @@ The main objects are:
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | Data Skills        | 250+ structured Arrays endpoints for equities, options, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
 | Runtime script     | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs.                                                                          | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK.                                            |
+| Channel loop       | Bounded scheduled Agent turns that continue one channel's conversation toward a goal.                                                                        | The user wants the Agent to re-check or keep working in the same channel until a condition, time, or run bound. |
 | Feed               | The persistent data pipeline and identity (`feed_id`) that writes outputs to ALFS. `alva automation` is its product-facing lifecycle CLI; `alva deploy` cronjobs produce its data. | Data needs freshness, history, public reads, charts, release, or push.                                         |
 | Playbook           | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`.                                                                                   | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface.                          |
 | Skillhub blueprint | A catalog methodology addressed by `/use-skill:<username>/<name>` or discovered from a user skill/method reference.                                          | The user references a skill/method, or a task matches an official template family.                             |
@@ -82,6 +83,8 @@ Think in artifacts:
 - **Answer**: a direct response grounded in fresh data. No feed or release
   required unless the user asks for persistence.
 - **Script**: an Alva Cloud computation that may be run manually or scheduled.
+- **Loop**: bounded scheduled Agent turns that re-enter one channel; no feed or
+  playbook is required unless the goal also needs durable data or a public UI.
 - **Feed**: the persistent output of a script, with schema, history, grants, and
   release metadata.
 - **Playbook**: a browser surface over feeds, README, design rules, and release
@@ -197,6 +200,7 @@ that section as mandatory, not optional debugging material.
 | `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
 | backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
 | recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Build a push-capable feed and verify alert or group subscription plus sidecar output.                                                                                                    |
+| keep researching, checking, or working in this channel on a cadence until a condition, time, or run count                              | Channel Loop                        | Read [deployment.md](references/deployment.md#channel-loops); use `alva loop create`, set `--start` for a future start, and provide at least one of `--until` or `--runs`.                |
 | `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
 | `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
 | "does Alva have X?"                                                                                                                     | Capability Verification             | Run `alva data-skills list` and search for `<topic>` before saying no.                                                                                                                   |
@@ -383,10 +387,21 @@ are sourced facts, computed values, or inference.
 
 Enter this tree when the user asks Alva to keep something running, reusable,
 shareable, inspectable, or actionable. The tree is broader than playbooks: a
-script, feed, alert, signal, model output, or trading analysis may be the right
-artifact without a hosted UI. Enter the playbook branch only for hosted apps,
-share URLs, remixes, annotation edits, release/version updates, or playbook
-alert/group-subscription setup.
+script, channel loop, feed, alert, signal, model output, or trading analysis
+may be the right artifact without a hosted UI. Enter the playbook branch only
+for hosted apps, share URLs, remixes, annotation edits, release/version
+updates, or playbook alert/group-subscription setup.
+
+#### Channel Goal Loops
+
+Use a channel loop when the Agent itself must return to the same conversation
+on a cadence, keep the goal and channel context, and stop on a bounded
+lifecycle. Read [deployment.md](references/deployment.md#channel-loops). Use
+the default backend-clock `now`, pass `--start now` explicitly, or set a future
+RFC3339 timestamp. Every loop requires `--until`, `--runs`, or both. Do not use
+the removed `--expires-in` flag. Use a feed and Automation / Push instead when
+the durable artifact is data or a notification pipeline rather than continued
+Agent work in the channel.
 
 #### Data Product Layer: Feed Lifecycle And Automation
 
@@ -798,6 +813,8 @@ Before finishing an Alva task, ask:
 - Did backtesting or signal work use Altra?
 - Did push work verify the publisher sidecar plus the personal alert or group
   subscription target?
+- Did a channel loop use the default or an explicit `--start`, plus a hard
+  `--until` or `--runs` bound, without the removed `--expires-in` flag?
 - If Alva-owned behavior blocked the task, did I offer the confirmed feedback
   flow after reading [api/feedback.md](references/api/feedback.md)?
 - Did the final response describe the delivered result without leaking

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -194,9 +194,20 @@ loop-runner and packs your goal/channel into the args, so you write no script.
 alva loop create \
   --channel-id 12345 \
   --name nvda-premarket-setup \
-  --goal 'Watch NVDA pre-market for a break above the pre-market high with 5-minute volume at least 2x the prior five-bar average. If confirmed, post one alert here with price, time, and evidence. If 09:30 ET passes first, post "no signal". After either outcome, stop this loop: run alva deploy list, find nvda-premarket-setup, then run alva deploy delete --id <id>. Otherwise finish this tick without an alert.' \
+  --goal 'Watch NVDA pre-market for a break above the pre-market high with 5-minute volume at least 2x the prior five-bar average. If confirmed, post one alert here with price, time, and evidence, then delete this loop by name. Otherwise finish this tick without an alert.' \
   --cron '*/15 * * * *' \
-  --expires-in 1d
+  --start now \
+  --until '2026-07-15T09:30:00-04:00'
+```
+
+Or start at a future time and stop after an exact number of admitted runs:
+
+```bash
+alva loop create \
+  --goal 'Check the next 12 hourly intervals and post only material changes.' \
+  --cron '0 * * * *' \
+  --start '2026-07-15T08:00:00-04:00' \
+  --runs 12
 ```
 
 The relay wraps the goal in an automated user-turn wake each tick, with
@@ -204,23 +215,36 @@ platform-owned context before it and loop policy after it. Keep `--goal`
 focused on the business objective, including concrete stop conditions and the
 stop action.
 
-| Flag           | Required | Description                                                        |
-| -------------- | -------- | ------------------------------------------------------------------ |
-| --goal         | yes      | Instruction run each tick                                          |
-| --cron         | yes      | Cron expression                                                    |
-| --channel-id   | no       | Target channel. Omit ⇒ your DM / Alva Agent channel               |
-| --expires-in   | no       | Lifetime `30m`/`24h`/`7d`, or `never` (discouraged). Default `7d`  |
-| --name         | no       | Stable job name; recommended when the goal stops its own loop      |
+| Flag         | Required    | Description                                                                 |
+| ------------ | ----------- | --------------------------------------------------------------------------- |
+| --goal       | yes         | Instruction run each tick                                                   |
+| --cron       | yes         | Cron expression                                                             |
+| --channel-id | no          | Target channel. Omit ⇒ your DM / Alva Agent channel                        |
+| --start      | no          | Inclusive start: `now` (default, resolved by backend clock) or RFC3339       |
+| --until      | conditional | Exclusive RFC3339 cutoff; required when `--runs` is absent                   |
+| --runs       | conditional | Positive maximum admitted runs after start; required when `--until` is absent |
+| --name       | no          | Stable job name; recommended when the goal may stop its own loop early      |
+
+At least one of `--until` or `--runs` is required. When both are present, the
+first exhausted bound completes the loop. RFC3339 timestamps must include a
+timezone (`Z` or `±HH:MM`). `--expires-in` is removed with no compatibility
+alias; express the real cutoff with `--until` or the exact count with `--runs`.
+
+Only admitted runs increment `run_count`: attempts before `--start`, at or
+after `--until`, or beyond `--runs` do not dispatch an Agent turn. The final
+admitted run still executes. Natural exhaustion removes the scheduler trigger
+and preserves the cronjob row with status `completed` for inspection.
 
 **Channel id**: read `channel-id` from the
 `<session-prefill-channel-memory channel-id="…">` block in your context — that
 is the current channel's id. There is no slug→id lookup.
 
-**Stopping a loop**: make the goal self-terminating: give explicit success and
-expiry conditions, then tell the agent to run `alva deploy list`, match the
-loop by its `--name`, and run `alva deploy delete --id <id>`. There is no
-`alva loop stop`; `pause` also stops future ticks. Left alone, a loop terminates
-at its `end_at` (default 7 days).
+**Stopping a loop**: the platform bounds are the hard stop. For success that
+can happen earlier, make the goal self-terminating: tell the Agent to run
+`alva deploy list`, match the loop by its `--name`, and run
+`alva deploy delete --id <id>`. There is no `alva loop stop` or list command;
+use `alva deploy` for lifecycle inspection and cleanup. `pause` also stops
+future ticks without deleting the row.
 
 ---
 

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -13,9 +13,10 @@ Decision order:
    to answers and artifacts.
 1. If the user wants an explanation, comparison, valuation, rank, or current
    market fact in chat, route to Financial Analysis / Ask Question.
-2. If the user wants persistence, cadence, alerting, trading signals, or a
-   reusable dataset, route to the durable artifact that fits, not automatically
-   to a playbook.
+2. If the Agent itself must return to the same channel on a cadence, route to a
+   bounded Channel Loop. If the durable artifact is data, alerting, a trading
+   signal, or a reusable dataset, route to that artifact instead, not
+   automatically to a playbook.
 3. If the user wants a hosted app, share URL, remix, annotation edit, release,
    or playbook version update, enter the Playbook Creation tree.
 
@@ -27,6 +28,7 @@ Decision order:
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. |
 | Automation / Push | Build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
+| Channel Loop | Re-enter the same channel with scheduled Agent turns until a condition, exclusive cutoff, or exact run limit. Read [deployment.md](deployment.md#channel-loops), set `--start` for a future start, and provide at least one of `--until` or `--runs`. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |
 


### PR DESCRIPTION
## Summary
- replace the removed expires-in loop guidance with start, until, and runs lifecycle bounds
- route scheduled same-channel Agent work to Channel Loop while keeping feed-backed alerts under Automation / Push
- document admission, completion, and early self-delete semantics
- add a regression scenario for future-start, time-bounded, run-bounded loops

## Testing
- quick_validate.py skills/alva
- skill-doc-eval.mjs: 51/51 cases, 466/466 checks
- mutation-smoke.mjs: 4/4 mutations failed as expected
- jq empty and git diff --check