### PR TITLE
docs(alva): use memory during automation setup

### DIFF
--- a/skills/alva/references/alva-knowledge.md
+++ b/skills/alva/references/alva-knowledge.md
@@ -7,6 +7,20 @@ automations. Feed construction and delivery mechanics remain in
 [feed-lifecycle.md](feed-lifecycle.md) and
 [push-notifications.md](push-notifications.md).
 
+## Use Memory During Setup
+
+When creating any automation, use relevant Global or Channel Memory already in
+context to prefill editable suggestions such as topics or tickers, timezone and
+cadence, thresholds, and notification preferences. Do not do extra Memory
+digging when nothing relevant is available, and never present a suggestion as a
+decision the user already made.
+
+If updated user context could improve later runs, ask one short setup question:
+should each run use relevant Memory, or keep today's confirmed setup fixed? Ask
+only when the choice would materially change the result. If the user opts in,
+use Memory as preference context and still fetch current facts from live
+sources; never expose private Memory content in public or shared output.
+
 ## Use History To Improve Judgment
 
 Do not default an automation to an isolated scheduled run. First decide whether


### PR DESCRIPTION
## Summary

- use relevant Global or Channel Memory already in context to prefill editable automation setup suggestions
- ask whether later runs should use updated saved context only when that choice would materially affect the result
- keep current facts sourced from live systems and private Memory out of public or shared output

## Why

Automation setup should feel personalized without introducing Memory modes, extra configuration, or an official-automation-only path.

## Impact

Agents can suggest topics or tickers, timezone and cadence, thresholds, and notification preferences from saved context while keeping every suggestion editable by the user.

## Companion PR

- https://github.com/alva-ai/sandbox-agent-ts/pull/295

## Validation

- `scenario.alert-push-monitor` passes in `skill-doc-eval.mjs`
- `git diff --check`

The full docs eval remains at 57/58 because the existing top-level `SKILL.md` is 880 lines against the 850-line size check; this PR does not change that file or line count.
