### PR TITLE
docs(alva): clarify alert delivery destinations

### DIFF
--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -2,11 +2,11 @@
 
 Source: `origin/main`
 
-SKILL.md lines: 836
+SKILL.md lines: 847
 
-Cases: 52/54
+Cases: 54/55
 
-Checks: 496/505 (98.22%)
+Checks: 505/508 (99.41%)
 
 ## Scoring Diagnosis
 
@@ -15,8 +15,7 @@ Classify the gap before editing: missing capability summary, missing routing poi
 Do not expose eval scores as product copy, and do not patch demos to hide a weak result.
 Instead, fix the canonical skill text or eval case, then rerun baseline and final reports so the regression mechanism proves the gap is closed.
 
-- target.auto-trade-consent-exemption: inspect for a skill gap before editing. Missing checks: auto-trade-consent:; ~/memory/auto-trade-consent.md; one-read verification; place live orders without per-order user confirmation; missing or unreadable record; applies only to loop ticks
-- target.auto-trade-consent-references: inspect for a skill gap before editing. Missing checks: consented auto-trading loop tick; recorded consent; stands in for this per-order confirmation
+- subscriptions.delivery-destination: inspect for a skill gap before editing. Missing checks: alert destination: references/push-notifications.md#Choose The Delivery Destination section exists; destination verification: references/push-notifications.md#Configure And Verify includes intended destination; destination verification: references/push-notifications.md#Configure And Verify includes global "subscribed" state is not sufficient
 
 ## retained
 
