### PR TITLE
docs(alva): require historical automation judgment

### DIFF
--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -39,6 +39,40 @@ const MUTATIONS = [
     remove: "User-Defined Functions are strict opt-in. ",
     expectFailedCases: ["scenario.udf-strict-opt-in"],
   },
+  {
+    id: "automation-knowledge-route",
+    file: "references/request-routing.md",
+    remove: "Read [alva-knowledge.md](alva-knowledge.md) before design, ",
+    expectFailedCases: ["scenario.alert-push-monitor"],
+  },
+  {
+    id: "automation-knowledge-publish-gate",
+    file: "references/feed-lifecycle.md",
+    remove:
+      "1. The applicable [Alva Knowledge](alva-knowledge.md) requirements passed\n" +
+      "   consecutive-run checks: longitudinal or decision automations compare bounded\n" +
+      "   history, and push-capable automations suppress non-material repeats.\n",
+    expectFailedCases: ["scenario.alert-push-monitor"],
+  },
+  {
+    id: "automation-knowledge-required-reading",
+    file: "SKILL.md",
+    remove:
+      "## Alva Knowledge (Required Reading)\n\n" +
+      "Before designing, modifying, or evaluating any automation, read\n" +
+      "[alva-knowledge.md](references/alva-knowledge.md). Every automation must decide\n" +
+      "whether bounded history improves its output; longitudinal or decision\n" +
+      "automations use that history, and push-capable automations also define semantic\n" +
+      "notification novelty.\n\n",
+    expectFailedCases: ["scenario.alert-push-monitor"],
+  },
+  {
+    id: "automation-knowledge-reference-index",
+    file: "SKILL.md",
+    remove:
+      "| [alva-knowledge.md](references/alva-knowledge.md)                                     | Required automation reasoning: bounded history, cross-run comparison, semantic notification novelty, quiet runs.                            |\n",
+    expectFailedCases: ["scenario.alert-push-monitor"],
+  },
 ];
 
 function parseArgs(argv) {

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -139,20 +139,62 @@
       "id": "scenario.alert-push-monitor",
       "group": "scenarios.push",
       "prompt": "Track BTC dominance and notify me when it breaks out.",
-      "description": "A monitoring request routes to Automation / Push and validates sidecar, release, subscription, and real-run delivery.",
+      "description": "A monitoring request routes to Automation / Push, compares bounded history, suppresses repeated content, and validates delivery.",
       "expect": {
         "route": "Automation / Push",
         "references": [
+          "alva-knowledge.md",
           "push-notifications.md",
           "feed-lifecycle.md"
         ],
         "behaviors": [
           "Build or modify a feed that emits actionable `signal/targets` or `notify/message`",
+          "bounded history source and lookback window",
+          "Notification deduplication is semantic",
+          "If no material delta exists",
           "A push is set up only after all of these succeed",
           "alva deploy update --id <ID> --push-notify",
           "alva alert enable --automation",
           "read `@last/1` of the sidecar",
           "do not claim push is set up"
+        ],
+        "sections": [
+          {
+            "file": "SKILL.md",
+            "heading": "Alva Knowledge (Required Reading)",
+            "includes": [
+              "[alva-knowledge.md](references/alva-knowledge.md)",
+              "Every automation must decide"
+            ]
+          },
+          {
+            "file": "SKILL.md",
+            "heading": "Reference Library",
+            "includes": [
+              "[alva-knowledge.md](references/alva-knowledge.md)",
+              "Required automation reasoning"
+            ]
+          },
+          {
+            "file": "references/request-routing.md",
+            "heading": "Routes",
+            "includes": [
+              "Read [alva-knowledge.md](alva-knowledge.md) before design"
+            ]
+          }
+        ],
+        "gates": [
+          {
+            "type": "hard_gate",
+            "file": "references/feed-lifecycle.md",
+            "id": "before-automation-publish",
+            "label": "automation knowledge",
+            "includes": [
+              "[Alva Knowledge](alva-knowledge.md)",
+              "longitudinal or decision automations compare bounded history",
+              "push-capable automations suppress non-material repeats"
+            ]
+          }
         ]
       }
     },

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -180,6 +180,14 @@ exposes it.
 Use [creators-note.md](references/creators-note.md) when composing a pinned
 post-release author note.
 
