### PR TITLE
feat(alva-skill): publish recursive alpkg package

### DIFF
--- a/.github/workflows/alva-skill-doc-evals.yml
+++ b/.github/workflows/alva-skill-doc-evals.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "skills/alva/**"
       - "evals/alva-skill-docs/**"
+      - "tools/alva-skill-package/**"
       - ".github/workflows/alva-skill-doc-evals.yml"
   push:
     branches: [main]
     paths:
       - "skills/alva/**"
       - "evals/alva-skill-docs/**"
+      - "tools/alva-skill-package/**"
       - ".github/workflows/alva-skill-doc-evals.yml"
   workflow_dispatch:
 
@@ -34,3 +36,8 @@ jobs:
 
       - name: Run mutation smoke
         run: node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva
+
+      - name: Validate alpkg package
+        run: |
+          node --test tools/alva-skill-package/validate.test.mjs
+          node tools/alva-skill-package/validate.mjs

--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ Update with one of:
 
 The check is silent when your skill is up to date. It runs at most once every 8 hours and fails gracefully offline.
 
+### Alva Package Registry
+
+Maintainers can publish the original multi-file skill tree to the Alva package
+registry as `@alva/skill`. The package allowlist includes `SKILL.md`,
+`references/`, and `scripts/`; local `.env` files and repository metadata are
+not uploaded. This initial package supports registry publish, info, and
+download workflows. Its `SKILL.md` main entry is not an executable Node or
+Jagent module.
+
+Preview the exact recursive file set without making a network request:
+
+```bash
+cd skills/alva
+npm run publish:dry-run
+```
+
+Publish the version declared in `skills/alva/package.json` to staging with an
+admin API key:
+
+```bash
+cd skills/alva
+ALVA_API_KEY=... npm run publish:stg
+```
+
+Verify the immutable release:
+
+```bash
+ALVA_ENDPOINT=https://api-llm.stg.alva.ai \
+ALVA_API_KEY=... \
+alpkg info @alva/skill:v<major>.<minor>.<patch>
+```
+
 ### 3. Try It
 
 Start with a simple prompt:

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -756,7 +756,6 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.15.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.15.1
+  version: v1.16.1
 ---
 
 # Alva

--- a/skills/alva/package.json
+++ b/skills/alva/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@alva/skill",
+  "version": "1.16.1",
+  "private": true,
+  "main": "SKILL.md",
+  "files": [
+    "SKILL.md",
+    "references",
+    "scripts"
+  ],
+  "scripts": {
+    "package:check": "node ../../tools/alva-skill-package/validate.mjs",
+    "publish:dry-run": "npm run package:check && alpkg publish --dry-run --endpoint https://api-llm.stg.alva.ai",
+    "publish:stg": "npm run package:check && alpkg publish --endpoint https://api-llm.stg.alva.ai"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT"
+}