@@ -436,15 +435,27 @@ Push setup is evaluated as a full delivery path instead of a single publisher fl
 - [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes alva alert follows --limit 100
 - [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes has_next
 
+## subscriptions
+
+0/1 cases, 0/3 checks
+
+### FAIL subscriptions.delivery-destination
+
+Agents distinguish the default personal destination, an Alva topic channel, and an external IM group before mutating an alert subscription.
+
+- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination section exists
+- [ ] destination verification: references/push-notifications.md#Configure And Verify includes intended destination
+- [ ] destination verification: references/push-notifications.md#Configure And Verify includes global "subscribed" state is not sufficient
+
 ## target
 
-9/11 cases, 120/129 checks
+11/11 cases, 129/129 checks
 
 ### PASS target.top-level-size
 
 Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count <= 850 (actual 836)
+- [x] line count <= 850 (actual 847)
 
 ### PASS target.playbook-task-offload
 
@@ -605,24 +616,24 @@ Latest mainline Alva skill updates remain integrated after rebasing the refactor
 - [x] headers-only tables
 - [x] fetch failures
 
-### FAIL target.auto-trade-consent-exemption
+### PASS target.auto-trade-consent-exemption
 
 A consent-referenced, record-verified channel-loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.
 
-- [ ] auto-trade-consent:
-- [ ] ~/memory/auto-trade-consent.md
-- [ ] one-read verification
-- [ ] place live orders without per-order user confirmation
-- [ ] missing or unreadable record
-- [ ] applies only to loop ticks
+- [x] auto-trade-consent:
+- [x] ~/memory/auto-trade-consent.md
+- [x] one-read verification
+- [x] place live orders without per-order user confirmation
+- [x] missing or unreadable record
+- [x] applies only to loop ticks
 
-### FAIL target.auto-trade-consent-references
+### PASS target.auto-trade-consent-references
 
 The broker and trading references reconcile their per-order confirm lines with the loop-tick consent exemption instead of demanding unqualified confirmation.
 
-- [ ] consented auto-trading loop tick
-- [ ] recorded consent
-- [ ] stands in for this per-order confirmation
+- [x] consented auto-trading loop tick
+- [x] recorded consent
+- [x] stands in for this per-order confirmation
 
 ## automation
 

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -586,6 +586,37 @@
       ]
     },
     {
+      "id": "subscriptions.delivery-destination",
+      "group": "subscriptions",
+      "target": "corpus",
+      "description": "Agents distinguish the default personal destination, an Alva topic channel, and an external IM group before mutating an alert subscription.",
+      "section_includes": [
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Choose The Delivery Destination",
+          "label": "alert destination",
+          "includes": [
+            "Default personal destination",
+            "Alva topic channel",
+            "External IM group",
+            "--automation-ids <id,id> --channel-id <channel_id>",
+            "`channel_id=0`",
+            "moves the personal alert",
+            "Never pass an Alva channel id as `--session-id`"
+          ]
+        },
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Configure And Verify",
+          "label": "destination verification",
+          "includes": [
+            "intended destination",
+            "global \"subscribed\" state is not sufficient"
+          ]
+        }
+      ]
+    },
+    {
       "id": "target.top-level-size",
       "group": "target",
       "target": "skill",

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/home/forge/mono-meta/code/public/skills/skills/alva`
+Source: `/Users/yimingchen/alva/mono-meta/code/public/skills-topic-alert-subscription/skills/alva`
 
 SKILL.md lines: 847
 
-Cases: 54/54
+Cases: 55/55
 
-Checks: 505/505 (100.00%)
+Checks: 514/514 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -434,6 +434,24 @@ Push setup is evaluated as a full delivery path instead of a single publisher fl
 - [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes alva alert list --first 200
 - [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes alva alert follows --limit 100
 - [x] push inventory: references/push-notifications.md#Inventory And Unsubscribe includes has_next
+
+## subscriptions
+
+1/1 cases, 9/9 checks
+
+### PASS subscriptions.delivery-destination
+
+Agents distinguish the default personal destination, an Alva topic channel, and an external IM group before mutating an alert subscription.
+
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Default personal destination
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Alva topic channel
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes External IM group
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes --automation-ids <id,id> --channel-id <channel_id>
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes `channel_id=0`
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes moves the personal alert
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Never pass an Alva channel id as `--session-id`
+- [x] destination verification: references/push-notifications.md#Configure And Verify includes intended destination
+- [x] destination verification: references/push-notifications.md#Configure And Verify includes global "subscribed" state is not sufficient
 
 ## target
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -729,7 +729,7 @@ text does not fully cover.
 | `comments`           | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md).                                                                                      |
 | `alert`              | Personal FEED alert opt-ins and automation history. See [push-notifications.md](references/push-notifications.md).                                                                    |
 | `subscriptions`      | Playbook follow commands plus FEED alert commands. Following never changes alerts. See [push-notifications.md](references/push-notifications.md).                                    |
-| `channel`            | FEED-only group push subscriptions. See [push-notifications.md](references/push-notifications.md).                                                                                    |
+| `channel`            | FEED-only subscriptions for external IM groups attached to channel sessions; never use for Alva topic channels. See [push-notifications.md](references/push-notifications.md).        |
 | `trading`            | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md).                                                                         |
 | `broker`             | Agentic order execution — place/cancel/read across venues (crypto + US equities). Run `alva broker describe` for live commands/capabilities; must read [api/broker.md](references/api/broker.md).                     |
 | `screenshot`         | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot).                                                               |

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -15,14 +15,31 @@ data.
 For heartbeat/watchlist/monitor feeds, recommend quiet behavior: notify only on
 material changes and emit `<|SKIP_NOTIFICATION|>` otherwise.
 
-## Delivery Channel
+## Choose The Delivery Destination
 
-Web notifications are always available. External DM delivery depends on
-`active_channel` plus a matching `telegram_username`, `discord_username`, or
-`slack_username` from `alva whoami`.
+A personal FEED alert has one delivery binding per viewer and feed. Enabling
+the same alert for another destination moves the personal alert; it does not
+create a second copy. Choose the destination before mutating it:
 
-If no active IM channel exists, say web notifications will work immediately and
-the user can connect Telegram, Discord, or Slack at <https://alva.ai/settings>.
+- **Default personal destination:** omit `--channel-id`. The service stores
+  `channel_id=0`; web delivery is available immediately, and external DM
+  delivery uses `active_channel` plus its matching username from `alva whoami`.
+- **Alva topic channel:** resolve the feed id and run
+  `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
+  binds the alert to that in-product channel. A topic channel is not an
+  external IM group, and its channel id is not a channel-session id.
+- **External IM group:** from the attached Telegram, Discord, or Slack group,
+  use `/alva subscribe feed <id>`. The CLI `alva channel
+  group-subscriptions ... --session-id <channel_session_id>` is only for that
+  external group. Never pass an Alva channel id as `--session-id`.
+
+The name-addressed `alva alert enable --automation <owner>/<feed>` command has
+no destination flag. When the user says "this channel", use the id-addressed
+form with `--channel-id`; do not silently fall back to the default destination.
+
+If no active IM channel exists for the default personal destination, say web
+notifications will work immediately and the user can connect Telegram,
+Discord, or Slack at <https://alva.ai/settings>.
 
 ## Configure And Verify
 
@@ -36,10 +53,10 @@ A push is set up only after all of these succeed:
    `before-automation-publish`.
 3. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-4. Enable the FEED alert: for one automation use
-   `alva alert enable --automation <owner>/<feed>`; for known feed ids use
-   `alva alert enable --automation-ids <id,id>`. For groups, use
-   `/alva subscribe feed <id>` in the group.
+4. Enable the FEED alert for the intended destination using
+   [Choose The Delivery Destination](#choose-the-delivery-destination). For the
+   default personal destination, use `alva alert enable --automation
+   <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`.
 5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
    the record is fresh and the message is non-empty or contains
    `<|SKIP_NOTIFICATION|>` for a quiet run.
@@ -47,9 +64,10 @@ A push is set up only after all of these succeed:
 If the automation is unpublished, the feed has no sidecar record, or the record
 has an empty body, do not claim push is set up. Diagnose and fix first.
 
-Confirm to the user with specifics: which automation alerts are enabled, what
-the next push will say, and when it will fire. For monitors, say quiet runs skip
-notifications.
+Confirm to the user with specifics: which automation alerts are enabled, the
+intended destination, what the next push will say, and when it will fire. A
+global "subscribed" state is not sufficient evidence that an alert targets the
+requested Alva topic channel. For monitors, say quiet runs skip notifications.
 
 There is no playbook alert target. Following or unfollowing a playbook never
 changes alerts. If the user explicitly asks to enable every current automation


### PR DESCRIPTION
## Summary
- distinguish default personal alerts, Alva topic-channel alerts, and external IM group subscriptions
- document that topic-channel delivery requires the ID-based alert command with `--channel-id` and moves the existing personal alert
- prevent Alva channel IDs from being used as external group session IDs
- add a regression case with refreshed baseline/final reports

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related PRs
None.

## Verification
- `git diff --check origin/main...HEAD`
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (55/55 cases, 514/514 checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (8/8 mutations rejected)