### PR TITLE
docs(alva): document feed-only alerts

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -552,7 +552,8 @@
             "before-automation-publish",
             "alva deploy update --id <ID> --push-notify",
             "alva alert enable --automation",
-            "alva alert enable --playbook",
+            "alva alert enable --automation-ids",
+            "There is no playbook alert target",
             "read `@last/1` of the sidecar",
             "do not claim push is set up"
           ]
@@ -762,7 +763,8 @@
         "api/feedback.md",
         "alva feedback --help",
         "alva alert enable --automation",
-        "alva alert enable --playbook",
+        "alva alert enable --automation-ids",
+        "There is no playbook alert target",
         "publish publicly by default",
         "registered UDFs",
         "implementation internals",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -390,7 +390,7 @@ shareable, inspectable, or actionable. The tree is broader than playbooks: a
 script, channel loop, feed, alert, signal, model output, or trading analysis
 may be the right artifact without a hosted UI. Enter the playbook branch only
 for hosted apps, share URLs, remixes, annotation edits, release/version
-updates, or playbook alert/group-subscription setup.
+updates, or playbook publication work.
 
 #### Channel Goal Loops
 
@@ -428,8 +428,7 @@ each feed, ALFS, deploy, and publish step.
 Playbooks are hosted investing apps: dashboards, screeners, thesis trackers,
 backtest surfaces, what-if studies, event studies, or custom interactive tools.
 Enter this branch only when the user wants a hosted/shareable surface, remix,
-annotation edit, release/version update, or playbook alert/group-subscription
-setup.
+annotation edit, release/version update, or playbook publication work.
 
 Read [playbook-creation.md](references/playbook-creation.md) before creating or
 changing the hosted surface. It owns the build order, Browser-safe feed reads,
@@ -525,8 +524,9 @@ authentication, `alva functions` creator registration and allowance tools,
 
 #### Action Layer: Alerts
 
-Alerts are personal notification opt-ins for automations or playbooks. A feed
-may emit `signal/targets` or `notify/message`; both dispatch `feed_alert_ready`.
+Alerts are personal notification opt-ins for automations (feeds). Playbook
+follows are independent and never enable or disable alerts. A feed may emit
+`signal/targets` or `notify/message`; both dispatch `feed_alert_ready`.
 `--push-notify` only marks the publisher capable of alerts. It does not
 subscribe users or bypass preferences.
 
@@ -632,8 +632,8 @@ alert, or playbook.
 ### Hosted Playbook Workflow
 
 Enter this tree when the user wants a hosted app, share URL, dashboard, screener
-app, report surface, remix, annotation edit, release/version update, or playbook
-alert/group-subscription setup. First choose the artifact shape: direct answer,
+app, report surface, remix, annotation edit, or release/version update. First
+choose the artifact shape: direct answer,
 feed, signal, model output, or hosted playbook. For hosted/shareable surfaces,
 turn the request into a data contract before UI work: universe, metrics,
 freshness, output groups, widgets, and release path. Then open
@@ -705,9 +705,9 @@ text does not fully cover.
 | `skillhub`           | Curated methodology blueprints. See [request-routing.md](references/request-routing.md#skillhub-blueprint).                                                                           |
 | `playbooks`          | Trending discovery and `set-visibility`.                                                                                                                                              |
 | `comments`           | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md).                                                                                      |
-| `alert`              | Personal automation/playbook alert opt-ins and history. See [push-notifications.md](references/push-notifications.md).                                                                |
-| `subscriptions`      | Legacy alert/follow compatibility surface. Prefer `alert`, including for follows. See [push-notifications.md](references/push-notifications.md).                                     |
-| `channel`            | Group push subscriptions. See [push-notifications.md](references/push-notifications.md).                                                                                              |
+| `alert`              | Personal FEED alert opt-ins and automation history. See [push-notifications.md](references/push-notifications.md).                                                                    |
+| `subscriptions`      | Playbook follow commands plus FEED alert commands. Following never changes alerts. See [push-notifications.md](references/push-notifications.md).                                    |
+| `channel`            | FEED-only group push subscriptions. See [push-notifications.md](references/push-notifications.md).                                                                                    |
 | `trading`            | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md).                                                                         |
 | `broker`             | Agentic order execution — place/cancel/read across venues (crypto + US equities). Run `alva broker describe` for live commands/capabilities; must read [api/broker.md](references/api/broker.md).                     |
 | `screenshot`         | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot).                                                               |

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -758,9 +758,9 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 `signal/targets` makes the feed push-capable, but delivery still requires the
 cronjob to be created or updated with `--push-notify` and
 `alva automation publish` to bind the feed to that cronjob. Actual delivery also
