### PR TITLE
docs(alva): use feed visibility lifecycle

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -508,14 +508,29 @@
       "id": "issue592.playbook-release-behavior",
       "group": "issue592",
       "target": "corpus",
-      "description": "Playbook release remains protected by behavior-level gates for feed freshness, live data reads, README, lint, and screenshot verification.",
+      "description": "Playbook draft and release remain protected by behavior-level gates for visibility-aware reads, feed freshness, README, lint, and screenshot verification.",
       "hard_gate_includes": [
+        {
+          "file": "references/playbook-creation.md",
+          "id": "before-playbook-draft",
+          "label": "draft gate",
+          "includes": [
+            "for public playbooks",
+            "for private or paid playbooks",
+            "authenticated SDK/PBSV read instead",
+            "do not make the feed public solely to pass this gate"
+          ]
+        },
         {
           "file": "references/playbook-creation.md",
           "id": "before-playbook-release",
           "label": "release gate",
           "includes": [
             "Every backing feed passed `before-automation-publish`",
+            "for public playbooks",
+            "for private or paid playbooks",
+            "authenticated SDK/PBSV read instead",
+            "do not make the feed public solely to pass this gate",
             "HTML fetches quantitative data from feeds, not inline literals",
             "Latest data from each referenced feed is fresh",
             "README exists, is current, and is passed via absolute `--readme-url`",
@@ -756,7 +771,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.15.1",
+        "version: v1.17.0",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -118,13 +118,13 @@
       "id": "retained.feed-lifecycle",
       "group": "retained",
       "target": "corpus",
-      "description": "Feed build, grant, deploy, and automation publish hard gate remain preserved.",
+      "description": "Feed build, deploy, automation publish, and visibility hard gate remain preserved.",
       "includes": [
         "Feed SDK",
         "alva run --entry-path",
-        "special:user:*",
         "alva deploy create",
         "alva automation publish",
+        "alva feed set-visibility --id <feed_id> --visibility public",
         "before-automation-publish"
       ]
     },

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -430,14 +430,16 @@ reusable dataset, or future answer.
 Read [alva-knowledge.md](references/alva-knowledge.md) before designing an
 automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic to ALFS, `alva run`, grant public
-read if needed, create the producer cronjob with `alva deploy`, then publish
-the user-facing automation data source with `alva automation publish`.
+short lifecycle is: write schema and logic to ALFS, `alva run`, deploy, publish
+with `alva automation publish`, then use its returned `feed_id` with
+`alva feed set-visibility` when public access is required.
 
 Before automation publish, satisfy `before-automation-publish`: fresh run,
-expected shape, needed grants, public read verification, and non-empty data for
-HTML dependencies. Feed scripts fail fast on missing data; the detailed publish
-and grant contract lives in the feed references. Read the matching
+expected shape, fresh evidence, and a known producer cronjob id. After publish,
+set public visibility through the feed lifecycle command and verify public,
+non-empty data before dependent HTML work. Feed scripts fail fast on missing
+data; the detailed publish and visibility contract lives in the feed
+references. Read the matching
 [operational-pitfalls.md](references/operational-pitfalls.md) section before
 each feed, ALFS, deploy, and publish step.
 
@@ -832,6 +834,7 @@ Before finishing an Alva task, ask:
   apply bounded history when it improves judgment, and suppress push without a
   material delta?
 - Did automation publish pass `before-automation-publish`?
+- If public, did `alva feed set-visibility` and an unauthenticated read succeed?
 - Did playbook work read [playbook-creation.md](references/playbook-creation.md)
   and pass the relevant hard gates?
 - Did design work read [design.md](references/design.md) and lint where needed?

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -63,21 +63,17 @@ consumers don't.
 `@kv` lives at the mount root (`~/feeds/<name>/v1/data/@kv/<key>`), not
 under a group/output.
 
-## Feed visibility is not a filesystem grant
+## Feed visibility
 
-You **cannot** grant public read directly on a Feed synth `data/` path or its
-parent feed directory. Both bypass the feed visibility record and return
-`PERMISSION_DENIED`. Deploy and publish the automation first, then use the
-`feed_id` returned by publish:
+After deploying and publishing the automation, use the returned `feed_id` to
+make the feed public:
 
 ```bash
-# Wrong — both error
-alva fs grant --path '~/feeds/my-feed/v1/data' --subject "special:user:*" --permission read
-alva fs grant --path '~/feeds/my-feed' --subject "special:user:*" --permission read
-
-# Right — updates feed visibility and its inherited ALFS projection together
 alva feed set-visibility --id <feed_id> --visibility public
 ```
+
+This keeps the feed visibility record and its inherited ALFS permission
+projection consistent.
 
 ## Clearing feed data (development only)
 

--- a/skills/alva/references/api/filesystem.md
+++ b/skills/alva/references/api/filesystem.md
@@ -63,18 +63,20 @@ consumers don't.
 `@kv` lives at the mount root (`~/feeds/<name>/v1/data/@kv/<key>`), not
 under a group/output.
 
-## Synth-mount grant gotcha
+## Feed visibility is not a filesystem grant
 
-You **cannot** grant permissions directly on a Feed synth `data/` path —
-it returns `PERMISSION_DENIED`. Grant on the parent feed directory; the
-permission is inherited by every child path including the synth data mount:
+You **cannot** grant public read directly on a Feed synth `data/` path or its
+parent feed directory. Both bypass the feed visibility record and return
+`PERMISSION_DENIED`. Deploy and publish the automation first, then use the
+`feed_id` returned by publish:
 
 ```bash
-# Wrong — errors
+# Wrong — both error
 alva fs grant --path '~/feeds/my-feed/v1/data' --subject "special:user:*" --permission read
-
-# Right — grant on the feed root
 alva fs grant --path '~/feeds/my-feed' --subject "special:user:*" --permission read
+
+# Right — updates feed visibility and its inherited ALFS projection together
+alva feed set-visibility --id <feed_id> --visibility public
 ```
 
 ## Clearing feed data (development only)

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -417,18 +417,21 @@ feed.def("market", {
 alva run --entry-path '~/feeds/btc-hourly/v1/src/index.js'
 ```
 
-### 3. Make the output public
-
-```bash
-# Grant the non-versioned base: inherited by all versions + data/.
-alva fs grant --path '~/feeds/btc-hourly' --subject "special:user:*" --permission read
-```
-
-### 4. Deploy as a cronjob
+### 3. Deploy as a cronjob
 
 ```bash
 alva deploy create --name btc-hourly-price-feed --path '~/feeds/btc-hourly/v1/src/index.js' --cron "0 */4 * * *"
 ```
+
+### 4. Publish the automation and visibility
+
+```bash
+alva automation publish --name btc-hourly --version 1.0.0 --cronjob-id <cronjob_id>
+alva feed set-visibility --id <feed_id_from_publish> --visibility public
+```
+
+Do not use `alva fs grant` to publish a feed. `feed set-visibility` keeps the
+feed record and inherited ALFS public-read projection consistent.
 
 ### 5. Verify the cronjob
 

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -18,11 +18,17 @@ Every feed follows the same path:
    `ctx.self.ts().append()`.
 2. Upload source to `'~/feeds/<name>/v1/src/index.js'`.
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
-4. Grant the feed root for public reads when a playbook or public user needs it:
-   `alva fs grant --path '~/feeds/<name>' --subject "special:user:*" --permission read`.
-5. Deploy the script with `alva deploy create`.
-6. Publish the automation with `alva automation publish` using the cronjob id
-   from deploy.
+4. Deploy the script with `alva deploy create`.
+5. Publish the automation with `alva automation publish` using the cronjob id
+   from deploy, and record the returned `feed_id`.
+6. When a playbook or public user needs the feed, publish its visibility with
+   `alva feed set-visibility --id <feed_id> --visibility public`.
+7. Verify an unauthenticated read of a public feed path returns HTTP 200.
+
+Do not use `alva fs grant` or `alva fs revoke` to change a feed's public
+visibility. Feed visibility must update the feed record and its ALFS projection
+together; direct filesystem grants are rejected to prevent those states from
+drifting.
 
 `alva run` is a test step. It does not replace deploy or release and does not
 guarantee public `@last` data for a playbook.
@@ -72,15 +78,19 @@ Before `alva automation publish`, verify:
    source write.
 3. Output groups and fields match the feed contract.
 4. Evidence is fresh; if source changed after the run, rerun.
-5. `special:user:*` read permission exists on the feed root when public reads
-   are needed.
-6. An unauthenticated public read returns HTTP 200, not 403.
-7. If the feed backs HTML, at least one public `@last` path the HTML reads has
-   non-empty data after grant.
+5. The producer cronjob exists and its id is known.
 
 If any evidence is missing or stale, do not publish. Fix the feed, rerun, and
 re-enter the gate.
 </HARD-GATE>
+
+After publish, when public access is required, verify:
+
+1. `alva feed set-visibility --id <feed_id> --visibility public` succeeded for
+   the `feed_id` returned by publish.
+2. An unauthenticated public read returns HTTP 200.
+3. Before building or releasing dependent HTML, at least one public `@last`
+   path used by the HTML is non-empty.
 
 ## Push Sidecars
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -779,14 +779,17 @@ records if some timestamps have multiple items.
 
 ## Making Feeds Public
 
-Grant public read access so anyone can read the data. **Grant the
-non-versioned feed base** (`~/feeds/<name>`, not `~/feeds/<name>/v1`) — ALFS
-inherits parent → child, so the base grant covers every version and its
-`data/`:
+First deploy and publish the automation. The publish response returns the
+`feed_id`; use that id to make the feed public so the feed record and ALFS
+permission projection change together:
 
 ```bash
-alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
+alva feed set-visibility --id <feed_id> --visibility public
 ```
+
+Do not grant `special:user:*` directly on a feed path with `alva fs grant`.
+Direct public grants on feed directories are rejected because they bypass the
+feed's visibility state.
 
 Public reads must use absolute paths:
 `/alva/home/<username>/feeds/btc-ema/v1/data/...`
@@ -846,23 +849,23 @@ feed.def("metrics", {
 alva run --entry-path '~/feeds/btc-ema/v1/src/index.js'
 ```
 
-### Step 3: Make it public
+### Step 3: Deploy and publish the automation
 
 ```bash
-# Grant the non-versioned base — inherited by all versions + data/.
-alva fs grant --path '~/feeds/btc-ema' --subject "special:user:*" --permission read
+alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
+alva automation publish --name btc-ema --version 1.0.0 --cronjob-id <cronjob_id>
+```
+
+Record the `feed_id` returned by publish. If the feed must be public:
+
+```bash
+alva feed set-visibility --id <feed_id> --visibility public
 ```
 
 ### Step 4: Read from any client
 
 ```bash
 alva fs read --path '/alva/home/alice/feeds/btc-ema/v1/data/metrics/prices/@last/100'
-```
-
-### Step 5: Deploy as a cronjob (required for live playbooks)
-
-```bash
-alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js' --cron "0 */4 * * *"
 ```
 
 ---

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -135,6 +135,8 @@ Before `alva release playbook-draft`, verify:
 - README exists at `~/playbooks/{name}/README.md`.
 - Target name and owner namespace match `alva whoami`.
 - Every feed in `--feeds` has passed `before-automation-publish`.
+- Every feed the HTML reads has public visibility set through
+  `alva feed set-visibility` and a successful unauthenticated read.
 - Draft metadata matches the approved plan.
 - `--tags` includes required asset overlap plus material related people:
   investors, company figures, officials/policymakers, Twitter/X KOLs.
@@ -171,8 +173,9 @@ alva release playbook ... \
 Before `alva release playbook`, verify:
 
 1. Every backing feed passed `before-automation-publish`.
-2. Every feed the HTML reads at runtime has a successful deploy and appears in
-   `--feeds`.
+2. Every feed the HTML reads at runtime has a successful deploy, appears in
+   `--feeds`, has public visibility set through `alva feed set-visibility`, and
+   passes an unauthenticated read.
 3. Cronjobs for referenced feeds are active.
 4. HTML fetches quantitative data from feeds, not inline literals.
 5. If UDFs exist, [api/udf-runtime.md](api/udf-runtime.md) has been read, the

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -135,8 +135,11 @@ Before `alva release playbook-draft`, verify:
 - README exists at `~/playbooks/{name}/README.md`.
 - Target name and owner namespace match `alva whoami`.
 - Every feed in `--feeds` has passed `before-automation-publish`.
-- Every feed the HTML reads has public visibility set through
-  `alva feed set-visibility` and a successful unauthenticated read.
+- Every feed the HTML reads appears in `--feeds` and passes the check for the
+  planned playbook visibility: for public playbooks, set public visibility with
+  `alva feed set-visibility` and verify an unauthenticated read; for private or
+  paid playbooks, verify an authenticated SDK/PBSV read instead and do not make
+  the feed public solely to pass this gate.
 - Draft metadata matches the approved plan.
 - `--tags` includes required asset overlap plus material related people:
   investors, company figures, officials/policymakers, Twitter/X KOLs.
@@ -174,8 +177,11 @@ Before `alva release playbook`, verify:
 
 1. Every backing feed passed `before-automation-publish`.
 2. Every feed the HTML reads at runtime has a successful deploy, appears in
-   `--feeds`, has public visibility set through `alva feed set-visibility`, and
-   passes an unauthenticated read.
+   `--feeds`, and passes the check for the release visibility: for public
+   playbooks, set public visibility with `alva feed set-visibility` and verify
+   an unauthenticated read; for private or paid playbooks, verify an
+   authenticated SDK/PBSV read instead and do not make the feed public solely
+   to pass this gate.
 3. Cronjobs for referenced feeds are active.
 4. HTML fetches quantitative data from feeds, not inline literals.
 5. If UDFs exist, [api/udf-runtime.md](api/udf-runtime.md) has been read, the

--- a/skills/alva/references/remix-workflow.md
+++ b/skills/alva/references/remix-workflow.md
@@ -199,21 +199,23 @@ request). Do not write fresh files from scratch.
    agent tool mode; shell-only fallback:
    `alva fs write --path '~/feeds/{new-name}/v1/src/index.js' --file ./{feed_name}.js --mkdir-parents`
 2. **Test** via `alva run --entry-path '~/feeds/{new-name}/v1/src/index.js'`
-3. **Grant** public read:
-   `alva fs grant --path '~/feeds/{new-name}' --subject "special:user:*" --permission read`
-4. **Deploy cronjob**:
+3. **Deploy cronjob**:
    `alva deploy create --name {new-name} --path '~/feeds/{new-name}/v1/src/index.js' --cron "..."`
-5. **Publish automation**:
+4. **Publish automation** and record the returned `feed_id`:
    `alva automation publish --name {new-name} --version 1.0.0 --cronjob-id ID --description "..."`
-6. **Write the edited HTML** to ALFS after updating data paths to point to your
+5. **Publish feed visibility** when the remixed playbook needs public reads:
+   `alva feed set-visibility --id <feed_id> --visibility public`
+6. **Verify public data** with an unauthenticated absolute-path read before the
+   HTML depends on it.
+7. **Write the edited HTML** to ALFS after updating data paths to point to your
    own feed. Use the ALFS write/edit tool in agent tool mode; shell-only
    fallback:
    `alva fs write --path '~/playbooks/{new-name}/index.html' --file ./index.html --mkdir-parents`
-7. **Copy inherited UDF entry scripts when present**: for each source UDF, write
+8. **Copy inherited UDF entry scripts when present**: for each source UDF, write
    the edited entry script to a path under the new playbook. Use the ALFS
    write/edit tool in agent tool mode; shell-only fallback:
    `alva fs write --path '~/playbooks/{new-name}/udf/{function_name}.js' --file ./udf-{function_name}.js --mkdir-parents`.
-8. **Write README** (mandatory) — adapt the source playbook's README to your
+9. **Write README** (mandatory) — adapt the source playbook's README to your
    data sources and methodology, then write it to ALFS. Use the ALFS write/edit
    tool in agent tool mode; shell-only fallback:
    `alva fs write --path '~/playbooks/{new-name}/README.md' --file ./README.md --mkdir-parents`.


### PR DESCRIPTION
## Summary

- replace direct public Feed grants with feed set-visibility guidance
- reorder Feed workflows to deploy, publish, set visibility, then verify public reads
- preserve the latest Alva Knowledge automation checks and strengthen the regression eval

## Breaking Changes

None.

## Database Migrations

None.

## Merge Order

None.

## Related

- alva-ai/sandbox-agent-ts#280
- alva-ai/sandbox-agent-ts#273
- alva-ai/alva-gateway#687

## Test Plan

- [x] skill documentation regression: 51/51 cases
- [x] skill documentation regression: 480/480 checks
- [x] verify canonical Feed workflows contain no direct fs grant command
- [x] git diff --check