### PR TITLE
docs(alva): keep group alerts profile-owned

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -602,7 +602,9 @@
             "--automation-ids <id,id> --channel-id <channel_id>",
             "`channel_id=0`",
             "moves the personal alert",
-            "Never pass an Alva channel id as `--session-id`"
+            "alva alert group enable --automation-ids <id>",
+            "accept no session id",
+            "feed need not be public"
           ]
         },
         {

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -600,6 +600,10 @@
             "Alva topic channel",
             "External IM group",
             "--automation-ids <id,id> --channel-id <channel_id>",
+            "<session-prefill-channel-memory channel-id=\"…\">",
+            "a non-`alva` slug denotes a topic channel",
+            "delivery is web-only",
+            "current Alva topic channel (channel id <id>)",
             "`channel_id=0`",
             "moves the personal alert",
             "alva alert group enable --automation-ids <id>",
@@ -613,7 +617,9 @@
           "label": "destination verification",
           "includes": [
             "intended destination",
-            "global \"subscribed\" state is not sufficient"
+            "global \"subscribed\" state is not sufficient",
+            "report it as an Alva web topic channel with its id",
+            "never as Telegram or another external DM"
           ]
         }
       ]
@@ -836,10 +842,10 @@
       "id": "deployment.manual-trigger-optional",
       "group": "deployment",
       "target": "corpus",
