### PR TITLE
SKILL.md: make X/non-US routing data-first

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -36,7 +36,7 @@ The main objects are:
 
 | Concept            | Meaning                                                                                                                                                      | Read when                                                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Data Skills        | 250+ structured Arrays endpoints for equities, options, crypto, macro, on-chain, semiconductor spot prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
+| Data Skills        | 250+ structured Arrays endpoints for US and non-US equities, fundamentals (earnings, filings), options, crypto, macro, on-chain, semiconductor spot/contract prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
 | Runtime script     | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs.                                                                          | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK.                                            |
 | Feed               | The persistent data pipeline and identity (`feed_id`) that writes outputs to ALFS. `alva automation` is its product-facing lifecycle CLI; `alva deploy` cronjobs produce its data. | Data needs freshness, history, public reads, charts, release, or push.                                         |
 | Playbook           | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`.                                                                                   | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface.                          |
@@ -216,10 +216,10 @@ Alva has broad coverage, but the boundaries are part of the product contract.
 Naming them early prevents wasted build time.
 
 **Structured data vs search.** Data Skills are for deterministic datasets and
-repeatable fields. Search is for source-backed context, non-US finance, global
-X/Grok search, and off-catalog assets. Search results may inform a feed or a
-source-cited answer, but they do not become raw chart data by being pasted into
-HTML.
+repeatable fields; search is for source-backed context and off-catalog assets.
+Try Data Skills first for anything it may cover — including X/social and non-US
+equities — and use search only for X/Grok beyond Arrays' indexed accounts or
+non-US tickers/intraday outside its curated coverage. Search informs a cited answer, not chart data.
 
 **Runtime vs local agent.** Runtime code runs on Alva Cloud, not on the agent's
 machine. It cannot use local filesystem paths, shell commands, Node builtins, or
@@ -320,9 +320,9 @@ not copy private runtime internals into user scripts.
 
 #### Data Access: Content Search And BYOD
 
-Content search enriches a real data pipeline; it does not replace one. Use it
-for market narratives, source discovery, global X/Grok queries, news, Reddit,
-YouTube, podcasts, web search, non-US finance, and off-catalog assets.
+Content search enriches a real data pipeline; it does not replace one — a fallback,
+not a default source. Try Data Skills, owned feeds, and official sources first; use
+it only for off-catalog content they can't provide (see Source routing).
 
 Open [search.md](references/search.md) for source-specific usage and gotchas,
 and [content-legitimacy.md](references/content-legitimacy.md) before presenting

--- a/skills/alva/references/fintwit.md
+++ b/skills/alva/references/fintwit.md
@@ -12,9 +12,11 @@ X/Twitter handle is tracked, what an account thinks about a ticker or theme, or 
 account's track record — read it here and answer from real data.
 
 **Not raw tweet search.** For "what is @X tweeting right now" with no
-curation/scoring, use Content Search (`getTwitterFeed`, see [search.md](search.md)).
-Fintwit Intelligence returns *processed* records: classified signals, extracted
-theses, backtested performance, computed rankings.
+curation/scoring, use Data Skills per-handle history / full-text over the X
+accounts Arrays tracks (see [data-skills.md](data-skills.md)); reach for Content
+Search (`searchGrokX`, see [search.md](search.md)) only for global X search
+beyond Arrays' tracked index. Fintwit Intelligence returns *processed* records:
+classified signals, extracted theses, backtested performance, computed rankings.
 
 ## Access
 

--- a/skills/alva/references/search.md
+++ b/skills/alva/references/search.md
@@ -21,16 +21,15 @@ below live in the `unified_search` partition.
 
 ### Finance Search
 
-- **Search**: `searchPerplexityFinance` — a live, source-cited finance answer engine covering quotes, company profiles, financial statements and ratios, valuation and pricing, earnings, analyst estimates, segment/KPI metrics, market movers, and ownership/corporate actions.
-- **Intended role**: the fallback for non-US equities outside the curated Data Skills set, and for asset classes outside the Alva data catalog.
-- **Non-US equities**: Data Skills carry a curated set of non-US listings (dotted-suffix tickers like `0700.HK`, `000660.KS`), now with intraday intervals (`1min`–`1m`) as well as daily — intraday covers a narrower subset than daily. Try Data Skills first for those; use finance search when the ticker isn't in the curated set, or intraday returns empty for it. Finance-search coverage is web-backed and best-effort, not a guaranteed dataset — depth and freshness track how well a market is reported online. Disambiguate the listing in the query — local ticker + exchange, or full company name (e.g. "Toyota 7203 on the Tokyo Stock Exchange", "HSBC on the LSE") — and verify the answer against the `sources` it returns.
-- **Forex, index & commodity**: in the catalog — Data Skills carry forex, major index levels, and commodity futures prices (e.g. gold, oil) via the macro endpoints (historical + real-time), so route them there, not to finance search. Crypto stays on the structured SDKs (`getCryptoKline`, perpetual-futures OHLCV, funding rates) — never route crypto to finance search. Use finance search only for asset classes genuinely outside the catalog.
-- **Query scoping**: state the business question first, then the company or ticker, then an explicit time window (`latest quarter`, `last 30 days`); it answers best when the prompt names the outcome, not the data shape.
-- **Fields**: `summary`, `data`/`arrays` result blocks, `tickers`, `sources`, and provider `usage` metadata when available.
-- **Gotcha**: a live search/answer tool, not a historical time-series endpoint. For US equities, crypto, and deterministic OHLCV / fundamentals / earnings / macro series, the structured Alva data SDKs are the source — finance search there adds only current context or source-backed enrichment.
+- **Data Skills first**: Data Skills (the structured Alva data) cover US and non-US equities, fundamentals (earnings, filings), options, crypto, macro (forex, index levels, commodity futures like gold/oil), on-chain, and prediction markets — route all of these there. `searchPerplexityFinance` is the fallback ONLY for non-US tickers outside the curated set (or when their intraday is empty) and asset classes genuinely outside the catalog.
+- **Search**: `searchPerplexityFinance` — a live, source-cited finance answer engine (quotes, profiles, statements/ratios, valuation, earnings, estimates, KPI metrics, market movers, ownership/corporate actions); current context or source-backed enrichment, not a historical time series.
+- **Non-US disambiguation**: name the local ticker + exchange or the full company name (e.g. "Toyota 7203 on the Tokyo Stock Exchange", "HSBC on the LSE"), and verify against the `sources` it returns. Coverage is web-backed and best-effort — depth and freshness track how well a market is reported online.
+- **Query scoping**: state the business question first, then the ticker, then a time window (`latest quarter`, `last 30 days`).
+- **Fields**: `summary`, `data`/`arrays` result blocks, `tickers`, `sources`, and provider `usage` when available.
 
 ### Twitter/X
 
+- **Data Skills first**: per-handle history, URL lookup, and full-text search over the X accounts Arrays tracks are served by Data Skills (see [data-skills.md](data-skills.md)). Use `searchGrokX` only for global X search beyond Arrays' tracked index.
 - **Search**: `searchGrokX` with `from_date`/`to_date` (YYYY-MM-DD format)
 - **Enrich**: Not needed — GrokX returns engagement natively
 - **Signals**: `like_count`, `retweet_count`, `reply_count`, `quote_count`


### PR DESCRIPTION
## Problem

Alva's routing intent is **Data Skills first** for tracked X/Twitter accounts and non-US equities, with search only as a fallback (for X activity beyond Arrays' index, or uncovered/intraday non-US prices). The authoritative **Source routing** section of `SKILL.md` and the `data-skills.md` / `search.md` references already say this correctly, but several summary passages contradicted it — some listing non-US finance / X search flatly under Search, and one reference routing tracked-handle tweet reads to search entirely.

## Changes

### `SKILL.md`
- **Concept table (Data Skills row):** call out US **and non-US** equity coverage (incl. non-US daily klines).
- **"Structured data vs search" (Capability Boundaries):** rewritten data-first — X/social and non-US equities go to Data Skills first; search only for X/Grok activity beyond Arrays' indexed accounts and non-US/intraday prices not covered by Data Skills.
- **"Content Search And BYOD":** same data-first framing with a back-reference to Source routing; narrowed "global X/Grok queries / non-US finance" to "beyond indexed accounts / not covered by Data Skills".

### References
- **`fintwit.md`:** "what is @X tweeting right now" was routed to Content Search via a `getTwitterFeed` function that does not exist in `search.md`, mislabeling tracked-handle tweet reads as search. Now routes to Data Skills per-handle history/full-text (consistent with `data-skills.md` and `search.md`), with `searchGrokX` reserved for global X search beyond the tracked index.
- **`search.md`:** added a "Data Skills first" note to the Twitter/X section, mirroring the caveat its non-US equities section already carries.

No behavioral routing change — this makes the summary passages and references consistent with the authoritative Source routing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)