### PR TITLE
docs(company-anomaly): summaryWithCitationsMarkdown, skipped tag, session-move fields

### DIFF
--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -60,11 +60,19 @@ episode purposes:
 | `tag`                  | `attributionClassKey`                       | Meaning                                                                    |
 | ---------------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
 | `not_triggered`        | `not_triggered`                             | Signals did not cross an anomaly rule. Quiet — not a claim price was flat. |
-| `insufficient_history` | `insufficient_history`                      | Not enough history to evaluate the signal.                                 |
+| `not_triggered`        | `insufficient_history`                      | History too short for a z-score **and** the absolute move stayed under the `insufficient_history_price_move` threshold — quiet, not active. `insufficient_history` is a class derived from `realReason`, **not** a `tag`. |
 | `real`                 | `new_anomaly` / `continued_new_attribution` | A confirmed, publishable attribution exists for this run.                  |
 | `candidate`            | `continued_no_new_attribution`              | Anomaly continued, but this run produced no new confirmed attribution.     |
 | `no_material`          | `continued_no_info`                         | Possible new material was checked but did not qualify as novel/material.   |
 | `skipped`              | `skipped`                                   | Data-quality skip — the run could not evaluate signals. Preserves the current active/inactive state; can carry `isActiveAnomaly: "true"` mid-episode. |
+
+There is no `insufficient_history` `tag` (the tags are `not_triggered`,
+`skipped`, `no_material`, `candidate`, `real`). A low-history ticker (e.g. a
+recent IPO) is still evaluated against an absolute-move threshold: if
+`|priceMovePct|` crosses `insufficient_history_price_move`, the run triggers as
+a normal anomaly (`real` / `candidate`, active episode) like any other. Only
+when the move stays under that threshold does the run stay quiet as
+`tag: not_triggered` with `attributionClassKey: insufficient_history`.
 
 ### Anomaly Episode
 
@@ -83,7 +91,7 @@ Current episode boundaries, keyed by the run's `attributionClassKey`:
 | `continued_no_info`            | Continue the current episode; no new material, or new info verified as not actually new           | —                      |
 | `skipped`                      | Data-quality skip; keeps the current episode open when `isActiveAnomaly` is `"true"`, otherwise leaves state unchanged (opens/closes nothing) | —                      |
 | `not_triggered`                | No anomaly rule fires; not active, close the episode (also stale / no current data)               | —                      |
