### PR TITLE
docs(alva): rely on alpi runtime defaults

### DIFF
--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -15,13 +15,9 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 // @ts-nocheck
 /** alva run --entry-path '~/tasks/run-result.js' */
 (async () => {
-	const { Agent, Type, getModel } = require("@alva/pi");
+	const { Agent, Type } = require("@alva/pi");
 	const args = require("env").args || {};
 
-	const provider = String(args.provider || "").trim();
-	const modelId = String(args.model || "").trim();
-	if (!provider || !modelId) throw new Error("Pass args.provider and args.model.");
-	const model = getModel(provider, modelId);
 	const prompt =
 		args.prompt ||
 		"Use add for 100+23, then subtract 7 from that sum. Reply with only the final number.";
@@ -29,7 +25,6 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 	const agent = new Agent({
 		initialState: {
 			systemPrompt: "Use add and subtract tools. Reply with only the final number.",
-			model,
 			tools: [
 				{
 					name: "add",
@@ -77,11 +72,11 @@ from secret-manager, never inline it in the script**:
 
 ```javascript
 const agent = new Agent({
-	initialState: { /* systemPrompt, model, tools */ },
+	initialState: { /* systemPrompt, tools */ },
 	// BYOK: jagent passes this key straight through to the provider and does
 	// NOT charge Alva platform credits for the call. Store the key with
 	// secret-manager; never paste a raw key into the script.
-	getApiKey: () => require("secret-manager").loadPlaintext("MY_ANTHROPIC_KEY"),
+	getApiKey: () => require("secret-manager").loadPlaintext("MY_PROVIDER_KEY"),
 });
 ```
 
@@ -100,7 +95,6 @@ events unless the script truly needs progress updates.
 | Field | Required | Description |
 | --- | --- | --- |
 | `initialState.systemPrompt` | no | Fixed instructions for the reasoning step. |
-| `initialState.model` | yes | Caller-selected `getModel(provider, modelId)` result. Pass provider/model through runtime args instead of hardcoding an ID. |
 | `initialState.tools` | no | Tool definitions available to the agent; defaults to none. |
 | `initialState.thinkingLevel` | no | Omit to use the runtime default. |
 | `getApiKey` | no | Omit to use the jagent-managed platform key (default). For BYOK, return your own key loaded via `secret-manager` — passed through to the provider, not billed to platform credits. |
@@ -161,9 +155,6 @@ Guidelines:
 
 ## Patterns & Examples
 
-The snippets below assume `model` was resolved from runtime arguments as shown
-in Quick Start. Keep provider and model selection outside the pattern itself.
-
 ### User-editable instructions — alpi feed
 
 Let the feed owner steer the agent by editing the feed's `AGENTS.md` (their own
@@ -190,7 +181,6 @@ Reply MUST begin with \`{\` and end with \`}\`. No prose, no markdown, no code f
 Output is parsed by JSON.parse with no preprocessing.
 
 Schema: {"summary":"...","changes":["..."],"sentiment":"up|down|neutral"}`,
-		model,
 		tools: [
 			{
 				name: "getIncomeStatements",
@@ -274,7 +264,6 @@ const tools = [
 const agent = new Agent({
 	initialState: {
 		systemPrompt: "Macro-financial analyst. Gather multiple sources before concluding.",
-		model,
 		tools,
 	},
 });
@@ -300,7 +289,6 @@ await feed.run(async (ctx) => {
 	const agent = new Agent({
 		initialState: {
 			systemPrompt: "Analyze each sector. After each, call saveSectorResult.",
-			model,
 			tools: [
 				{
 					name: "saveSectorResult",

--- a/skills/alva/references/alpi.md
+++ b/skills/alva/references/alpi.md
@@ -18,7 +18,10 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 	const { Agent, Type, getModel } = require("@alva/pi");
 	const args = require("env").args || {};
 
-	const model = getModel("openai", args.model || "gpt-5.5");
+	const provider = String(args.provider || "").trim();
+	const modelId = String(args.model || "").trim();
+	if (!provider || !modelId) throw new Error("Pass args.provider and args.model.");
+	const model = getModel(provider, modelId);
 	const prompt =
 		args.prompt ||
 		"Use add for 100+23, then subtract 7 from that sum. Reply with only the final number.";
@@ -45,7 +48,6 @@ inside a deterministic pipeline. The runtime module is `@alva/pi`; use
 					}),
 				},
 			],
-			thinkingLevel: "off",
 		},
 	});
 
@@ -98,9 +100,9 @@ events unless the script truly needs progress updates.
 | Field | Required | Description |
 | --- | --- | --- |
 | `initialState.systemPrompt` | no | Fixed instructions for the reasoning step. |
-| `initialState.model` | yes | `getModel(provider, modelId)` result, usually OpenAI. |
-| `initialState.tools` | yes | Tool definitions available to the agent. |
-| `initialState.thinkingLevel` | no | Use `"off"` for deterministic result-only jobs unless reasoning is needed. |
+| `initialState.model` | yes | Caller-selected `getModel(provider, modelId)` result. Pass provider/model through runtime args instead of hardcoding an ID. |
+| `initialState.tools` | no | Tool definitions available to the agent; defaults to none. |
+| `initialState.thinkingLevel` | no | Omit to use the runtime default. |
 | `getApiKey` | no | Omit to use the jagent-managed platform key (default). For BYOK, return your own key loaded via `secret-manager` — passed through to the provider, not billed to platform credits. |
 
 ### Tool
@@ -159,6 +161,9 @@ Guidelines:
 
 ## Patterns & Examples
 
+The snippets below assume `model` was resolved from runtime arguments as shown
+in Quick Start. Keep provider and model selection outside the pattern itself.
+
 ### User-editable instructions — alpi feed
 
 Let the feed owner steer the agent by editing the feed's `AGENTS.md` (their own
@@ -173,7 +178,7 @@ Read the agent's previous output via feed time-series paths
 (`@last/N`, `@range/{start}..{end}`).
 
 ```javascript
-const { Agent, Type, getModel } = require("@alva/pi");
+const { Agent, Type } = require("@alva/pi");
 const env = require("env");
 const alfs = require("alfs");
 
@@ -185,7 +190,7 @@ Reply MUST begin with \`{\` and end with \`}\`. No prose, no markdown, no code f
 Output is parsed by JSON.parse with no preprocessing.
 
 Schema: {"summary":"...","changes":["..."],"sentiment":"up|down|neutral"}`,
-		model: getModel("openai", "gpt-5.5"),
+		model,
 		tools: [
 			{
 				name: "getIncomeStatements",
@@ -219,7 +224,6 @@ Schema: {"summary":"...","changes":["..."],"sentiment":"up|down|neutral"}`,
 				},
 			},
 		],
-		thinkingLevel: "off",
 	},
 });
 
@@ -232,7 +236,7 @@ Expose multiple domain tools and let the agent decide fetch order from the
 fixed prompt.
 
 ```javascript
-const { Agent, Type, getModel } = require("@alva/pi");
+const { Agent, Type } = require("@alva/pi");
 
 const tools = [
 	{
@@ -270,9 +274,8 @@ const tools = [
 const agent = new Agent({
 	initialState: {
 		systemPrompt: "Macro-financial analyst. Gather multiple sources before concluding.",
-		model: getModel("openai", "gpt-5.5"),
+		model,
 		tools,
-		thinkingLevel: "off",
 	},
 });
 
@@ -285,7 +288,7 @@ Use a tool to persist intermediate results while alpi runs. Partial results can
 survive even if a later turn fails.
 
 ```javascript
-const { Agent, Type, getModel } = require("@alva/pi");
+const { Agent, Type } = require("@alva/pi");
 const { Feed, feedPath, makeDoc, str, num } = require("@alva/feed");
 
 const feed = new Feed({ path: feedPath("sector-scan") });
@@ -297,7 +300,7 @@ await feed.run(async (ctx) => {
 	const agent = new Agent({
 		initialState: {
 			systemPrompt: "Analyze each sector. After each, call saveSectorResult.",
-			model: getModel("openai", "gpt-5.5"),
+			model,
 			tools: [
 				{
 					name: "saveSectorResult",
@@ -313,7 +316,6 @@ await feed.run(async (ctx) => {
 					},
 				},
 			],
-			thinkingLevel: "off",
 		},
 	});
 


### PR DESCRIPTION
## Summary
- remove `getModel` and explicit model selection from every `alpi.md` example
- omit explicit `thinkingLevel: "off"` and use runtime defaults
- keep the BYOK example provider-neutral

## Validation
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (51/51 cases, 466/466 checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (4/4)
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`
- cold-read judgment audit: no findings
- `git diff --check`