-requires an explicit personal alert or group subscription to the automation or
-to a playbook that references it. See `references/deployment.md` for the
-deploy/publish flow.
+requires an explicit personal alert or group subscription to the automation's
+feed. A playbook follow does not enable alerts for its feeds. See
+`references/deployment.md` for the deploy/publish flow.
 
 ---
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -54,10 +54,11 @@ feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
 canonical `feed_alert_ready` event with different feed-alert sources. The push
 body is read from the _published_ automation: a cronjob with `--push-notify` but
 no `alva automation publish` dispatches an empty body. Delivery also requires an
-explicit personal alert or group subscription to the automation or to a playbook
-that references the feed; `--push-notify` does not subscribe the owner, any
-user, or any group. For `notify/message`, `<|SKIP_NOTIFICATION|>` in
-`body`/`text` skips the user-visible push while advancing fanout.
+explicit personal alert or group subscription to the automation's feed.
+Following a playbook that references the feed does not enable alerts;
+`--push-notify` does not subscribe the owner, any user, or any group. For
+`notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text` skips the user-visible
+push while advancing fanout.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -162,14 +162,13 @@ await feed.run(async (ctx) => {
 
 Read `@last/N` (where N >= batch size) to get the most recent batch.
 
-### Pattern D: Signal / Playbook Push Notification
+### Pattern D: Signal Feed Push Notification
 
 For feeds that produce actionable signals worth pushing to users with alerts or
-groups subscribed to the feed, or to a playbook that references the feed.
-Write signal records to the **`signal`** group with a **`targets`** output --
-the resulting path `~/feeds/{name}/v{major}/data/signal/targets` is one source
-the platform reads when dispatching the canonical `feed_alert_ready`
-notification event.
+groups subscribed to the feed. Write signal records to the **`signal`** group
+with a **`targets`** output -- the resulting path
+`~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
+when dispatching the canonical `feed_alert_ready` notification event.
 
 The target format follows the same structure used by Altra trading strategies:
 
@@ -190,7 +189,7 @@ const feed = new Feed({ path: feedPath("my-signal") });
 feed.def("signal", {
   targets: makeDoc(
     "Signal Targets",
-    "Actionable signals for playbook notifications",
+    "Actionable signal alerts",
     [
       obj("instruction", [
         str("type"), // "allocate" | "orders"
@@ -234,9 +233,9 @@ await feed.run(async (ctx) => {
 
 When this feed runs as a cronjob with `--push-notify`, the platform reads
 `/data/signal/targets` and dispatches the signal content as `feed_alert_ready`
-to eligible automation/playbook alerts and group subscriptions. Telegram
-delivery chunks long messages at the platform's per-message limit; the feed SDK
-does not require a 500-character summary.
+to eligible FEED alert and group subscribers. Telegram delivery chunks long
+messages at the platform's per-message limit; the feed SDK does not require a
+500-character summary.
 
 **Key points:**
 
@@ -245,10 +244,9 @@ does not require a 500-character summary.
 - `--push-notify` and `alva automation publish --cronjob-id ...` only make the
   feed publisher capable of emitting alerts. They do **not** subscribe any user
   or group.
-- Real delivery requires an explicit alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>` /
-  `--playbook <owner>/<playbook>`, group `/alva subscribe feed <id>` /
-  `/alva subscribe playbook <id>`, or — from inside a playbook iframe — a
+- Real delivery requires an explicit FEED alert/subscription: personal
+  `alva alert enable --automation <owner>/<feed>`, group
+  `/alva subscribe feed <id>`, or — from inside a playbook iframe — a
   parent-confirmed `window.alva.subscribe.propose()` (see
   `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
   never call a subscribe API directly.
@@ -278,8 +276,8 @@ periodic research summaries, heartbeat monitoring, and proactive alerts.
 
 Write the agent's response to the **`notify`** group with a **`message`**
 output. When the cronjob completes with `--push-notify`, the platform reads this
-path and dispatches `feed_alert_ready` to users with alerts or groups subscribed
-to the feed, or to a playbook that references the feed.
+path and dispatches `feed_alert_ready` to users or groups explicitly subscribed
+to the feed.
 
 ```javascript
 const { ask } = require("@alva/alvaask");
@@ -343,11 +341,10 @@ alva automation publish --name daily-briefing --version 1.0.0 \
   dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal alerts or group subscriptions.
-- Real delivery requires an explicit alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>` or
-  `alva alert enable --playbook <owner>/<playbook>`, or group
-  `/alva subscribe feed <feed_id>` / `/alva subscribe playbook <playbook_id>`.
-  For inventory and unsubscribe (including ghost rows of deleted targets), see
+- Real delivery requires an explicit FEED alert/subscription: personal
+  `alva alert enable --automation <owner>/<feed>` or group
+  `/alva subscribe feed <feed_id>`. Following a playbook does not subscribe any
+  of its feeds. For inventory and unsubscribe (including deleted feed rows), see
   [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and
   signal-style notifications.

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -3,7 +3,7 @@
 This is the concrete task guide for building, drafting, releasing, verifying,
 and updating Alva playbooks. Read it for hosted app/share URL, screener app,
 report surface, strategy UI, remix, annotation edit, release, version update,
-and playbook alert/group-subscription tasks.
+and push-after-release checks for backing feeds.
 
 The playbook tree has subroutes: new build, Skillhub-guided build, remix,
 annotation/edit, release/version update, and push after release. Use this guide

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -36,9 +36,10 @@ A push is set up only after all of these succeed:
    `before-automation-publish`.
 3. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-4. Enable the personal alert: `alva alert enable --automation <owner>/<feed>` or
-   `alva alert enable --playbook <owner>/<playbook>`. For groups, use
-   `/alva subscribe feed <id>` or `/alva subscribe playbook <id>` in the group.
+4. Enable the FEED alert: for one automation use
+   `alva alert enable --automation <owner>/<feed>`; for known feed ids use
+   `alva alert enable --automation-ids <id,id>`. For groups, use
+   `/alva subscribe feed <id>` in the group.
 5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
    the record is fresh and the message is non-empty or contains
    `<|SKIP_NOTIFICATION|>` for a quiet run.
@@ -46,27 +47,28 @@ A push is set up only after all of these succeed:
 If the automation is unpublished, the feed has no sidecar record, or the record
 has an empty body, do not claim push is set up. Diagnose and fix first.
 
-Confirm to the user with specifics: which automation/playbook alert is enabled,
-what the next push will say, and when it will fire. For monitors, say quiet runs
-skip notifications.
+Confirm to the user with specifics: which automation alerts are enabled, what
+the next push will say, and when it will fire. For monitors, say quiet runs skip
+notifications.
+
+There is no playbook alert target. Following or unfollowing a playbook never
+changes alerts. If the user explicitly asks to enable every current automation
+behind a playbook, resolve the feed ids from that playbook's latest release and
+submit those ids with `alva alert enable --automation-ids <id,id>`. Treat this
+as a snapshot: feeds added by a later release are not subscribed automatically.
 
 ## Inventory And Unsubscribe
 
-- `alva alert list --first 200` — rows carry `kind`, `target_status`,
-  playbook/feed identity, `feed_status`, and `last_pushed_at_ms` when available.
-  If `items` < `total_count`, keep paginating; never report a truncated page as
-  the full inventory. Alert enablement is the relevant `FEED_ALERT` or
-  `PLAYBOOK_ALERTS` row with `target_status=ACTIVE`; social playbook follows are
-  separate and must not be used as delivery state. Raw JSON/SDK rows may retain
-  a legacy `following` field for compatibility; ignore it for alert
-  verification.
+- `alva alert list --first 200` — rows carry `kind`, `target_status`, feed
+  identity, `feed_status`, and `last_pushed_at_ms` when available. If `items` <
+  `total_count`, keep paginating; never report a truncated page as the full
+  inventory. Alert enablement is an active `FEED_ALERT`. Social playbook follows
+  are separate and must not be used as delivery state.
 - `alva alert follows --limit 100` — the playbook follow list. Keep paginating
   with `--cursor` when `has_next` is true.
-- Disable by name (`alva alert disable --playbook owner/name` or
-  `--automation owner/name`) for live targets; by id
-  (`alva alert disable --playbook-ids a,b --automation-ids c`) for bulk and for
-  `TARGET_DELETED` ghosts (name-addressed 404s on deleted targets).
-- Resolve ids with `alva playbooks get --ids a,b` / `--ref owner/name`; list a
-  user's playbooks with `alva playbooks list --owner <username>`.
+- Disable by name (`alva alert disable --automation owner/name`) for live
+  targets; use `alva alert disable --automation-ids a,b` for bulk and for
+  `TARGET_DELETED` feed ghosts (name-addressed calls 404 on deleted targets).
+- Use the `target.id` returned by `alva alert list` for a deleted feed row.
 - Never probe with mutating calls — the read surface answers all identity
   questions.


### PR DESCRIPTION
## Summary

- Teach agents that alerts and group subscriptions target FEED automations only.
- Separate social playbook follows from delivery state throughout the Alva skill corpus.
- Document explicit latest-release feed snapshots for requests to alert on every current playbook automation.

## Breaking Changes

Behavioral guidance no longer permits removed playbook alert targets or playbook notification history commands.

## Database Migrations

None.

## Merge Order

⚠️ Merge alva-ai/alva-backend#1828, alva-ai/alva-gateway#678, then alva-ai/toolkit-ts#132.

## Related

- alva-ai/alva-backend#1792
- alva-ai/alva-backend#1828
- alva-ai/alva-gateway#678
- alva-ai/toolkit-ts#132

## Test Plan

- [x] Skill doc eval: 51/51 cases, 468/468 checks
- [x] Mutation smoke: 4/4
- [x] `git diff --check`

🤖 Generated with Codex.