-      "description": "Manual deployment trigger commands remain discoverable without becoming a recommended workflow, verification step, or update gate.",
+      "description": "Manual trigger commands remain discoverable without becoming a required deployment, update, or push-verification workflow.",
       "excludes": [
         "Trigger an Out-of-Schedule Run",
-        "alva deploy trigger --id",
+        "Immediately after enabling the alert, trigger one out-of-schedule run",
         "alva deploy run-status --id",
         "Verify the deployment via `alva deploy trigger`",
         "Any producer change, including a producer-only update, requires",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -589,7 +589,12 @@
       "id": "subscriptions.delivery-destination",
       "group": "subscriptions",
       "target": "corpus",
-      "description": "Agents distinguish the default personal destination, an Alva topic channel, and an external IM group before mutating an alert subscription.",
+      "description": "The general skill distinguishes the default personal destination from an Alva topic channel; external-group operations stay profile-owned.",
+      "excludes": [
+        "External IM group",
+        "alva alert group",
+        "group-subscriptions"
+      ],
       "section_includes": [
         {
           "file": "references/push-notifications.md",
@@ -598,17 +603,13 @@
           "includes": [
             "Default personal destination",
             "Alva topic channel",
-            "External IM group",
             "--automation-ids <id,id> --channel-id <channel_id>",
             "<session-prefill-channel-memory channel-id=\"…\">",
             "a non-`alva` slug denotes a topic channel",
             "delivery is web-only",
             "current Alva topic channel (channel id <id>)",
             "`channel_id=0`",
-            "moves the personal alert",
-            "alva alert group enable --automation-ids <id>",
-            "accept no session id",
-            "feed need not be public"
+            "moves the personal alert"
           ]
         },
         {

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -76,7 +76,7 @@ const MUTATIONS = [
   {
     id: "current-topic-channel-destination",
     file: "references/push-notifications.md",
-    remove: "  is web-only. In a channel turn, read the current id from\n",
+    remove: "  channel-session id. Topic-channel delivery is web-only. In a channel turn,\n",
     expectFailedCases: ["subscriptions.delivery-destination", "scenario.current-topic-channel-alert"],
   },
 ];

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -73,6 +73,12 @@ const MUTATIONS = [
       "| [alva-knowledge.md](references/alva-knowledge.md)                                     | Required automation reasoning: bounded history, cross-run comparison, semantic notification novelty, quiet runs.                            |\n",
     expectFailedCases: ["scenario.alert-push-monitor"],
   },
+  {
+    id: "current-topic-channel-destination",
+    file: "references/push-notifications.md",
+    remove: "  is web-only. In a channel turn, read the current id from\n",
+    expectFailedCases: ["subscriptions.delivery-destination", "scenario.current-topic-channel-alert"],
+  },
 ];
 
 function parseArgs(argv) {

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -199,6 +199,34 @@
       }
     },
     {
+      "id": "scenario.current-topic-channel-alert",
+      "group": "scenarios.push",
+      "prompt": "<session-prefill-channel-memory channel-id=\"44\" root=\"/alva/home/ymchcom/channels/research/memory\"> Notify this channel every minute with hello111.",
+      "description": "A request made in an Alva web topic channel binds the feed to that exact channel id and never invents Telegram delivery.",
+      "expect": {
+        "route": "Automation / Push",
+        "references": [
+          "push-notifications.md"
+        ],
+        "behaviors": [
+          "a non-`alva` slug denotes a topic channel",
+          "delivery is web-only",
+          "alva alert enable --automation-ids <id,id> --channel-id <channel_id>",
+          "do not silently fall back to the default destination",
+          "Do not infer Telegram, Discord, Slack, or another transport",
+          "current Alva topic channel (channel id <id>)",
+          "Do not trigger the cronjob or wait for its next scheduled run solely to verify setup",
+          "A successful enable proves that alert delivery is configured",
+          "it does not prove that a message has already been delivered",
+          "A sidecar record alone is also not delivery proof",
+          "report it as an Alva web topic channel with its id"
+        ],
+        "forbidden_behaviors": [
+          "never as Telegram or another external DM"
+        ]
+      }
+    },
+    {
       "id": "scenario.backtest-strategy",
       "group": "scenarios.strategy",
       "prompt": "Backtest a weekly NVDA momentum strategy and show drawdowns.",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -62,8 +62,8 @@ The stack is layered:
 4. **Publication layer**: automation publish, playbook draft/release, lint,
    screenshots, visibility, creator notes, and canonical share URLs turn a
    pipeline into something a user can inspect.
-5. **Action layer**: alerts, signal feeds, trading execution, and group
-   subscriptions connect the artifact to ongoing decisions.
+5. **Action layer**: alerts, signal feeds, trading execution, and alert bindings
+   connect the artifact to ongoing decisions.
 
 Those layers matter because most Alva bugs are layer violations: using search as
 data, using runtime code as a one-off local script, skipping automation publish
@@ -205,7 +205,7 @@ that section as mandatory, not optional debugging material.
 | dashboard, screener app, thesis tracker, hosted report, shareable surface                                                               | Playbook Creation                   | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md).                                                                                               |
 | `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
 | backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
-| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify the personal or group alert plus sidecar output.                                        |
+| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify the alert binding plus sidecar output.                                                  |
 | `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
 | `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
 | "does Alva have X?"                                                                                                                     | Capability Verification             | Run `alva data-skills list` and search for `<topic>` before saying no.                                                                                                                   |
@@ -551,13 +551,13 @@ follows are independent and never enable or disable alerts. A feed may emit
 subscribe users or bypass preferences.
 
 Open [push-notifications.md](references/push-notifications.md) for sidecar creation,
-automation publish, personal/group alert setup, and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
+automation publish, alert setup, and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
 push-worthy. Recommend specific feeds, not generic "notifications". A push setup
 is not complete until the feed sidecar exists, `alva automation publish` ran
 after that sidecar was added, the publisher has `--push-notify`, and the
-intended personal or group alert is enabled. That proves configuration, not that a
+intended alert binding is enabled. That proves configuration, not that a
 message has already been delivered.
 
 #### Playbook Subroute: Remix
@@ -695,8 +695,8 @@ generator behind the selected element rather than the rendered DOM.
 For a recurring alert, design the feed output first: signal target or message,
 quiet-run sentinel, cadence, and subscriber. Publish the automation after adding
 the sidecar, then enable the intended alert. Do not trigger or wait for a run
-solely to verify setup. A cronjob with `--push-notify` and no personal or group
-alert is not a completed push setup.
+solely to verify setup. A cronjob with `--push-notify` and no alert binding is
+not a completed push setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 
@@ -730,7 +730,6 @@ text does not fully cover.
 | `comments`           | Playbook comments and pinned creator notes. See [creators-note.md](references/creators-note.md).                                                                                      |
 | `alert`              | Personal FEED alert opt-ins and automation history. See [push-notifications.md](references/push-notifications.md).                                                                    |
 | `subscriptions`      | Playbook follow commands plus FEED alert commands. Following never changes alerts. See [push-notifications.md](references/push-notifications.md).                                    |
-| `channel`            | FEED-only subscriptions for external IM groups attached to channel sessions; never use for Alva topic channels. See [push-notifications.md](references/push-notifications.md).        |
 | `trading`            | Accounts, portfolio, orders, subscriptions, execution. Must read [api/trading.md](references/api/trading.md).                                                                         |
 | `broker`             | Agentic order execution — place/cancel/read across venues (crypto + US equities). Run `alva broker describe` for live commands/capabilities; must read [api/broker.md](references/api/broker.md).                     |
 | `screenshot`         | PNG capture for released playbook verification. See [playbook-creation.md](references/playbook-creation.md#screenshot).                                                               |
@@ -842,8 +841,8 @@ Before finishing an Alva task, ask:
 - Did design work read [design.md](references/design.md) and lint where needed?
 - Did Skillhub work fetch the blueprint fresh and set `--skill-id` if used?
 - Did backtesting or signal work use Altra?
-- Did push work verify the publisher sidecar plus the intended personal/group
-  alert target without claiming an unobserved delivery?
+- Did push work verify the publisher sidecar plus the intended alert target
+  without claiming an unobserved delivery?
 - If Alva-owned behavior blocked the task, did I offer the confirmed feedback
   flow after reading [api/feedback.md](references/api/feedback.md)?
 - Did the final response describe the delivered result without leaking

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -550,15 +550,15 @@ follows are independent and never enable or disable alerts. A feed may emit
 `--push-notify` only marks the publisher capable of alerts. It does not
 subscribe users or bypass preferences.
 
-Open [push-notifications.md](references/push-notifications.md) for sidecar
-creation, automation publish, personal and group alert setup,
-and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
+Open [push-notifications.md](references/push-notifications.md) for sidecar creation,
+automation publish, personal/group alert setup, and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
 push-worthy. Recommend specific feeds, not generic "notifications". A push setup
 is not complete until the feed sidecar exists, `alva automation publish` ran
-after that sidecar was added, the publisher has `--push-notify`, the user has an
-personal or group alert is enabled, and a real run writes a fresh sidecar record.
+after that sidecar was added, the publisher has `--push-notify`, and the
+intended personal or group alert is enabled. That proves configuration, not that a
+message has already been delivered.
 
 #### Playbook Subroute: Remix
 
@@ -694,8 +694,9 @@ generator behind the selected element rather than the rendered DOM.
 
 For a recurring alert, design the feed output first: signal target or message,
 quiet-run sentinel, cadence, and subscriber. Publish the automation after adding
-the sidecar, then verify a real run. A cronjob with `--push-notify` and no alert
-or group alert is not a completed push setup.
+the sidecar, then enable the intended alert. Do not trigger or wait for a run
+solely to verify setup. A cronjob with `--push-notify` and no personal or group
+alert is not a completed push setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 
@@ -841,8 +842,8 @@ Before finishing an Alva task, ask:
 - Did design work read [design.md](references/design.md) and lint where needed?
 - Did Skillhub work fetch the blueprint fresh and set `--skill-id` if used?
 - Did backtesting or signal work use Altra?
-- Did push work verify the publisher sidecar plus the personal alert or group
-  subscription target?
+- Did push work verify the publisher sidecar plus the intended personal/group
+  alert target without claiming an unobserved delivery?
 - If Alva-owned behavior blocked the task, did I offer the confirmed feedback
   flow after reading [api/feedback.md](references/api/feedback.md)?
 - Did the final response describe the delivered result without leaking

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -205,7 +205,7 @@ that section as mandatory, not optional debugging material.
 | dashboard, screener app, thesis tracker, hosted report, shareable surface                                                               | Playbook Creation                   | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md).                                                                                               |
 | `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
 | backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
-| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify alert or group subscription plus sidecar output.                                        |
+| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify the personal or group alert plus sidecar output.                                        |
 | `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
 | `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
 | "does Alva have X?"                                                                                                                     | Capability Verification             | Run `alva data-skills list` and search for `<topic>` before saying no.                                                                                                                   |
@@ -551,14 +551,14 @@ follows are independent and never enable or disable alerts. A feed may emit
 subscribe users or bypass preferences.
 
 Open [push-notifications.md](references/push-notifications.md) for sidecar
-creation, automation publish, personal alert setup, group subscription setup,
+creation, automation publish, personal and group alert setup,
 and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
 push-worthy. Recommend specific feeds, not generic "notifications". A push setup
 is not complete until the feed sidecar exists, `alva automation publish` ran
 after that sidecar was added, the publisher has `--push-notify`, the user has an
-alert or the group is subscribed, and a real run writes a fresh sidecar record.
+personal or group alert is enabled, and a real run writes a fresh sidecar record.
 
 #### Playbook Subroute: Remix
 
@@ -695,7 +695,7 @@ generator behind the selected element rather than the rendered DOM.
 For a recurring alert, design the feed output first: signal target or message,
 quiet-run sentinel, cadence, and subscriber. Publish the automation after adding
 the sidecar, then verify a real run. A cronjob with `--push-notify` and no alert
-or group subscription is not a completed push setup.
+or group alert is not a completed push setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -758,7 +758,7 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 `signal/targets` makes the feed push-capable, but delivery still requires the
 cronjob to be created or updated with `--push-notify` and
 `alva automation publish` to bind the feed to that cronjob. Actual delivery also
-requires an explicit personal alert or group subscription to the automation's
+requires an explicit personal or group alert to the automation's
 feed. A playbook follow does not enable alerts for its feeds. See
 `references/deployment.md` for the deploy/publish flow.
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -758,8 +758,8 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 `signal/targets` makes the feed push-capable, but delivery still requires the
 cronjob to be created or updated with `--push-notify` and
 `alva automation publish` to bind the feed to that cronjob. Actual delivery also
-requires an explicit personal or group alert to the automation's
-feed. A playbook follow does not enable alerts for its feeds. See
+requires an explicit alert binding to the automation's feed. A playbook follow
+does not enable alerts for its feeds. See
 `references/deployment.md` for the deploy/publish flow.
 
 ---

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -52,9 +52,9 @@ feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
 canonical `feed_alert_ready` event with different feed-alert sources. The push
 body is read from the _published_ automation: a cronjob with `--push-notify` but
 no `alva automation publish` dispatches an empty body. Delivery also requires an
-explicit personal or group alert to the automation's feed.
+explicit alert binding to the automation's feed.
 Following a playbook that references the feed does not enable alerts;
-`--push-notify` does not subscribe the owner, any user, or any group. For
+`--push-notify` does not subscribe the owner or any user. For
 `notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text` skips the user-visible
 push while advancing fanout.
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -52,7 +52,7 @@ feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
 canonical `feed_alert_ready` event with different feed-alert sources. The push
 body is read from the _published_ automation: a cronjob with `--push-notify` but
 no `alva automation publish` dispatches an empty body. Delivery also requires an
-explicit personal alert or group subscription to the automation's feed.
+explicit personal or group alert to the automation's feed.
 Following a playbook that references the feed does not enable alerts;
 `--push-notify` does not subscribe the owner, any user, or any group. For
 `notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text` skips the user-visible

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -142,9 +142,9 @@ Both dispatch `feed_alert_ready`. Do not use legacy names such as
 `playbook_data_ready` or `feed_run_complete` in new docs.
 
 `--push-notify` marks the cronjob publisher as capable of emitting alerts. It
-does not subscribe any user or group and does not bypass notification
-preferences. For `notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
+does not create an alert binding or bypass notification preferences. For
+`notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
 without sending a visible push.
 
-See [push-notifications.md](push-notifications.md) for the personal alert,
-group alert, and verification workflow.
+See [push-notifications.md](push-notifications.md) for alert destination and
+verification workflows.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -147,4 +147,4 @@ preferences. For `notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
 without sending a visible push.
 
 See [push-notifications.md](push-notifications.md) for the personal alert,
-group subscription, and verification workflow.
+group alert, and verification workflow.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -164,8 +164,8 @@ Read `@last/N` (where N >= batch size) to get the most recent batch.
 
 ### Pattern D: Signal Feed Push Notification
 
-For feeds that produce actionable signals worth pushing to users with alerts or
-groups subscribed to the feed. Write signal records to the **`signal`** group
+For feeds that produce actionable signals worth pushing to subscribed alert
+destinations. Write signal records to the **`signal`** group
 with a **`targets`** output -- the resulting path
 `~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
 when dispatching the canonical `feed_alert_ready` notification event.
@@ -233,7 +233,7 @@ await feed.run(async (ctx) => {
 
 When this feed runs as a cronjob with `--push-notify`, the platform reads
 `/data/signal/targets` and dispatches the signal content as `feed_alert_ready`
-to eligible FEED alert and group subscribers. Telegram delivery chunks long
+to eligible FEED alert subscribers. Telegram delivery chunks long
 messages at the platform's per-message limit; the feed SDK does not require a
 500-character summary.
 
@@ -242,12 +242,11 @@ messages at the platform's per-message limit; the feed SDK does not require a
 - The group **must** be named `signal` and the output **must** be named
   `targets` -- this is the path the notification system looks for.
 - `--push-notify` and `alva automation publish --cronjob-id ...` only make the
-  feed publisher capable of emitting alerts. They do **not** subscribe any user
-  or group.
-- Real delivery requires an explicit FEED alert: personal `alva alert enable
-  --automation <owner>/<feed>`, `alva alert group enable --automation-ids
-  <feed_id>` from the attached external group, or — from inside a playbook
-  iframe — a parent-confirmed `window.alva.subscribe.propose()` (see
+  feed publisher capable of emitting alerts. They do **not** create an alert
+  binding.
+- Real delivery requires an explicit FEED alert: `alva alert enable
+  --automation <owner>/<feed>` or — from inside a playbook iframe — a
+  parent-confirmed `window.alva.subscribe.propose()` (see
   `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
   never call a subscribe API directly.
 - Use `meta.reason` to provide the push-notification body -- this is what
@@ -276,8 +275,7 @@ periodic research summaries, heartbeat monitoring, and proactive alerts.
 
 Write the agent's response to the **`notify`** group with a **`message`**
 output. When the cronjob completes with `--push-notify`, the platform reads this
-path and dispatches `feed_alert_ready` to users or groups explicitly subscribed
-to the feed.
+path and dispatches `feed_alert_ready` to eligible alert destinations.
 
 ```javascript
 const { ask } = require("@alva/alvaask");
@@ -340,13 +338,11 @@ alva automation publish --name daily-briefing --version 1.0.0 \
 - **`alva automation publish` is required** — without it, the push is still
   dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
-  personal or group alerts.
-- Real delivery requires an explicit FEED alert: personal `alva alert enable
-  --automation <owner>/<feed>` or, from the attached external group, `alva alert
-  group enable --automation-ids <feed_id>`. Following a playbook does not
-  subscribe any of its feeds. For inventory and unsubscribe (including deleted
-  feed rows), see [push-notifications.md](push-notifications.md) § Inventory And
-  Unsubscribe.
+  alert bindings.
+- Real delivery requires an explicit FEED alert such as `alva alert enable
+  --automation <owner>/<feed>`. Following a playbook does not subscribe any of
+  its feeds. For inventory and unsubscribe (including deleted feed rows), see
+  [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and
   signal-style notifications.
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -245,9 +245,9 @@ messages at the platform's per-message limit; the feed SDK does not require a
   feed publisher capable of emitting alerts. They do **not** subscribe any user
   or group.
 - Real delivery requires an explicit FEED alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>`, group
-  `/alva subscribe feed <id>`, or — from inside a playbook iframe — a
-  parent-confirmed `window.alva.subscribe.propose()` (see
+  `alva alert enable --automation <owner>/<feed>`, a group FEED subscription
+  configured from the attached external group, or — from inside a playbook
+  iframe — a parent-confirmed `window.alva.subscribe.propose()` (see
   `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
   never call a subscribe API directly.
 - Use `meta.reason` to provide the push-notification body -- this is what
@@ -342,10 +342,11 @@ alva automation publish --name daily-briefing --version 1.0.0 \
 - `--push-notify` only enables publisher-side fanout. It does **not** create
   personal alerts or group subscriptions.
 - Real delivery requires an explicit FEED alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>` or group
-  `/alva subscribe feed <feed_id>`. Following a playbook does not subscribe any
-  of its feeds. For inventory and unsubscribe (including deleted feed rows), see
-  [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
+  `alva alert enable --automation <owner>/<feed>` or a group FEED subscription
+  configured from the attached external group. Following a playbook does not
+  subscribe any of its feeds. For inventory and unsubscribe (including deleted
+  feed rows), see [push-notifications.md](push-notifications.md) § Inventory And
+  Unsubscribe.
 - Combine with Pattern D if you want both feed completion notifications and
   signal-style notifications.
 

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -244,9 +244,9 @@ messages at the platform's per-message limit; the feed SDK does not require a
 - `--push-notify` and `alva automation publish --cronjob-id ...` only make the
   feed publisher capable of emitting alerts. They do **not** subscribe any user
   or group.
-- Real delivery requires an explicit FEED alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>`, a group FEED subscription
-  configured from the attached external group, or — from inside a playbook
+- Real delivery requires an explicit FEED alert: personal `alva alert enable
+  --automation <owner>/<feed>`, `alva alert group enable --automation-ids
+  <feed_id>` from the attached external group, or — from inside a playbook
   iframe — a parent-confirmed `window.alva.subscribe.propose()` (see
   `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
   never call a subscribe API directly.
@@ -340,10 +340,10 @@ alva automation publish --name daily-briefing --version 1.0.0 \
 - **`alva automation publish` is required** — without it, the push is still
   dispatched but arrives with an empty body (no `title`/`body`).
 - `--push-notify` only enables publisher-side fanout. It does **not** create
-  personal alerts or group subscriptions.
-- Real delivery requires an explicit FEED alert/subscription: personal
-  `alva alert enable --automation <owner>/<feed>` or a group FEED subscription
-  configured from the attached external group. Following a playbook does not
+  personal or group alerts.
+- Real delivery requires an explicit FEED alert: personal `alva alert enable
+  --automation <owner>/<feed>` or, from the attached external group, `alva alert
+  group enable --automation-ids <feed_id>`. Following a playbook does not
   subscribe any of its feeds. For inventory and unsubscribe (including deleted
   feed rows), see [push-notifications.md](push-notifications.md) § Inventory And
   Unsubscribe.

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -28,10 +28,11 @@ create a second copy. Choose the destination before mutating it:
   `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
   binds the alert to that in-product channel. A topic channel is not an
   external IM group, and its channel id is not a channel-session id.
-- **External IM group:** from the attached Telegram, Discord, or Slack group,
-  use `/alva subscribe feed <id>`. The CLI `alva channel
-  group-subscriptions ... --session-id <channel_session_id>` is only for that
-  external group. Never pass an Alva channel id as `--session-id`.
+- **External IM group:** group delivery requires an explicit FEED subscription
+  configured from the attached Telegram, Discord, or Slack group by its Alva
+  admin. The channel-group session profile owns the operation and current-group
+  routing. Outside that group context, do not claim group delivery is configured
+  and do not substitute a personal alert or Alva topic-channel binding.
 
 The name-addressed `alva alert enable --automation <owner>/<feed>` command has
 no destination flag. When the user says "this channel", use the id-addressed

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -28,11 +28,13 @@ create a second copy. Choose the destination before mutating it:
   `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
   binds the alert to that in-product channel. A topic channel is not an
   external IM group, and its channel id is not a channel-session id.
-- **External IM group:** group delivery requires an explicit FEED subscription
-  configured from the attached Telegram, Discord, or Slack group by its Alva
-  admin. The channel-group session profile owns the operation and current-group
-  routing. Outside that group context, do not claim group delivery is configured
-  and do not substitute a personal alert or Alva topic-channel binding.
+- **External IM group:** from the attached Telegram, Discord, or Slack group,
+  use `alva alert group list`, `alva alert group enable --automation-ids <id>`,
+  or the matching `disable` command. These commands infer the current group and
+  accept no session id. Only the group's Alva admin may mutate group alerts, and
+  the admin must own or be able to read the feed; the feed need not be public.
+  Outside that group context, do not claim group delivery is configured and do
+  not substitute a personal alert or Alva topic-channel binding.
 
 The name-addressed `alva alert enable --automation <owner>/<feed>` command has
 no destination flag. When the user says "this channel", use the id-addressed
@@ -57,9 +59,10 @@ A push is set up only after all of these succeed:
 4. Enable the FEED alert for the intended destination using
    [Choose The Delivery Destination](#choose-the-delivery-destination). For the
    default personal destination, use `alva alert enable --automation
-   <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`.
-5. Wait for a scheduled real run, read `@last/1` of the sidecar, and confirm the
-   record is fresh and the message is non-empty or contains
+   <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`. For the
+   current external group, use `alva alert group enable --automation-ids <id>`.
+5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
+   the record is fresh and the message is non-empty or contains
    `<|SKIP_NOTIFICATION|>` for a quiet run.
 
 If the automation is unpublished, the feed has no sidecar record, or the record
@@ -89,5 +92,7 @@ as a snapshot: feeds added by a later release are not subscribed automatically.
   targets; use `alva alert disable --automation-ids a,b` for bulk and for
   `TARGET_DELETED` feed ghosts (name-addressed calls 404 on deleted targets).
 - Use the `target.id` returned by `alva alert list` for a deleted feed row.
+- In an attached external group, use `alva alert group list` for inventory and
+  `alva alert group disable --automation-ids <id>` to remove group delivery.
 - Never probe with mutating calls — the read surface answers all identity
   questions.

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -27,7 +27,11 @@ create a second copy. Choose the destination before mutating it:
 - **Alva topic channel:** resolve the feed id and run
   `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
   binds the alert to that in-product channel. A topic channel is not an
-  external IM group, and its channel id is not a channel-session id.
+  external IM group, its channel id is not a channel-session id, and delivery
+  is web-only. In a channel turn, read the current id from
+  `<session-prefill-channel-memory channel-id="…">`; a non-`alva` slug denotes
+  a topic channel. If the user says "this channel" or "current channel" there,
+  this is the required destination.
 - **External IM group:** from the attached Telegram, Discord, or Slack group,
   use `alva alert group list`, `alva alert group enable --automation-ids <id>`,
   or the matching `disable` command. These commands infer the current group and
@@ -39,6 +43,10 @@ create a second copy. Choose the destination before mutating it:
 The name-addressed `alva alert enable --automation <owner>/<feed>` command has
 no destination flag. When the user says "this channel", use the id-addressed
 form with `--channel-id`; do not silently fall back to the default destination.
+Do not infer Telegram, Discord, Slack, or another transport from the generic
+`channel` session profile. Only name an external transport when current context
+explicitly identifies it; otherwise describe a topic destination as the
+`current Alva topic channel (channel id <id>)`.
 
 If no active IM channel exists for the default personal destination, say web
 notifications will work immediately and the user can connect Telegram,
@@ -54,16 +62,25 @@ A push is set up only after all of these succeed:
      and proactive alerts.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-automation-publish`.
-3. Enable publisher push on the cronjob:
+3. Read `@last/1` of the sidecar written by the lifecycle test and confirm the
+   message is non-empty or contains `<|SKIP_NOTIFICATION|>` for a quiet run.
+4. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-4. Enable the FEED alert for the intended destination using
+5. Enable the FEED alert for the intended destination using
    [Choose The Delivery Destination](#choose-the-delivery-destination). For the
    default personal destination, use `alva alert enable --automation
    <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`. For the
+   current Alva topic channel, use `alva alert enable --automation-ids <id,id>
+   --channel-id <current_channel_id>`; never replace this with the
+   name-addressed default-personal command. For the
    current external group, use `alva alert group enable --automation-ids <id>`.
-5. Trigger or wait for a real run, read `@last/1` of the sidecar, and confirm
-   the record is fresh and the message is non-empty or contains
-   `<|SKIP_NOTIFICATION|>` for a quiet run.
+
+Do not trigger the cronjob or wait for its next scheduled run solely to verify
+setup. A successful enable proves that alert delivery is configured for the
+selected destination; it does not prove that a message has already been
+delivered. A sidecar record alone is also not delivery proof. Claim real
+delivery only when an existing `alva alert history` row for the intended
+destination records the run as `sent`.
 
 If the automation is unpublished, the feed has no sidecar record, or the record
 has an empty body, do not claim push is set up. Diagnose and fix first.
@@ -71,7 +88,9 @@ has an empty body, do not claim push is set up. Diagnose and fix first.
 Confirm to the user with specifics: which automation alerts are enabled, the
 intended destination, what the next push will say, and when it will fire. A
 global "subscribed" state is not sufficient evidence that an alert targets the
-requested Alva topic channel. For monitors, say quiet runs skip notifications.
+requested Alva topic channel. For a topic binding, report it as an Alva web
+topic channel with its id, never as Telegram or another external DM. For
+monitors, say quiet runs skip notifications.
 
 There is no playbook alert target. Following or unfollowing a playbook never
 changes alerts. If the user explicitly asks to enable every current automation

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -26,20 +26,12 @@ create a second copy. Choose the destination before mutating it:
   delivery uses `active_channel` plus its matching username from `alva whoami`.
 - **Alva topic channel:** resolve the feed id and run
   `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
-  binds the alert to that in-product channel. A topic channel is not an
-  external IM group, its channel id is not a channel-session id, and delivery
-  is web-only. In a channel turn, read the current id from
+  binds the alert to that in-product web channel. Its channel id is not a
+  channel-session id. Topic-channel delivery is web-only. In a channel turn,
+  read the current id from
   `<session-prefill-channel-memory channel-id="…">`; a non-`alva` slug denotes
   a topic channel. If the user says "this channel" or "current channel" there,
   this is the required destination.
-- **External IM group:** from the attached Telegram, Discord, or Slack group,
-  use `alva alert group list`, `alva alert group enable --automation-ids <id>`,
-  or the matching `disable` command. These commands infer the current group and
-  accept no session id. Only the group's Alva admin may mutate group alerts, and
-  the admin must own or be able to read the feed; the feed need not be public.
-  Outside that group context, do not claim group delivery is configured and do
-  not substitute a personal alert or Alva topic-channel binding.
-
 The name-addressed `alva alert enable --automation <owner>/<feed>` command has
 no destination flag. When the user says "this channel", use the id-addressed
 form with `--channel-id`; do not silently fall back to the default destination.
@@ -72,8 +64,7 @@ A push is set up only after all of these succeed:
    <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`. For the
    current Alva topic channel, use `alva alert enable --automation-ids <id,id>
    --channel-id <current_channel_id>`; never replace this with the
-   name-addressed default-personal command. For the
-   current external group, use `alva alert group enable --automation-ids <id>`.
+   name-addressed default-personal command.
 
 Do not trigger the cronjob or wait for its next scheduled run solely to verify
 setup. A successful enable proves that alert delivery is configured for the
@@ -111,7 +102,5 @@ as a snapshot: feeds added by a later release are not subscribed automatically.
   targets; use `alva alert disable --automation-ids a,b` for bulk and for
   `TARGET_DELETED` feed ghosts (name-addressed calls 404 on deleted targets).
 - Use the `target.id` returned by `alva alert list` for a deleted feed row.
-- In an attached external group, use `alva alert group list` for inventory and
-  `alva alert group disable --automation-ids <id>` to remove group delivery.
 - Never probe with mutating calls — the read surface answers all identity
   questions.


### PR DESCRIPTION
## Summary

- remove external-group commands, admin rules, visibility rules, and session inference from the public Alva skill and its feed/deployment references
- keep external-group alert operations owned exclusively by sandbox CHANNEL_GROUP.md, which is injected only for group turns
- limit the general skill to default personal alerts and Alva web topic-channel bindings
- require a current topic channel to use the prefilled numeric channel id with alva alert enable --automation-ids ... --channel-id ...
- prohibit inferring Telegram/Discord/Slack from the generic channel profile and require final confirmation to name the verified Alva web topic channel
- do not trigger or wait for a producer run solely to verify alert setup
- distinguish configuration proof from real-delivery proof
- add deterministic destination-boundary and channel-id=44 regression coverage

## Breaking Changes

None.

## Database Migrations

None.

## Merge Order

1. https://github.com/alva-ai/sandbox-agent-ts/pull/292
2. This PR

## Related PRs

- https://github.com/alva-ai/sandbox-agent-ts/pull/291 (merged; CHANNEL_GROUP.md owns group alert commands)
- https://github.com/alva-ai/sandbox-agent-ts/pull/292 (topic-channel identity fix)

## Test Plan

- node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva --cases evals/alva-skill-docs/cases.json --scenarios evals/alva-skill-docs/scenarios.json (58/58 cases, 542/542 checks)
- node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva (9/9)
- rg confirms no group-alert or group-subscription commands remain under skills/alva
- git diff --check
- SKILL.md remains below the 850-line eval ceiling