-| `insufficient_history`         | Not enough history to evaluate the signal; not active, close the episode                          | —                      |
+| `insufficient_history`         | Low-history ticker whose absolute move stayed under the trigger threshold; quiet, not active, close the episode | —                      |
 
 ### Attribution
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -275,10 +275,8 @@ Label the driver split and narrative as Alva analysis, not established causality
 `movePct` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` / `latestPrice`
 are the attribution run's own snapshot, as-of its `latestPriceAsOfMs` — pair them
 with this driver, not a newer timeline tick. Both timeline and attribution
-`latestPrice` are point-in-time snapshots (each as-of its own `latestPriceAsOfMs`)
-and lag real time — even the latest timeline row. For a live price use Data
-Skills, not these rows; and never show an attribution's (often much older)
-`latestPrice` as current.
+`latestPrice` are point-in-time snapshots (each as-of its own `latestPriceAsOfMs`).
+For a live price use Data Skills, not these rows.
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -71,7 +71,9 @@ episode purposes:
 - **Price** — a **two-sided** z-score of the latest move against the trailing
   **90 trading days** of daily returns (`z = (move − mean) / stdev`), with tiers
   at **|z| ≥ 1 / 1.5 / 2**.
-- **Volume** — a **one-sided** volume z-score (elevated volume only), tiers at
+- **Volume** — a **one-sided** z-score of today's cumulative volume *at this
+  point in the session* against the same-slot cumulative volume across the
+  baseline window of prior sessions (`z = (cumVol − mean) / stdev`), tiers at
   **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular session**.
 - **Low history** — with too little history for a z-score (e.g. a recent IPO),
   the run instead triggers on the **absolute** move (default **≥ 5%**);

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -271,22 +271,12 @@ as though it were a regular-session return.
 | `previousClose`                         | Baseline close the move is measured against |
 | `latestPriceAsOfMs`                     | Timestamp of this attribution's `latestPrice` |
 
-Supporting events and source links are already copied onto the attribution, so
-the consumer contract does not read the raw `event/items` stream. Label the
-driver split and narrative as Alva analysis, not established causality.
-`summaryWithCitationsMarkdown` is the same analysis with source links inline —
-the links are evidence, the narrative is still Alva analysis. `movePct` /
-`priceMoveBasis` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` are the
-signal snapshot **as of the attribution's own run** — pair them with the driver,
-not with a newer timeline tick.
-
-**Price carries its own timestamp — read it against `latestPriceAsOfMs`, not the
-row's `runAtMs`.** The latest `anomaly/timeline` row's `latestPrice` is the
-**current** price (as-of its `latestPriceAsOfMs`, ~one run ago); an attribution's
-`latestPrice` is the price **when that driver was computed** (its own, possibly
-much older, `latestPriceAsOfMs`). They routinely differ — e.g. a 1-minute-old
-timeline price next to a 30-minute-old attribution. Never render an attribution's
-stale price as the current price; show each with its own `latestPriceAsOfMs`.
+Label the driver split and narrative as Alva analysis, not established causality.
+`movePct` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` / `latestPrice`
+are the attribution run's own snapshot, as-of its `latestPriceAsOfMs` — pair them
+with this driver, not a newer timeline tick. For current price/state read the
+latest `anomaly/timeline` row; an attribution's `latestPrice` is the price when
+the driver was computed, so never show it as current.
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -68,14 +68,14 @@ episode purposes:
 
 ### What A Run Tests
 
-- **Price** — a standardized price move (z-score of the latest move against the
-  ticker's recent daily-return distribution) crossing a tier threshold.
-- **Volume** — a standardized volume move, evaluated **only during the regular
-  session**.
-- **Low history** — when there isn't enough history for a price z-score (e.g. a
-  recent IPO), the run instead tests the **absolute** price move against a
-  threshold; crossing it triggers a normal anomaly, otherwise the run stays
-  quiet with `attributionClassKey: insufficient_history`.
+- **Price** — a **two-sided** z-score of the latest move against the trailing
+  **90 trading days** of daily returns (`z = (move − mean) / stdev`), with tiers
+  at **|z| ≥ 1 / 1.5 / 2**.
+- **Volume** — a **one-sided** volume z-score (elevated volume only), tiers at
+  **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular session**.
+- **Low history** — with too little history for a z-score (e.g. a recent IPO),
+  the run instead triggers on the **absolute** move (default **≥ 5%**);
+  otherwise it stays quiet with `attributionClassKey: insufficient_history`.
 - **Move basis** (`priceMoveBasis`) — pre-market and regular-session moves are
   measured against the **previous day's close**; after-hours moves count as a
   new day and are measured against **today's (regular-session) close**.

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -274,24 +274,6 @@ the links are evidence, the narrative is still Alva analysis. `movePct` /
 signal snapshot **as of the attribution's own run** — pair them with the driver,
 not with a newer timeline tick.
 
-`decompositionJson` is the computed "how much"; the `driver*` fields are the
-LLM's "why" over the same three layers. Example (one NVDA run, trimmed):
-
-```json
-// decompositionJson — quantitative split of a -2.72% move
-{ "nameMovePct": -2.72,
-  "market":        { "movePct": -1.28 },
-  "sector":        { "beyondMarketPct": -0.13 },
-  "idiosyncratic": { "beyondSectorPct": -1.32 },
-  "dominant": "idiosyncratic" }
-```
-
-```text
-driverMarket        : broad risk-off — Iran escalation, oil/VIX up
-driverSector        : semis only slightly worse than the market
-driverAssetSpecific : NVDA underperformed peers on mega-cap rotation
-```
-
 ## Internal Surfaces (Not The Contract)
 
 These partitions are producer-internal — audit, debug, and observability. They

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -64,6 +64,7 @@ episode purposes:
 | `real`                 | `new_anomaly` / `continued_new_attribution` | A confirmed, publishable attribution exists for this run.                  |
 | `candidate`            | `continued_no_new_attribution`              | Anomaly continued, but this run produced no new confirmed attribution.     |
 | `no_material`          | `continued_no_info`                         | Possible new material was checked but did not qualify as novel/material.   |
+| `skipped`              | `skipped`                                   | Data-quality skip — the run could not evaluate signals. Preserves the current active/inactive state; can carry `isActiveAnomaly: "true"` mid-episode. |
 
 ### Anomaly Episode
 
@@ -80,6 +81,7 @@ Current episode boundaries, keyed by the run's `attributionClassKey`:
 | `continued_new_attribution`    | Continue the current episode with a newly published driver                                       | `finding/attribution`  |
 | `continued_no_new_attribution` | Continue the current episode; new material was checked and the LLM ran, but it did not pass promotion | `finding/candidate`    |
 | `continued_no_info`            | Continue the current episode; no new material, or new info verified as not actually new           | —                      |
+| `skipped`                      | Data-quality skip; keeps the current episode open when `isActiveAnomaly` is `"true"`, otherwise leaves state unchanged (opens/closes nothing) | —                      |
 | `not_triggered`                | No anomaly rule fires; not active, close the episode (also stale / no current data)               | —                      |
 | `insufficient_history`         | Not enough history to evaluate the signal; not active, close the episode                          | —                      |
 
@@ -139,8 +141,9 @@ Logic for ticker `TICKER`:
 2. Take `runAtMs` as the latest run time and `anomalyEpisodeId` /
    `episodeFirstRunId` as the current episode identity.
 3. **Determine active anomaly:** `isActiveAnomaly === "true"`. The producer sets
-   this flag exactly when `tag` is `real`, `candidate`, or `no_material`, so read
-   the flag directly rather than re-deriving it from `tag`.
+   this flag when `tag` is `real`, `candidate`, or `no_material`, and also on a
+   `skipped` (data-quality) run that lands mid-episode, so read the flag directly
+   rather than re-deriving it from `tag`.
 4. **If not active:** return `inAnomaly: false`, `latestRealAttribution: null`.
 5. **If active:** read confirmed attributions:
    `<feed-base>/data/finding/attribution/@last/20`. Do **not** read
@@ -163,6 +166,7 @@ Logic for ticker `TICKER`:
     "runAtMs": 1784102823773,
     "headline": "...",
     "summary": "...",
+    "summaryWithCitationsMarkdown": "...",
     "confidence": "high",
     "attributionStatus": "confirmed",
     "driverMarket": "...",
@@ -210,6 +214,8 @@ history.
 | `attributionClassKey` | Attribution class/key for the run                                          |
 | `priceMovePct`        | Move on the basis named by `priceMoveBasis`                                |
 | `priceMoveBasis`      | Comparison basis (e.g. pre-market vs previous close, after-hours vs close) |
+| `regularSessionMovePct` / `preMarketMovePct` / `afterHoursMovePct` / `totalMovePct` | Per-session breakdown of the move; pair with `priceMoveBasis` so a pre-market/after-hours move is not read as a regular-session return |
+| `realReason`          | Why the run reached its classification (e.g. `first`, `new_rule`, `insufficient_history`) |
 | `priceZScore`         | Standardized price signal                                                  |
 | `volumeZScore`        | Standardized volume signal                                                 |
 | `newRulesJson`        | JSON array of rules newly active in this transition                        |
@@ -230,6 +236,7 @@ as though it were a regular-session return.
 | `symbol`                                | Attributed company                                |
 | `headline`                              | Short likely-driver statement                     |
 | `summary`                               | Full attribution narrative                        |
+| `summaryWithCitationsMarkdown`          | Same narrative as `summary`, with inline Markdown source links (`([source](url))`) after sourced claims, drawn only from `supportingEvents` / `sourceLinks`; falls back to `summary` when absent |
 | `drivers` / driver split                | Decomposition into market, sector, asset-specific |
 | `confidence`                            | Confidence classification                         |
 | `attributionStatus`                     | Result status; the contract uses `confirmed` rows |
@@ -239,6 +246,8 @@ as though it were a regular-session return.
 Supporting events and source links are already copied onto the attribution, so
 the consumer contract does not read the raw `event/items` stream. Label the
 driver split and narrative as Alva analysis, not established causality.
+`summaryWithCitationsMarkdown` is the same analysis with source links inline —
+the links are evidence, the narrative is still Alva analysis.
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -66,13 +66,19 @@ episode purposes:
 | `no_material`          | `continued_no_info`                         | Possible new material was checked but did not qualify as novel/material.   |
 | `skipped`              | `skipped`                                   | Data-quality skip — the run could not evaluate signals. Preserves the current active/inactive state; can carry `isActiveAnomaly: "true"` mid-episode. |
 
-There is no `insufficient_history` `tag` (the tags are `not_triggered`,
-`skipped`, `no_material`, `candidate`, `real`). A low-history ticker (e.g. a
-recent IPO) is still evaluated against an absolute-move threshold: if
-`|priceMovePct|` crosses `insufficient_history_price_move`, the run triggers as
-a normal anomaly (`real` / `candidate`, active episode) like any other. Only
-when the move stays under that threshold does the run stay quiet as
-`tag: not_triggered` with `attributionClassKey: insufficient_history`.
+### What A Run Tests
+
+- **Price** — a standardized price move (z-score of the latest move against the
+  ticker's recent daily-return distribution) crossing a tier threshold.
+- **Volume** — a standardized volume move, evaluated **only during the regular
+  session**.
+- **Low history** — when there isn't enough history for a price z-score (e.g. a
+  recent IPO), the run instead tests the **absolute** price move against a
+  threshold; crossing it triggers a normal anomaly, otherwise the run stays
+  quiet with `attributionClassKey: insufficient_history`.
+- **Move basis** (`priceMoveBasis`) — pre-market and regular-session moves are
+  measured against the **previous day's close**; after-hours moves count as a
+  new day and are measured against **today's (regular-session) close**.
 
 ### Anomaly Episode
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -72,9 +72,10 @@ episode purposes:
   **90 trading days** of daily returns (`z = (move − mean) / stdev`), with tiers
   at **|z| ≥ 1 / 1.5 / 2**.
 - **Volume** — a **one-sided** z-score of today's cumulative volume *at this
-  point in the session* against the same-slot cumulative volume across the
-  baseline window of prior sessions (`z = (cumVol − mean) / stdev`), tiers at
-  **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular session**.
+  point in the session* against the same-slot cumulative volume over the prior
+  **~1 month** of sessions (`volumeBaselineWindow`, `1M`; `z = (cumVol − mean) /
+  stdev`), tiers at **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular
+  session**.
 - **Low history** — with too little history for a z-score (e.g. a recent IPO),
   the run instead triggers on the **absolute** move (default **≥ 5%**);
   otherwise it stays quiet with `attributionClassKey: insufficient_history`.

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -230,6 +230,9 @@ history.
 | `attributionClassKey` | Attribution class/key for the run                                          |
 | `priceMovePct`        | Move on the basis named by `priceMoveBasis`                                |
 | `priceMoveBasis`      | Comparison basis (e.g. pre-market vs previous close, after-hours vs close) |
+| `latestPrice`         | Price at this run (last 1-min bar close) |
+| `previousClose`       | Baseline close the move is measured against |
+| `latestPriceAsOfMs`   | Timestamp of `latestPrice` — the price is as-of this, not necessarily `runAtMs` |
 | `regularSessionMovePct` / `preMarketMovePct` / `afterHoursMovePct` / `totalMovePct` | Per-session breakdown of the move; pair with `priceMoveBasis` so a pre-market/after-hours move is not read as a regular-session return |
 | `realReason`          | Why the run reached its classification (e.g. `first`, `new_rule`, `insufficient_history`) |
 | `priceZScore`         | Standardized price signal                                                  |
@@ -264,6 +267,9 @@ as though it were a regular-session return.
 | `priceZScore`                           | Price z-score at that run                         |
 | `volumeZScore`                          | Volume z-score at that run                        |
 | `triggeredRulesJson`                    | JSON array of rules that fired (e.g. `price_z2`, `volume_z1`, `insufficient_history_price_move`) |
+| `latestPrice`                           | Price at the attribution run (as-of `latestPriceAsOfMs`) |
+| `previousClose`                         | Baseline close the move is measured against |
+| `latestPriceAsOfMs`                     | Timestamp of this attribution's `latestPrice` |
 
 Supporting events and source links are already copied onto the attribution, so
 the consumer contract does not read the raw `event/items` stream. Label the
@@ -273,6 +279,14 @@ the links are evidence, the narrative is still Alva analysis. `movePct` /
 `priceMoveBasis` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` are the
 signal snapshot **as of the attribution's own run** — pair them with the driver,
 not with a newer timeline tick.