+## Alva Knowledge (Required Reading)
+
+Before designing, modifying, or evaluating any automation, read
+[alva-knowledge.md](references/alva-knowledge.md). Every automation must decide
+whether bounded history improves its output; longitudinal or decision
+automations use that history, and push-capable automations also define semantic
+notification novelty.
+
 ## Request Routing
 
 Open [request-routing.md](references/request-routing.md) whenever the task is
@@ -200,7 +208,7 @@ that section as mandatory, not optional debugging material.
 | dashboard, screener app, thesis tracker, hosted report, shareable surface                                                               | Playbook Creation                   | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md).                                                                                               |
 | `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
 | backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
-| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Build a push-capable feed and verify alert or group subscription plus sidecar output.                                                                                                    |
+| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify alert or group subscription plus sidecar output.                                        |
 | keep researching, checking, or working in this channel on a cadence until a condition, time, or run count                              | Channel Loop                        | Read [deployment.md](references/deployment.md#channel-loops); use `alva loop create`, set `--start` for a future start, and provide at least one of `--until` or `--runs`.                |
 | `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
 | `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
@@ -419,7 +427,8 @@ products, playbooks, dashboards, signals, alerts, and reusable outputs. A feed
 is not automatically a playbook; it can also back an alert, digest, signal,
 reusable dataset, or future answer.
 
-Read [feed-lifecycle.md](references/feed-lifecycle.md) and
+Read [alva-knowledge.md](references/alva-knowledge.md) before designing an
+automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
 short lifecycle is: write schema and logic to ALFS, `alva run`, grant public
 read if needed, create the producer cronjob with `alva deploy`, then publish
@@ -743,6 +752,7 @@ Use this index to open only the file needed for the current task.
 | File                                                                                  | Owns                                                                                                                                          |
 | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | [preflight.md](references/preflight.md)                                               | Session start, Rule 0, CLI, auth, profile, Arrays JWT, memory load, user scope.                                                               |
+| [alva-knowledge.md](references/alva-knowledge.md)                                     | Required automation reasoning: bounded history, cross-run comparison, semantic notification novelty, quiet runs.                            |
 | [request-routing.md](references/request-routing.md)                                   | Route choice, Skillhub, Guided Planning, capability verification, completion gate.                                                            |
 | [content-legitimacy.md](references/content-legitimacy.md)                             | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions.                                                           |
 | [data-skills.md](references/data-skills.md)                                           | Data Skills discovery, endpoint calls, Arrays auth, search/data routing.                                                                      |
@@ -818,6 +828,9 @@ Before finishing an Alva task, ask:
 - Did I run current online verification before using training knowledge to
   rule out a listing, ADR/ADS, ticker, or other requested security form?
 - Did I run Data Skills `list` -> `summary` -> `endpoint` before coding calls?
+- Did automation work read [alva-knowledge.md](references/alva-knowledge.md),
+  apply bounded history when it improves judgment, and suppress push without a
+  material delta?
 - Did automation publish pass `before-automation-publish`?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)
   and pass the relevant hard gates?

--- a/skills/alva/references/alva-knowledge.md
+++ b/skills/alva/references/alva-knowledge.md
@@ -1,0 +1,69 @@
+# Alva Knowledge
+
+Read this chapter before designing, modifying, or evaluating any automation. It
+owns the history decision for every automation, cross-run judgment for
+longitudinal or decision automations, and notification novelty for push-capable
+automations. Feed construction and delivery mechanics remain in
+[feed-lifecycle.md](feed-lifecycle.md) and
+[push-notifications.md](push-notifications.md).
+
+## Use History To Improve Judgment
+
+Do not default an automation to an isolated scheduled run. First decide whether
+prior state, inputs, outputs, or decisions can improve the current result. A
+pure data refresh may correctly remain current-state-only; make that decision
+explicit. For a longitudinal or decision automation, define:
+
+- the decision subject and stable identity, such as asset, topic, event, or
+  monitored condition;
+- the bounded history source and lookback window;
+- the baseline to compare against, such as the previous state, rolling norm, or
+  last emitted decision;
+- the first-run and missing-history behavior.
+
+On every relevant run, read the prior inputs, outputs, or decisions and compare
+them with current evidence before reaching a conclusion. Use only the bounded
+history needed for the decision; do not load an entire unbounded stream. Keep
+the current state, relevant history, material delta, and resulting action
+distinct so the reasoning can be inspected.
+
+For LLM-backed automations, use the historical-reference pattern in
+[alpi.md](alpi.md#historical-reference-feed-as-memory). Historical context
+supports judgment but never replaces fresh factual data or repairs missing
+coverage; the provenance rules in
+[content-legitimacy.md](content-legitimacy.md) still apply.
+
+## Decide Novelty Before Writing The Notification
+
+Notification deduplication is semantic, not textual. Feed SDK timestamp
+deduplication only controls stored records; it does not stop an automation from
+rephrasing and pushing the same conclusion on every run.
+
+For a push-capable automation, use this order before writing user-facing
+notification copy:
+
+1. Normalize the candidate decision into a stable subject, state or direction,
+   severity, evidence timestamp, and evidence identifiers.
+2. Read recent decisions or notifications for that subject within the defined
+   lookback window.
+3. Identify what is materially new: a new event, a state transition, a
+   meaningful severity or confidence change, or new evidence that changes the
+   action.
+4. Push only when that delta is useful to the user. A rewritten summary,
+   unchanged conclusion, or insignificant value movement is not novelty.
+5. Persist enough structured decision state for the next run to make the same
+   comparison. If no material delta exists, take the quiet-run path described in
+   [push-notifications.md](push-notifications.md).
+
+Repeated notifications are valid only when the automation defines a reminder
+or escalation policy. The repeated message must state the new elapsed-time,
+severity, or escalation reason instead of presenting unchanged content as a new
+finding.
+
+## Automation Review
+
+Before publishing, test consecutive runs against the applicable rules above. A
+longitudinal or decision automation must cover unchanged input, material change,
+and missing history. A push-capable automation must additionally prove that an
+unchanged conclusion takes the quiet-run path and that any policy-defined
+reminder or escalation states why the repeat is warranted.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -65,14 +65,17 @@ to 2048) before editing logic.
 <HARD-GATE id="before-automation-publish">
 Before `alva automation publish`, verify:
 
-1. The exact feed script ran successfully in this session after the latest
+1. The applicable [Alva Knowledge](alva-knowledge.md) requirements passed
+   consecutive-run checks: longitudinal or decision automations compare bounded
+   history, and push-capable automations suppress non-material repeats.
+2. The exact feed script ran successfully in this session after the latest
    source write.
-2. Output groups and fields match the feed contract.
-3. Evidence is fresh; if source changed after the run, rerun.
-4. `special:user:*` read permission exists on the feed root when public reads
+3. Output groups and fields match the feed contract.
+4. Evidence is fresh; if source changed after the run, rerun.
+5. `special:user:*` read permission exists on the feed root when public reads
    are needed.
-5. An unauthenticated public read returns HTTP 200, not 403.
-6. If the feed backs HTML, at least one public `@last` path the HTML reads has
+6. An unauthenticated public read returns HTTP 200, not 403.
+7. If the feed backs HTML, at least one public `@last` path the HTML reads has
    non-empty data after grant.
 
 If any evidence is missing or stale, do not publish. Fix the feed, rerun, and

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -27,7 +27,7 @@ Decision order:
 | Financial Analysis / Ask Question | Answer market, asset, portfolio, valuation, comparison, and "why" questions with fresh data/search/`alva run` evidence. Comparison baselines are figures too: fetch or qualify them. Every answer must read [user-facing-prose.md](user-facing-prose.md), then pass the ask evidence gate. |
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. |
-| Automation / Push | Build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
+| Automation / Push | Read [alva-knowledge.md](alva-knowledge.md) before design, build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
 | Channel Loop | Re-enter the same channel with scheduled Agent turns until a condition, exclusive cutoff, or exact run limit. Read [deployment.md](deployment.md#channel-loops), set `--start` for a future start, and provide at least one of `--until` or `--runs`. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |


### PR DESCRIPTION
## Summary

- Add Alva Knowledge as required reading for automation design.
- Require bounded historical comparison for longitudinal decisions and semantic novelty for push-capable automations.
- Enforce the applicable rules in routing and before-automation-publish, with scoped regression and mutation coverage.

## Breaking Changes

None.

## Database Migrations

None.

## Merge Order

None.

## Related PRs

None.

## Verification

- node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva (51/51 cases, 480/480 checks)
- node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva (8/8 mutations failed as expected)
- bash alva-skill-standard/scripts/audit.sh skills/alva (no broken links or orphan references)
- git diff --check