### PR TITLE
chore(alva): bump version to v1.18.1

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -894,7 +894,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.17.0",
+        "version: v1.18.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.17.0
+  version: v1.18.1
 ---
 
 # Alva


### PR DESCRIPTION
## Summary
- set the Alva skill metadata version to `v1.18.1`
- prepare the current reviewed skill contents for an immutable GitHub release
- leave the existing `v1.18.0` tag untouched

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
Merge before creating the `v1.18.1` GitHub Release and before pinning sandbox-agent-ts.

## Related PRs
- alva-ai/toolkit-ts#137

## Verification
- Ruby YAML frontmatter validation (`metadata.version=v1.18.1`)
- `bash -n skills/alva/scripts/version_check.sh`
- `git diff --check`