+
+**Price carries its own timestamp — read it against `latestPriceAsOfMs`, not the
+row's `runAtMs`.** The latest `anomaly/timeline` row's `latestPrice` is the
+**current** price (as-of its `latestPriceAsOfMs`, ~one run ago); an attribution's
+`latestPrice` is the price **when that driver was computed** (its own, possibly
+much older, `latestPriceAsOfMs`). They routinely differ — e.g. a 1-minute-old
+timeline price next to a 30-minute-old attribution. Never render an attribution's
+stale price as the current price; show each with its own `latestPriceAsOfMs`.
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -274,9 +274,11 @@ as though it were a regular-session return.
 Label the driver split and narrative as Alva analysis, not established causality.
 `movePct` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` / `latestPrice`
 are the attribution run's own snapshot, as-of its `latestPriceAsOfMs` — pair them
-with this driver, not a newer timeline tick. For current price/state read the
-latest `anomaly/timeline` row; an attribution's `latestPrice` is the price when
-the driver was computed, so never show it as current.
+with this driver, not a newer timeline tick. Both timeline and attribution
+`latestPrice` are point-in-time snapshots (each as-of its own `latestPriceAsOfMs`)
+and lag real time — even the latest timeline row. For a live price use Data
+Skills, not these rows; and never show an attribution's (often much older)
+`latestPrice` as current.
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -73,9 +73,8 @@ episode purposes:
   at **|z| ≥ 1 / 1.5 / 2**.
 - **Volume** — a **one-sided** z-score of today's cumulative volume *at this
   point in the session* against the same-slot cumulative volume over the prior
-  **~1 month** of sessions (`volumeBaselineWindow`, `1M`; `z = (cumVol − mean) /
-  stdev`), tiers at **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular
-  session**.
+  **90 trading days** (`z = (cumVol − mean) / stdev`), tiers at
+  **z ≥ 1 / 1.5 / 2**, evaluated **only during the regular session**.
 - **Low history** — with too little history for a z-score (e.g. a recent IPO),
   the run instead triggers on the **absolute** move (default **≥ 5%**);
   otherwise it stays quiet with `attributionClassKey: insufficient_history`.

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -253,7 +253,8 @@ as though it were a regular-session return.
 | `headline`                              | Short likely-driver statement                     |
 | `summary`                               | Full attribution narrative                        |
 | `summaryWithCitationsMarkdown`          | Same narrative as `summary`, with inline Markdown source links (`([source](url))`) after sourced claims, drawn only from `supportingEvents` / `sourceLinks`; falls back to `summary` when absent |
-| `drivers` / driver split                | Decomposition into market, sector, asset-specific |
+| `driverMarket` / `driverSector` / `driverAssetSpecific` | Per-layer **narrative** ("why"), LLM-generated — the market, sector, and asset-specific drivers (no single `drivers` field) |
+| `decompositionJson`                     | Computed **quantitative** 3-way split ("how much") — `market.movePct`, `sector.beyondMarketPct`, `idiosyncratic.beyondSectorPct` (each with a `z`), plus `dominant` / `dominantOrder` |
 | `confidence`                            | Confidence classification                         |
 | `attributionStatus`                     | Result status; the contract uses `confirmed` rows |
 | `supportingEvents`                      | Evidence items (`title`, `why_it_fits`, `url`)    |
@@ -272,6 +273,24 @@ the links are evidence, the narrative is still Alva analysis. `movePct` /
 `priceMoveBasis` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` are the
 signal snapshot **as of the attribution's own run** — pair them with the driver,
 not with a newer timeline tick.