--- a/tools/alva-skill-package/validate.mjs
+++ b/tools/alva-skill-package/validate.mjs
@@ -1,0 +1,96 @@
+import { lstat, readFile, readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MAX_FILES = 64;
+const MAX_TOTAL_BYTES = 32 * 1024 * 1024;
+const EXPECTED_FILES = ['SKILL.md', 'references', 'scripts'];
+
+const toolDir = dirname(fileURLToPath(import.meta.url));
+const defaultSkillDir = resolve(toolDir, '../../skills/alva');
+
+export async function validatePackage(skillDir = defaultSkillDir) {
+  const packageJSON = JSON.parse(await readFile(join(skillDir, 'package.json'), 'utf8'));
+  assert(packageJSON.name === '@alva/skill', 'package name must be @alva/skill');
+  assert(packageJSON.private === true, 'package must remain private to prevent npm publication');
+  assert(packageJSON.main === 'SKILL.md', 'package main must be SKILL.md');
+  assert(
+    JSON.stringify(packageJSON.files) === JSON.stringify(EXPECTED_FILES),
+    `package files must be ${JSON.stringify(EXPECTED_FILES)}`,
+  );
+
+  const skillMD = await readFile(join(skillDir, 'SKILL.md'), 'utf8');
+  const skillVersion = readSkillVersion(skillMD);
+  assert(
+    skillVersion === `v${packageJSON.version}`,
+    `SKILL.md version ${skillVersion ?? '<missing>'} must match package version v${packageJSON.version}`,
+  );
+
+  const files = [];
+  let totalBytes = 0;
+  for (const root of packageJSON.files) {
+    await collect(join(skillDir, root), root, files, (size) => {
+      totalBytes += size;
+    });
+  }
+  files.sort();
+
+  assert(files.includes('SKILL.md'), 'package must include SKILL.md');
+  assert(files.includes('scripts/version_check.sh'), 'package must include scripts/version_check.sh');
+  assert(files.some((file) => file.startsWith('references/')), 'package must include references');
+  assert(!files.includes('package.json'), 'package.json must not be included in the artifact');
+  assert(!files.some(hasHiddenSegment), 'artifact must not include hidden paths');
+  assert(files.length <= MAX_FILES, `artifact has ${files.length} files; maximum is ${MAX_FILES}`);
+  assert(totalBytes <= MAX_TOTAL_BYTES, 'artifact exceeds the 32 MiB limit');
+
+  return {
+    package: packageJSON.name,
+    version: skillVersion,
+    main: packageJSON.main,
+    files,
+    file_count: files.length,
+    total_bytes: totalBytes,
+  };
+}
+
+function readSkillVersion(skillMD) {
+  const normalized = skillMD.replaceAll('\r\n', '\n');
+  const match = /^---\n([\s\S]*?)\n---(?:\n|$)/.exec(normalized);
+  if (!match) return undefined;
+  return /^\s*version:\s*(v\d+\.\d+\.\d+)\s*$/m.exec(match[1])?.[1];
+}
+
+async function collect(localPath, artifactPath, files, addBytes) {
+  const stat = await lstat(localPath);
+  assert(!stat.isSymbolicLink(), `artifact path must not be a symlink: ${artifactPath}`);
+  assert(!hasHiddenSegment(artifactPath), `artifact path must not be hidden: ${artifactPath}`);
+  if (stat.isFile()) {
+    files.push(artifactPath);
+    addBytes(stat.size);
+    return;
+  }
+  assert(stat.isDirectory(), `artifact path must be a file or directory: ${artifactPath}`);
+  const entries = await readdir(localPath, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    await collect(join(localPath, entry.name), `${artifactPath}/${entry.name}`, files, addBytes);
+  }
+}
+
+function hasHiddenSegment(filePath) {
+  return filePath.split('/').some((segment) => segment.startsWith('.'));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = await validatePackage(process.argv[2] ? resolve(process.argv[2]) : undefined);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`alva-skill-package: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/alva-skill-package/validate.test.mjs
+++ b/tools/alva-skill-package/validate.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { validatePackage } from './validate.mjs';
+
+const repoSkillDir = fileURLToPath(new URL('../../skills/alva/', import.meta.url));
+
+test('validates the repository package and its recursive artifact surface', async () => {
+  const packageJSON = JSON.parse(await readFile(join(repoSkillDir, 'package.json'), 'utf8'));
+  const result = await validatePackage(repoSkillDir);
+
+  assert.equal(result.package, '@alva/skill');
+  assert.equal(result.version, `v${packageJSON.version}`);
+  assert.equal(result.main, 'SKILL.md');
+  assert(result.files.includes('SKILL.md'));
+  assert(result.files.includes('scripts/version_check.sh'));
+  assert(result.files.includes('references/feed-sdk.md'));
+  assert(!result.files.includes('package.json'));
+  assert(!result.files.some((file) => file.startsWith('.env')));
+  assert(result.file_count <= 64);
+  assert(result.total_bytes < 32 * 1024 * 1024);
+});
+
+test('rejects a package version that differs from SKILL.md', async () => {
+  const fixture = await makeFixture({ packageVersion: '1.16.1', skillVersion: 'v1.16.0' });
+  try {
+    await assert.rejects(() => validatePackage(fixture), /must match package version v1\.16\.1/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test('rejects symlinks within recursively declared roots', async () => {
+  const fixture = await makeFixture({ packageVersion: '1.16.1', skillVersion: 'v1.16.1' });
+  try {
+    await symlink(join(fixture, 'SKILL.md'), join(fixture, 'references', 'linked.md'));
+    await assert.rejects(() => validatePackage(fixture), /must not be a symlink/);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+async function makeFixture({ packageVersion, skillVersion }) {
+  const root = await mkdtemp(join(tmpdir(), 'alva-skill-package-'));
+  await mkdir(join(root, 'references'));
+  await mkdir(join(root, 'scripts'));
+  await writeFile(
+    join(root, 'package.json'),
+    JSON.stringify({
+      name: '@alva/skill',
+      version: packageVersion,
+      private: true,
+      main: 'SKILL.md',
+      files: ['SKILL.md', 'references', 'scripts'],
+    }),
+  );
+  await writeFile(
+    join(root, 'SKILL.md'),
+    `---\nname: alva\nmetadata:\n  version: ${skillVersion}\n---\n\n# Alva\n`,
+  );
+  await writeFile(join(root, 'references', 'feed-sdk.md'), '# Feed SDK\n');
+  await writeFile(join(root, 'scripts', 'version_check.sh'), '#!/bin/sh\n');
+  return root;
+}


### PR DESCRIPTION
## Summary

- Define `skills/alva` as the private `@alva/skill` alpkg package at version `v1.16.1`.
- Recursively publish `SKILL.md`, `references/**`, and `scripts/**` while excluding local config and repository metadata.
- Add package validation, CI coverage, and maintainer staging instructions.

## Breaking Changes

None. This initial artifact supports publish, info, and download. Its `SKILL.md` main entry is intentionally not an executable Node or Jagent module.

## Database Migrations

None.

## Merge Order

None.

## Related PRs

None.

## Verification

- `node --test tools/alva-skill-package/validate.test.mjs`
- `node tools/alva-skill-package/validate.mjs`
- `node --check tools/alva-skill-package/validate.mjs`
- `node --check tools/alva-skill-package/validate.test.mjs`
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva`
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva`
- `npm --prefix skills/alva run publish:dry-run` with the merged alpkg binary on `PATH`
- `git diff --check origin/main...HEAD`
- Alva skill mechanical audit and independent judgment pass

## Staging Publication

Published `@alva/skill:v1.16.1` from commit `515caa0e7684e232bce19a7f8b37fb64e7638a3d` to `https://api-llm.stg.alva.ai`.

- Target: `/alva/registry/sdk/alva/skill/releases/v1.16.1`
- Files: 43 (583,719 bytes)
- Main: `SKILL.md`
- Bundle: `sha256:abf7bc10d1904f9929dc4b5609dcae0c2ae3d8f63cfa4c0178e5732d00d6b599`
- Publish readback: verified
- Exact-version and latest reads: identical manifests
- Latest ref: `/alva/registry/sdk/alva/skill/refs/latest`