### PR TITLE
feat(alva): link companies to Alva company pages

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -871,10 +871,10 @@
       ]
     },
     {
-      "id": "communication.company-entity-links",
+      "id": "communication.company-page-links",
       "group": "communication",
       "target": "skill",
-      "description": "User-facing replies link high-confidence company mentions to production Entity Pages without extra lookups or ambiguous entity matches.",
+      "description": "User-facing replies link high-confidence company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
       "excludes": [
         "https://stg.alva.ai/company/",
         "https://stg.alva.xyz/company/"
@@ -882,22 +882,23 @@
       "section_includes": [
         {
           "file": "SKILL.md",
-          "heading": "Company Entity Links",
-          "label": "company entity link contract",
+          "heading": "Company Page Links",
+          "label": "company page link contract",
           "includes": [
             "In every user-facing Alva response",
-            "each covered stock company to its Company Entity Page",
+            "each covered stock company to its Alva company page",
             "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
             "semantically clear company names",
             "common names, or localized aliases",
             "Apple",
             "Use semantic context, not token shape alone",
-            "mapping, share class, or Company Entity coverage",
-            "Do not call a tool solely to add a link",
+            "company/ticker mapping already resolved by Alva data",
+            "mapping, share class, or page coverage",
+            "do not call a tool just to add a link",
             "Link each company at most once per reply",
             "non-company assets",
-            "Never emit a staging or relative Company Entity URL",
-            "Do not add an entity footer"
+            "Never use a staging host or relative URL for a company page",
+            "Do not add a separate company-page footer"
           ]
         }
       ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -887,9 +887,9 @@
           "includes": [
             "including New Chat and Alva Agent Channel",
             "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
-            "semantically clear company names or aliases",
+            "semantically clear company names",
+            "common names, or localized aliases",
             "Apple",
-            "苹果公司",
             "Use semantic context, not token shape alone",
             "mapping, share class, or Company Entity coverage",
             "Do not call a tool solely to add a link",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -871,6 +871,37 @@
       ]
     },
     {
+      "id": "communication.company-entity-links",
+      "group": "communication",
+      "target": "skill",
+      "description": "User-facing replies link high-confidence company mentions to production Entity Pages without extra lookups or ambiguous entity matches.",
+      "excludes": [
+        "https://stg.alva.ai/company/",
+        "https://stg.alva.xyz/company/"
+      ],
+      "section_includes": [
+        {
+          "file": "SKILL.md",
+          "heading": "Company Entity Links",
+          "label": "company entity link contract",
+          "includes": [
+            "including New Chat and Alva Agent Channel",
+            "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
+            "semantically clear company names or aliases",
+            "Apple",
+            "苹果公司",
+            "Use semantic context, not token shape alone",
+            "mapping, share class, or Company Entity coverage",
+            "Do not call a tool solely to add a link",
+            "Link each company at most once per reply",
+            "non-company assets",
+            "Never emit a staging or relative Company Entity URL",
+            "Do not add an entity footer"
+          ]
+        }
+      ]
+    },
+    {
       "id": "communication.concise-completion",
       "group": "communication",
       "target": "corpus",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -885,7 +885,8 @@
           "heading": "Company Entity Links",
           "label": "company entity link contract",
           "includes": [
-            "including New Chat and Alva Agent Channel",
+            "In every user-facing Alva response",
+            "each covered stock company to its Company Entity Page",
             "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
             "semantically clear company names",
             "common names, or localized aliases",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -837,10 +837,10 @@ identified with high confidence, wrap its first clear mention in
 `[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
-  company names or aliases such as `Apple` or `苹果公司` as the same entity
-  when context refers to Apple Inc. Use semantic context, not token shape
-  alone: do not link `apple` when it means fruit, `Meta` as a general term, or
-  `AI` as a theme rather than a company.
+  company names, common names, or localized aliases. Treat `Apple` as `AAPL`
+  when context refers to Apple Inc. Use semantic context, not token shape alone:
+  do not link `apple` when it means fruit, `Meta` as a general term, or `AI` as
+  a theme rather than a company.
 - Preserve the visible wording and use the canonical uppercase ticker only in
   the URL. Prefer an entity already resolved by Alva data or clearly established
   in the conversation. If the mapping, share class, or Company Entity coverage

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -829,10 +829,10 @@ Runtime artifacts:
 
 ## User-Facing Communication
 
-### Company Entity Links
+### Company Page Links
 
 In every user-facing Alva response, link the first high-confidence mention of
-each covered stock company to its Company Entity Page:
+each covered stock company to its Alva company page:
 `[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
@@ -841,15 +841,15 @@ each covered stock company to its Company Entity Page:
   do not link `apple` when it means fruit, `Meta` as a general term, or `AI` as
   a theme rather than a company.
 - Preserve the visible wording and use the canonical uppercase ticker only in
-  the URL. Prefer an entity already resolved by Alva data or clearly established
-  in the conversation. If the mapping, share class, or Company Entity coverage
-  is uncertain, leave it plain. Do not call a tool solely to add a link.
+  the URL. Prefer a company/ticker mapping already resolved by Alva data or
+  clearly established in the conversation. If the mapping, share class, or page
+  coverage is uncertain, leave it plain; do not call a tool just to add a link.
 - Link each company at most once per reply. Do not link non-company assets such
   as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
   quoted passages; or verbatim tool output.
 - Always use an absolute production URL under `https://alva.ai/company/`. Never
-  emit a staging or relative Company Entity URL. Do not add an entity footer or
-  explain that a link was added.
+  use a staging host or relative URL for a company page. Do not add a separate
+  company-page footer or explain that a link was added.
 
 Lead with the result, not the machinery. Say what the user got, what was
 verified, and what remains. Avoid raw ALFS paths, API payloads, job ids,

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -829,6 +829,29 @@ Runtime artifacts:
 
 ## User-Facing Communication
 
+### Company Entity Links
+
+Make covered stock companies directly navigable from every Alva-hosted
+user-facing reply, including New Chat and Alva Agent Channel. When a company is
+identified with high confidence, wrap its first clear mention in
+`[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
+
+- Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
+  company names or aliases such as `Apple` or `苹果公司` as the same entity
+  when context refers to Apple Inc. Use semantic context, not token shape
+  alone: do not link `apple` when it means fruit, `Meta` as a general term, or
+  `AI` as a theme rather than a company.
+- Preserve the visible wording and use the canonical uppercase ticker only in
+  the URL. Prefer an entity already resolved by Alva data or clearly established
+  in the conversation. If the mapping, share class, or Company Entity coverage
+  is uncertain, leave it plain. Do not call a tool solely to add a link.
+- Link each company at most once per reply. Do not link non-company assets such
+  as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
+  quoted passages; or verbatim tool output.
+- Always use an absolute production URL under `https://alva.ai/company/`. Never
+  emit a staging or relative Company Entity URL. Do not add an entity footer or
+  explain that a link was added.
+
 Lead with the result, not the machinery. Say what the user got, what was
 verified, and what remains. Avoid raw ALFS paths, API payloads, job ids,
 internal function names, or scaffold details unless the user is debugging or

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -831,9 +831,8 @@ Runtime artifacts:
 
 ### Company Entity Links
 
-Make covered stock companies directly navigable from every Alva-hosted
-user-facing reply, including New Chat and Alva Agent Channel. When a company is
-identified with high confidence, wrap its first clear mention in
+In every user-facing Alva response, link the first high-confidence mention of
+each covered stock company to its Company Entity Page:
 `[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear


### PR DESCRIPTION
## Summary

- Link the first high-confidence mention of each covered stock company in every user-facing Alva response to its production Alva company page.
- Recognize explicit tickers and semantically clear company names, common names, or localized aliases while preserving visible wording.
- Leave ambiguous mappings, unsupported asset types, existing links, quoted text, and verbatim tool output unchanged.
- Use only absolute `https://alva.ai/company/{CANONICAL_TICKER}` URLs; this iteration intentionally does not add tab deep links.
- Add a scoped documentation regression case for the company-page link contract.

## Why

This gives users a direct path from generated answers to the company one-pager without changing `CLAUDE.md`, frontend rendering, or channel adapters. The prompt stays conservative so links improve navigation without adding lookup latency or false company matches.

## Validation

- `jq empty evals/alva-skill-docs/cases.json`
- `git diff --check`
- `communication.company-page-links`: pass
- Full doc eval: 557/558 checks. The only miss is the existing `target.top-level-size` gate (`902 > 850`; base `main` was already `880 > 850`), so this PR does not fold in an unrelated Skill refactor.