+
+`decompositionJson` is the computed "how much"; the `driver*` fields are the
+LLM's "why" over the same three layers. Example (one NVDA run, trimmed):
+
+```json
+// decompositionJson — quantitative split of a -2.72% move
+{ "nameMovePct": -2.72,
+  "market":        { "movePct": -1.28 },
+  "sector":        { "beyondMarketPct": -0.13 },
+  "idiosyncratic": { "beyondSectorPct": -1.32 },
+  "dominant": "idiosyncratic" }
+```
+
+```text
+driverMarket        : broad risk-off — Iran escalation, oil/VIX up
+driverSector        : semis only slightly worse than the market
+driverAssetSpecific : NVDA underperformed peers on mega-cap rotation
+```
 
 ## Internal Surfaces (Not The Contract)
 

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -258,12 +258,20 @@ as though it were a regular-session return.
 | `attributionStatus`                     | Result status; the contract uses `confirmed` rows |
 | `supportingEvents`                      | Evidence items (`title`, `why_it_fits`, `url`)    |
 | `sourceLinks`                           | Supporting source URLs                            |
+| `movePct`                               | Price move at the attribution run (signal snapshot) |
+| `priceMoveBasis`                        | Basis for that move (pre-market / after-hours / intraday) |
+| `priceZScore`                           | Price z-score at that run                         |
+| `volumeZScore`                          | Volume z-score at that run                        |
+| `triggeredRulesJson`                    | JSON array of rules that fired (e.g. `price_z2`, `volume_z1`, `insufficient_history_price_move`) |
 
 Supporting events and source links are already copied onto the attribution, so
 the consumer contract does not read the raw `event/items` stream. Label the
 driver split and narrative as Alva analysis, not established causality.
 `summaryWithCitationsMarkdown` is the same analysis with source links inline —
