### PR TITLE
docs(alva): teach automation update lifecycle

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -794,7 +794,10 @@
           "includes": [
             "target numeric ID belongs to the intended owned automation",
             "replacement cronjob exists",
-            "exact script ran successfully in this session",
+            "Any producer change, including a producer-only update",
+            "alva deploy trigger --id <replacement_cronjob_id>",
+            "replacement cronjob's latest run succeeded",
+            "current-producer script ran successfully in this session",
             "`--trigger` is present only when an immediate post-update run is intended",
             "do not fall back to delete-and-recreate"
           ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -766,6 +766,42 @@
       ]
     },
     {
+      "id": "automation.explicit-update-lifecycle",
+      "group": "automation",
+      "target": "corpus",
+      "description": "Existing automations retain identity and subscriptions through the explicit ID-scoped update flow instead of publish or delete-and-recreate workarounds.",
+      "section_includes": [
+        {
+          "file": "references/feed-lifecycle.md",
+          "heading": "Updating An Existing Automation",
+          "label": "automation update lifecycle",
+          "includes": [
+            "ALFS source writes take effect without republishing",
+            "alva automation update --id <feed_id>",
+            "Omitted fields keep their current values",
+            "explicit empty metadata string clears",
+            "do not trigger a run unless `--trigger` is supplied",
+            "alert subscriptions remain intact",
+            "do not delete and recreate an automation to work around `ALREADY_EXISTS`"
+          ]
+        }
+      ],
+      "hard_gate_includes": [
+        {
+          "file": "references/feed-lifecycle.md",
+          "id": "before-automation-update",
+          "label": "automation update gate",
+          "includes": [
+            "target numeric ID belongs to the intended owned automation",
+            "replacement cronjob exists",
+            "exact script ran successfully in this session",
+            "`--trigger` is present only when an immediate post-update run is intended",
+            "do not fall back to delete-and-recreate"
+          ]
+        }
+      ]
+    },
+    {
       "id": "target.mainline-updates",
       "group": "target",
       "target": "corpus",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -415,9 +415,13 @@ reusable dataset, or future answer.
 Read [alva-knowledge.md](references/alva-knowledge.md) before designing an
 automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 [feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
-short lifecycle is: write schema and logic to ALFS, `alva run`, deploy, publish
-with `alva automation publish`, then use its returned `feed_id` with
-`alva feed set-visibility` when public access is required.
+short creation lifecycle is: write schema and logic to ALFS, `alva run`,
+deploy, publish once with `alva automation publish`, then use its returned
+`feed_id` with `alva feed set-visibility` when public access is required.
+For an existing automation, keep that identity: ALFS source edits are already
+live, while registered version, producer, or metadata changes use
+`alva automation update --id <feed_id>`. Never delete and recreate merely to
+apply an update.
 
 Before automation publish, satisfy `before-automation-publish`: fresh run,
 expected shape, fresh evidence, and a known producer cronjob id. After publish,
@@ -706,7 +710,7 @@ text does not fully cover.
 | `fs`                 | ALFS reads/writes/grants/time-series suffixes and shared modules under `~/library`. Must read [api/filesystem.md](references/api/filesystem.md) for synth suffixes and grant gotchas. |
 | `run`                | Execute jagent JS. See [jagent-runtime.md](references/jagent-runtime.md).                                                                                                             |
 | `deploy`             | Cronjob lifecycle for producer scripts: schedule, args, trigger, run-status, runs, logs. See [deployment.md](references/deployment.md).                                               |
-| `automation`         | Product-facing lifecycle CLI for feeds (`list`, `inspect`, `publish`, `stop`, `resume`, `delete`). Must read [feed-lifecycle.md](references/feed-lifecycle.md).                         |
+| `automation`         | Product-facing lifecycle CLI for feeds (`list`, `inspect`, `publish`, `update`, `stop`, `resume`, `delete`). Must read [feed-lifecycle.md](references/feed-lifecycle.md).               |
 | `release`            | Playbook draft/release; the release reference also covers automation publish metadata extras. Must read [api/release.md](references/api/release.md).                                   |
 | `lint playbook`      | Design-system linter, same gate as release. See [design-contract.yaml](references/design-contract.yaml).                                                                              |
 | `skillhub`           | Curated methodology blueprints. See [request-routing.md](references/request-routing.md#skillhub-blueprint).                                                                           |

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -1,7 +1,7 @@
 # Release And Automation Publish — extras not in CLI help
 
 Run `alva release --help` for playbook workflows and `alva automation --help` for
-automation publish flags before acting. CLI help is authoritative for
+automation publish/update flags before acting. CLI help is authoritative for
 subcommands, flags, display-name conventions, and examples. This file covers
 only:
 
@@ -12,6 +12,11 @@ only:
    the required overlap between trading symbols and tags
 4. `--skill-id` — when it is required
 5. `--agent-type` — marking a feed as a prompt-editable agent
+
+`alva automation publish` registers a new automation and is create-only. For an
+existing automation, use `alva automation update --id <feed_id>` for registered
+metadata, version, or producer changes; ALFS source edits themselves need no
+republish. See [feed-lifecycle.md](../feed-lifecycle.md).
 
 ## Automation Publish `--description` conventions
 

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -56,9 +56,14 @@ Before `alva automation update`, verify:
 2. The requested flags describe only the fields the user intends to change.
 3. If changing the producer, the replacement cronjob exists, belongs to the
    same user, and its id is known.
-4. If changing the version after source or producer changes, the exact script
-   ran successfully in this session and its output still matches the contract.
-5. `--trigger` is present only when an immediate post-update run is intended.
+4. Any producer change, including a producer-only update, requires
+   `alva deploy trigger --id <replacement_cronjob_id>` followed by confirmation
+   that the replacement cronjob's latest run succeeded and its output still
+   matches the feed contract.
+5. If changing source or version without changing the producer, the exact
+   current-producer script ran successfully in this session and its output
+   still matches the contract.
+6. `--trigger` is present only when an immediate post-update run is intended.
 
 If any evidence is missing, inspect or test first; do not fall back to
 delete-and-recreate.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -25,6 +25,45 @@ Every feed follows the same path:
    `alva feed set-visibility --id <feed_id> --visibility public`.
 7. Verify an unauthenticated read of a public feed path returns HTTP 200.
 
+`automation publish` is create-only. Run it once to register a new automation;
+do not treat it as create-or-update.
+
+## Updating An Existing Automation
+
+ALFS source writes take effect without republishing. Use an explicit ID-scoped
+update only when the registered semantic version, producer cronjob,
+description, changelog, or agent type must change:
+
+```bash
+alva automation inspect --id <feed_id>
+alva automation update --id <feed_id> --description "..."
+```
+
+Run `alva automation update --help` before choosing flags. Omitted fields keep
+their current values; an explicit empty metadata string clears that field.
+Updates do not trigger a run unless `--trigger` is supplied. The automation ID,
+visibility, and alert subscriptions remain intact.
+
+Do not call `automation publish` again for the same name, and do not delete and
+recreate an automation to work around `ALREADY_EXISTS`. If the ID is unknown,
+find the exact owned automation with `alva automation list`, then inspect it
+before updating.
+
+<HARD-GATE id="before-automation-update">
+Before `alva automation update`, verify:
+
+1. The target numeric ID belongs to the intended owned automation.
+2. The requested flags describe only the fields the user intends to change.
+3. If changing the producer, the replacement cronjob exists, belongs to the
+   same user, and its id is known.
+4. If changing the version after source or producer changes, the exact script
+   ran successfully in this session and its output still matches the contract.
+5. `--trigger` is present only when an immediate post-update run is intended.
+
+If any evidence is missing, inspect or test first; do not fall back to
+delete-and-recreate.
+</HARD-GATE>
+
 Do not use `alva fs grant` or `alva fs revoke` to change a feed's public
 visibility. Feed visibility must update the feed record and its ALFS projection
 together; direct filesystem grants are rejected to prevent those states from


### PR DESCRIPTION
## Summary
- document `automation publish` as create-only
- direct existing automations to `alva automation update --id` while preserving identity, visibility, and alert subscriptions
- clarify that ALFS source writes need no republish
- add a `before-automation-update` hard gate and regression coverage that rejects delete/recreate workarounds

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
1. Backend PR #1857
2. Gateway PR #691
3. Toolkit PR #133 and its package release
4. This skill guidance PR

## Related PRs
- https://github.com/alva-ai/alva-backend/pull/1857
- https://github.com/alva-ai/alva-gateway/pull/691
- https://github.com/alva-ai/toolkit-ts/pull/133
- https://github.com/alva-ai/skills/pull/553

## Verification
- `python3 -m json.tool evals/alva-skill-docs/cases.json`
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` — 51/51 cases, 492/492 checks
- skill-creator `quick_validate.py skills/alva`
- `git diff --check`

## Skipped Checks
No LLM forward test; the deterministic hard-gate regression covers the new behavior.