### PR TITLE
docs: refresh README for current Alva capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![Agent Skills](https://alva-ai-static.b-cdn.net/images/alva-skill-github-cover-new.png)
 
-> Turn your AI agent into Alva Agent — research market theses with live financial context, build or remix Playbooks, set alerts, connect accounts, and backtest strategies on Alva Cloud.
+> Turn your AI agent into Alva Agent: get sourced market answers, run research
+> Automations, build and subscribe to Playbooks, and backtest or trade on Alva
+> Cloud.
 
 ## Quick Start
 
@@ -28,151 +30,161 @@ cp -r skills/alva ~/.openclaw/skills/alva
 
 #### Other Agents
 
-This skill uses the [AgentSkills](https://github.com/anthropics/agent-skills) format. Any agent that supports `SKILL.md` can load it by pointing to the `skills/alva/` directory.
+Any [Agent Skills](https://agentskills.io) client can load `skills/alva/`.
 
-### 2. Configure
+### 2. Connect Alva
 
-Get an API key at [alva.ai](https://alva.ai), then add it to your agent's environment:
+Install the Alva toolkit, sign in, and verify the active account:
 
-#### Claude Code
-
-```json
-// ~/.claude/settings.json
-{
-  "env": {
-    "ALVA_API_KEY": "your_api_key"
-  }
-}
+```bash
+npm install -g @alva-ai/toolkit@latest
+alva auth login
+alva whoami
 ```
 
-#### OpenClaw
+For headless environments, create an API key at [alva.ai](https://alva.ai) and
+configure it directly:
 
-```json
-// openclaw.json
-{
-  "skills": {
-    "entries": {
-      "alva": {
-        "enabled": true,
-        "env": { "ALVA_API_KEY": "your_api_key" }
-      }
-    }
-  }
-}
+```bash
+alva configure --api-key alva_your_key_here
 ```
 
-### Auto-Update
-
-The Alva skill automatically checks for updates on first use each session. If a
-newer version is available, your agent will display a notification:
-
-```
-Alva skill update available.
-  Installed: v1.0.0
-  Latest:    v1.2.0
-Update with one of:
-  npx skills update
-  clawhub update alva
-  git clone https://github.com/alva-ai/skills ./tmp/alva-skills && cp -r ./tmp/alva-skills/skills/alva/* "<skill-dir>/" && rm -rf ./tmp/alva-skills
-```
-
-The check is silent when your skill is up to date. It runs at most once every 8 hours and fails gracefully offline.
+You can also provide the key as `ALVA_API_KEY` in your agent's environment.
 
 ### 3. Try It
 
-Start with a simple prompt:
+Ask a market question:
 
-```
+```text
 Explain why NVDA moved last week and what changed in semis
 ```
 
-That's it. Your agent can now answer market questions, build or remix live Playbooks, set alerts, and work with connected accounts on Alva. By default, the skill builds live Playbooks unless you explicitly ask for a static snapshot. When you explicitly ask for user-callable functions, interactive Playbooks register them through the functions CLI and invoke them through the PBSV + UDF runtime.
+Alva answers one-off questions in chat. For ongoing research, ask it to build an
+Automation or Playbook. Playbooks use live data by default; request a static
+snapshot explicitly.
 
----
+### Keep It Updated
+
+The skill checks GitHub for updates on first use, at most once every eight
+hours. It stays silent when current or offline. When needed, it prints the exact
+update command.
+
+- Agent Skills CLI: `npx skills update`
+- OpenClaw: `clawhub update alva`
 
 ## Example Prompts
 
-| Use Case                    | Example Prompt                                                                                         |
-| --------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Ask Market Questions        | *"Explain why NVDA moved last week and what changed in semis."*                                        |
-| Set Alerts                  | *"Create a weekday 8:30am ET alert for SPY, QQQ, NVDA, MSFT, and TSLA meaningful changes."*            |
-| Build Playbooks             | *"Build a Playbook tracking AAPL with price charts, analyst targets, and insider trades."*             |
-| Discover & Remix Playbooks  | *"Find a semiconductor Playbook tracking AI infrastructure and subscribe me to its alerts."*            |
-| Backtest Strategies         | *"Backtest an RSI mean-reversion strategy on BTC with daily rebalancing."*                             |
-| Connect Accounts & Trading  | *"Show my connected portfolio holdings and summarize recent activity."*                                |
-| Interactive Playbook Tools  | *"Register a Playbook UDF and expose it through a Run analysis button for the selected ticker."*        |
-
----
+| Use Case                         | Example Prompt                                                                                               |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Ask Market Questions             | Explain why NVDA moved last week and what changed in semiconductors.                                         |
+| Check Company Anomalies          | Analyze AAPL and check whether its latest move looks company-specific or sector-driven.                      |
+| Research Fintwit                 | Who are the top tracked semiconductor voices on Fintwit, and what are they saying about AI infrastructure?   |
+| Automate Research & Alerts       | Track meaningful changes in SPY, QQQ, NVDA, MSFT, and TSLA every weekday at 8:30am ET and alert me.          |
+| Build Playbooks                  | Build a Playbook tracking AAPL with price charts, analyst targets, and insider trades.                       |
+| Discover, Subscribe & Remix      | Find a semiconductor Playbook tracking AI infrastructure, subscribe to it, and show me how I could remix it. |
+| Use a Skillhub Method            | Use the Alva thesis method from Skillhub to track NVDA's AI infrastructure thesis.                           |
+| Backtest Strategies              | Backtest an RSI mean-reversion strategy on BTC with daily rebalancing.                                       |
+| Work with Connected Accounts     | Show my connected portfolio holdings and summarize recent activity.                                          |
+| Add Interactive Playbook Actions | Add a Run analysis action to this Playbook for the selected ticker.                                          |
 
 ## Platform Capabilities
 
-### Data — 250+ Financial Skills
+### Research
 
-Unified access to crypto, equities, ETFs, macro, on-chain, and social data through built-in skills:
+One-off market questions return sourced results in chat. Alva keeps Data Skills,
+Platform Data, and source-backed search separate, so you can see where each
+claim comes from.
 
-| Category      | Highlights                                                                                                  |
-| ------------- | ----------------------------------------------------------------------------------------------------------- |
-| Crypto        | Spot & futures OHLCV, funding rates, open interest, long/short ratios, exchange flows, DeFi metrics         |
-| Equities      | Fundamentals (income, balance sheet, cash flow), analyst estimates, price targets, insider & senator trades |
-| Macro         | CPI, GDP, unemployment, fed funds rate, Treasury rates, VIX, consumer sentiment                             |
-| On-Chain      | MVRV, SOPR, NUPL, whale ratio, exchange inflow/outflow                                                      |
-| Social & News | Twitter/X, Reddit, YouTube, podcasts, news feeds, web search                                                |
-| Technical     | 50+ indicator calculations — RSI, MACD, Bollinger, ATR, VWAP, Ichimoku, and more                            |
+#### Structured Data Skills
 
-For unstructured content, use `feed_widgets` to subscribe to specific accounts or channels, and `unified_search` to discover content about a topic.
+Alva exposes 250+ structured endpoints across these data areas:
 
-### Compute — Cloud JavaScript Runtime
+| Data Area                       | Representative Coverage                                                                                                                                                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Equity prices & volume          | US intraday and daily OHLCV; curated non-US daily bars; raw price, volume, and price-change history                                                                                                                             |
+| Equity fundamentals & valuation | Company profiles, financial statements, KPIs, shares and float, TTM metrics, margins, leverage and liquidity ratios, P/E, P/B, P/S, enterprise value, EV/EBITDA, estimates, price targets, and company guidance                 |
+| Equity events & ownership       | Dividends, splits, earnings calendars, transcripts and SEC releases, IPOs, M&A and offerings, institutional holdings, insider and Congress trades, and short interest                                                           |
+| Stock screening & technicals    | Country, exchange, industry and sector screens; financial, event and technical filters; moving averages, RSI, MACD, Bollinger Bands, VWAP, beta, volatility, dark-pool OHLC, and point-in-time ratings                          |
+| ETFs                            | Fund details, holdings, country and sector weights, and fund flows                                                                                                                                                              |
+| Options                         | Contract specifications, OHLCV and VWAP history, full option chains, historical Greeks, implied volatility, volume, and open interest                                                                                           |
+| Crypto spot & derivatives       | Binance and Hyperliquid spot/perpetual OHLCV, funding rates, open interest, long/short ratios, taker buy/sell volume, and supported HIP-3 tokenized equities                                                                    |
+| Crypto on-chain                 | Token metadata, market cap and supply, Fear & Greed, MVRV, NUPL, SOPR, realized price, leverage and whale metrics, exchange/miner/entity flows, unlock schedules, AMM/DEX data, network statistics, and company crypto holdings |
+| Macro & cross-asset             | Treasury rates, CPI, GDP, unemployment, inflation, consumer sentiment, forex, gold, silver, oil, major equity indexes, and VIX                                                                                                  |
+| Semiconductor pricing           | DRAM and NAND spot/contract prices, memory-card prices, and the DXI index                                                                                                                                                       |
+| Prediction markets              | Polymarket discovery, real-time and historical prices, order books, spreads, positions and P&L, trade history, top holders, and open interest                                                                                   |
+| News & indexed Twitter/X        | Market news, tracked-handle history and recent posts, post lookup by URL, full-text search, handle metadata, and the tracked-accounts registry                                                                                  |
 
-Write JavaScript that runs on Alva Cloud in a secure V8 isolate. No local dependencies, no infrastructure to manage. Full access to built-in skills, HTTP networking, and LLM APIs.
+Coverage and access tiers can change, so Alva checks the live catalog before it
+chooses a source.
 
-### Pipelines — Feed SDK
+#### Alva Platform Data
 
-Build persistent data pipelines that store time series data. Schedule them as cronjobs for continuous updates — every minute, every hour, or daily.
+| Surface                         | What It Adds                                                                                                |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Company Anomaly Intelligence    | Current anomaly state, company-versus-sector breakdown, supporting events, and the latest attributed driver |
+| Fintwit Intelligence / KOL data | Tracked-account rankings, handle coverage, account views, ticker sentiment, and historical track records    |
+| Fintwit Digest SDK              | Reusable Fintwit data for market-attention and alpha-radar Automations                                      |
 
-### Backtest — Altra Trading Engine
+#### Search and External Data
 
-Event-driven backtesting with historical data and live paper trading. Define strategies, register features, simulate portfolios, and analyze performance.
+Search covers global Twitter/X, the broader web, and public content sources.
+That includes Reddit, YouTube, and podcasts. It also fills gaps in non-US market
+coverage. For off-catalog assets, you can connect your own source. Alva checks
+freshness and tells you what is missing before using the results.
 
-### Deploy & Share — Playbook Web Apps
+### Automations and Alerts
 
-Turn your work into a hosted web app at `https://alva.ai/u/<username>/playbooks/<playbook_name>`. Built with the Alva Design System — charts, KPIs, tables, and optional UDF controls for explicitly requested user-registered functions registered by the functions CLI. You can also remix published playbooks and add a creator's note after release.
+- Turn screens, watchlists, digests, thesis checks, and signal monitors into
+  Automations that keep running on a schedule.
+- Compare each run with prior results and alert only when the change matters.
+- Send alerts in Alva or a connected channel. Quiet runs stay quiet.
+- Edit an Automation without losing its history or subscriptions.
 
----
+### Playbooks
 
-## Architecture at a Glance
+- Publish dashboards, screeners, thesis trackers, event studies, what-if tools,
+  and strategy surfaces as hosted Playbooks.
+- Use Skillhub methods to define the research process; Data Skills supply the
+  financial data.
+- Discover and subscribe to published Playbooks.
+- Remix a Playbook without losing its source lineage, then add a creator's note
+  when you publish.
+- Add buttons or parameterized analyses that viewers can run on demand.
 
-```
-┌───────────────┐    ┌──────────────────────────────────────────────────────┐
-│   AI Agent    │───▶│                      Alva Cloud                      │
-│ (Claude, etc) │    │                                                      │
-└───────────────┘    │  ┌──────────────┐  ┌──────────┐  ┌──────────────┐    │
-                     │  │  Skill Hub   │  │   ALFS   │  │  JS Runtime  │    │
-                     │  │ 250+ Skills  │  │  Files   │  │  V8 Isolate  │    │
-                     │  └──────┬───────┘  └────┬─────┘  └──────┬───────┘    │
-                     │         │               │               │            │
-                     │  ┌──────▼────────────────▼───────────────▼───────┐   │
-                     │  │               Feed SDK + Altra                │   │
-                     │  │         Data Pipelines & Backtesting          │   │
-                     │  └───────────────────────┬───────────────────────┘   │
-                     │                          │                           │
-                     │  ┌───────────────────────▼───────────────────────┐   │
-                     │  │          Cronjobs · Playbooks · Releases      │   │
-                     │  └───────────────────────────────────────────────┘   │
-                     └──────────────────────────────────────────────────────┘
-```
+### Backtesting and Trading
 
----
+- Use Altra for event-driven backtests, feature registration, portfolio
+  simulation, signal generation, and performance analysis.
+- Inspect connected portfolios and account activity.
+- Preview orders with a dry run, then confirm before Alva sends a real order to
+  a supported crypto or US-equity broker.
 
-## Available Skills
+### Alva Cloud
 
-| Skill                            | Description                                                                                                                                                                 |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[alva](skills/alva/SKILL.md)** | Alva Agent for investing workflows — ask market questions, set alerts, build/remix Playbooks, connect accounts, backtest strategies, and use Alva Cloud data/runtime capabilities. See the [skill reference](skills/alva/SKILL.md) for detailed instructions. |
+- Run JavaScript on Alva Cloud with financial data and external APIs. Secrets
+  and persistent storage are built in.
+- Add scheduled LLM analysis with `alpi` or run ONNX models over live data.
+- Use those results in chat, Automations, Playbooks, alerts, or signals.
 
----
+### Data Rules
+
+Alva Agent uses the model for analysis, not as a source of market facts.
+Financial values must come from live Data Skills, Platform Data, or a validated
+external source. Search and LLM output can add context, but they cannot replace
+source data. Real orders require a dry run and explicit confirmation.
+
+## How Alva Fits Together
+
+| Stage     | Includes                                                             |
+| --------- | -------------------------------------------------------------------- |
+| Sources   | Data Skills, Platform Data, external sources, and Skillhub methods   |
+| Execution | Alva Cloud, Automations, Altra, and connected brokers                |
+| Results   | Sourced answers, alerts, Playbooks, trading signals, and real orders |
 
 ## Links
 
 - **Platform**: [alva.ai](https://alva.ai)
-- **Skill Reference**: [skills/alva/SKILL.md](skills/alva/SKILL.md)
-- **Issues**: [github.com/alva-ai/skills/issues](https://github.com/alva-ai/skills/issues)
+- **Instructions**: [SKILL.md](skills/alva/SKILL.md)
+- **Release**: [Latest](https://github.com/alva-ai/skills/releases/latest)
+- **Toolkit**: [npm](https://www.npmjs.com/package/@alva-ai/toolkit)
+- **Issues**: [GitHub](https://github.com/alva-ai/skills/issues)


### PR DESCRIPTION
## Summary

- Refresh the Quick Start flow with the current toolkit login, API-key, and update paths.
- Align the README with the current Alva capability model: sourced answers, Automations, Playbooks, subscriptions, backtesting, trading, and Alva Cloud.
- Expand the data section with concrete coverage across equities, ETFs, options, crypto, macro, semiconductors, prediction markets, news, and indexed Twitter/X.
- Separate structured Data Skills, Alva Platform Data, and external search, and simplify the architecture and prose throughout.

## Why

The README had fallen behind the current skill and mixed user-facing capabilities with older implementation language. The refresh makes the first-run path clearer and gives readers a more accurate view of what Alva Agent can do today.

## Impact

Users get a shorter setup path, more representative starter prompts, clearer data coverage, and consistent `Subscribe` terminology. The change is documentation-only.

## Validation

- `npx prettier@3.6.2 --check README.md`
- `git diff --check`
- Rendered the README as Markdown and confirmed there are no explicit `<br>` or `<hr>` elements.
- Checked capability claims against the current Alva skill references and live Data Skills catalog.