-the links are evidence, the narrative is still Alva analysis.
+the links are evidence, the narrative is still Alva analysis. `movePct` /
+`priceMoveBasis` / `priceZScore` / `volumeZScore` / `triggeredRulesJson` are the
+signal snapshot **as of the attribution's own run** — pair them with the driver,
+not with a newer timeline tick.
 
 ## Internal Surfaces (Not The Contract)
 


### PR DESCRIPTION
Updates `skills/alva/references/company-anomaly.md` to match the current producer code. Consumer-contract doc only — producer internals (volume/market-metrics caches, sharding) intentionally left out of scope.

**1. `summaryWithCitationsMarkdown` (new attribution field)**
- Added to the Attribution Fields table, the Return Shape example, and the analysis-layer note.
- Same narrative as `summary` with inline Markdown source links (`([source](url))`) drawn only from `supportingEvents`/`sourceLinks`; falls back to `summary` when absent. Written to both `finding/attribution` and `finding/candidate`.

**2. `skipped` tag/class (was missing)**
- Added to the Run table and the Episode-boundaries table.
- It's a data-quality skip that can carry `isActiveAnomaly: "true"` mid-episode (keeps the episode open); fixed the consumer-contract step 3 note, which previously said the flag is set "exactly when `tag` is real/candidate/no_material".

**3. Timeline session-move fields**
- Added `regularSessionMovePct` / `preMarketMovePct` / `afterHoursMovePct` / `totalMovePct` and `realReason`, reinforcing the existing "don't read a pre-market move as a regular-session return" guidance.

**4. `insufficient_history` is a class, not a tag**
- The tags are `not_triggered` / `skipped` / `no_material` / `candidate` / `real` — there is no `insufficient_history` tag. It's an `attributionClassKey` derived from `realReason`, riding on a `not_triggered` run.
- Low-history tickers (e.g. new IPOs) are still evaluated against an absolute-move threshold (`insufficient_history_price_move`, default 5%): crossing it triggers a normal `real`/`candidate` active anomaly; only a sub-threshold move stays quiet as `tag: not_triggered` + `attributionClassKey: insufficient_history`.
- Fixed the Run table (tag column), added a clarifying note, and reworded the episode-boundary row. The doc's "insufficient_history → not active, close episode" is correct in effect (it's the quiet, non-triggering case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)