### PR TITLE
feat(alva): add generic ticker analysis route

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -379,6 +379,56 @@
       ]
     },
     {
+      "id": "ticker-analysis.generic-single-ticker-method",
+      "group": "ticker-analysis",
+      "target": "corpus",
+      "description": "Broad analysis of one named equity routes through a reusable ticker-analysis method that combines setup, expectations, company evidence, anomaly context, and the live debate.",
+      "section_includes": [
+        {
+          "file": "SKILL.md",
+          "heading": "Request Routing",
+          "label": "top-level request route",
+          "includes": [
+            "broad analysis of one named equity or ticker",
+            "Financial Analysis: Ticker Analysis",
+            "Read [ticker-analysis.md](references/ticker-analysis.md)"
+          ]
+        },
+        {
+          "file": "SKILL.md",
+          "heading": "Financial Analysis / Ask Question Tree",
+          "label": "financial-analysis pointer",
+          "includes": [
+            "For broad analysis of one named equity",
+            "[ticker-analysis.md](references/ticker-analysis.md)",
+            "the default method",
+            "Company Anomaly"
+          ]
+        },
+        {
+          "file": "references/ticker-analysis.md",
+          "heading": "Ticker Analysis",
+          "label": "method chapter",
+          "includes": [
+            "Answer first",
+            "Do not lead with the last price or the day's move",
+            "buyable here",
+            "needs a pullback or confirmation",
+            "extended",
+            "no clean entry",
+            "what would improve or break the setup",
+            "WILF",
+            "expectations baseline",
+            "Company Anomaly",
+            "company-information sweep",
+            "one identifiable investor, operator, analyst, or industry expert",
+            "original post or source",
+            "confirm company guidance, financial figures, and event facts with stronger evidence"
+          ]
+        }
+      ]
+    },
+    {
       "id": "issue592.scoped-eval-checks",
       "group": "issue592",
       "target": "eval",
@@ -873,7 +923,7 @@
     {
       "id": "communication.company-page-links",
       "group": "communication",
-      "target": "skill",
+      "target": "corpus",
       "description": "User-facing replies link high-confidence company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
       "excludes": [
         "https://stg.alva.ai/company/",
@@ -881,7 +931,7 @@
       ],
       "section_includes": [
         {
-          "file": "SKILL.md",
+          "file": "references/user-facing-prose.md",
           "heading": "Company Page Links",
           "label": "company page link contract",
           "includes": [

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -19,6 +19,17 @@ const MUTATIONS = [
     expectFailedCases: ["issue592.financial-ask-contract", "scenario.simple-latest-price"],
   },
   {
+    id: "ticker-analysis-route",
+    file: "SKILL.md",
+    remove:
+      "For broad analysis of one named equity, read\n" +
+      "[ticker-analysis.md](references/ticker-analysis.md) and use it as the default method.\n",
+    expectFailedCases: [
+      "ticker-analysis.generic-single-ticker-method",
+      "scenario.broad-single-ticker-analysis",
+    ],
+  },
+  {
     id: "capability-before-refusal",
     file: "references/request-routing.md",
     remove: "Before saying Alva lacks a capability or recommending BYOD, verify the catalog:",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -51,6 +51,45 @@
       }
     },
     {
+      "id": "scenario.broad-single-ticker-analysis",
+      "group": "scenarios.ask",
+      "prompt": "分析一下 MU",
+      "description": "A broad named-equity ask uses the reusable ticker-analysis method before answering, without requiring the user to supply a thesis or turning the request into a playbook.",
+      "expect": {
+        "route": "Financial Analysis: Ticker Analysis",
+        "top_level_route": "Financial Analysis / Ask Question Tree",
+        "references": [
+          "ticker-analysis.md",
+          "company-anomaly.md",
+          "user-facing-prose.md"
+        ],
+        "behaviors": [
+          "Answer first",
+          "WILF as the expectations baseline",
+          "run the company-information sweep",
+          "test exact-ticker Company Anomaly coverage",
+          "what would improve or break the setup",
+          "confirm company guidance, financial figures, and event facts with stronger evidence"
+        ],
+        "sections": [
+          {
+            "file": "SKILL.md",
+            "heading": "Financial Analysis / Ask Question Tree",
+            "label": "ticker-analysis route",
+            "includes": [
+              "For broad analysis of one named equity",
+              "[ticker-analysis.md](references/ticker-analysis.md)",
+              "the default method"
+            ]
+          }
+        ],
+        "forbidden_behaviors": [
+          "Do not make the user supply a thesis before receiving value",
+          "not automatically to a playbook"
+        ]
+      }
+    },
+    {
       "id": "scenario.capability-gap-before-refusal",
       "group": "scenarios.capability",
       "prompt": "Does Alva have darkpool L2 realtime data?",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -198,7 +198,8 @@ that section as mandatory, not optional debugging material.
 
 | User asks for                                                                                                                           | Route                               | Must not miss                                                                                                                                                                            |
 | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| price, valuation, holdings, broad company analysis, "why did it move", compare peers, explain a thesis, rank in text                    | Financial Analysis / Ask Question   | For a named company, also apply the proactive Company Anomaly check in the Financial Analysis tree; it supplements rather than replaces ordinary analysis.                              |
+| price, valuation, holdings, "why did it move", compare peers, explain a thesis, rank in text                                           | Financial Analysis / Ask Question   | Use the smallest relevant subroute and apply every matching evidence gate.                                                                                                             |
+| broad analysis of one named equity or ticker, "analyze MU", "META setup"                                                             | Financial Analysis: Ticker Analysis | Read [ticker-analysis.md](references/ticker-analysis.md); use its setup, expectations, company evidence, anomaly, catalyst, risk, and live-debate method.                                |
 | company anomaly, scan/check whether a company is anomalous, use Platform Data to analyze a company, unusual price/volume move            | Platform Data: Company Anomaly      | Read [company-anomaly.md](references/company-anomaly.md); verify exact-ticker coverage, live-read the current state, and keep any prior attribution timestamp distinct.                 |
 | fintwit / KOL / leaderboard — top accounts or ranking, is @handle tracked, what an account thinks about a ticker or theme, track record | Platform Data: Fintwit Intelligence | Use the Platform Data section below, then read [fintwit.md](references/fintwit.md); cite the snapshot date; read-only, never fabricate rankings.                                         |
 | FinTwit digest SDK, alpha radar automation, custom digest module, `@alva/fintwit-digest`                                                | Platform Data: Fintwit Digest SDK   | Use the Platform Data section below, then read [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md); follow the SDK API and ability contracts instead of copying runtime internals. |
@@ -377,26 +378,20 @@ sourced current data next to memory-derived baselines.
 
 Financial analysis is the default for user questions about markets, assets,
 portfolios, valuation, catalysts, rankings, comparisons, and "why" narratives.
-It may be a single fresh data fetch, an `alva run` computation over live data, a
-sourced explanation, a peer comparison, a thesis check, or a concise table. It
-is not merely "Data Query": data access and execution are steps inside an
-analysis answer.
+It is not merely "Data Query": data access and execution are steps inside an
+analysis answer, including an `alva run` computation over live data when needed.
+Use the shared data and execution layer, then answer directly with provenance
+unless the user asks to track, alert, share, or publish.
 
-For broad analysis of a named company, proactively read
-[company-anomaly.md](references/company-anomaly.md), then test its exact-ticker
-Company Anomaly coverage before answering. When covered, include the current
-anomaly state and freshness as one analysis dimension. When unavailable,
-continue the ordinary analysis; do not substitute anomaly intelligence for
-fundamentals, valuation, or company news.
+For broad analysis of one named equity, read
+[ticker-analysis.md](references/ticker-analysis.md) and use it as the default method.
+It includes the proactive exact-ticker Company Anomaly check, WILF expectations,
+company-event sweep, setup, thesis, catalysts, risks, and live debate. Missing
+Company Anomaly coverage does not block ordinary analysis or justify replacing
+fundamentals, valuation, or news with anomaly intelligence.
 
-Common subroutes are latest fact, contextual explanation, comparison/valuation,
-ranking or screen-in-text, and thesis check. They produce an answer, not an
-unsolicited build; enter the durable artifact tree only when the user requests
-it or accepts an Automation suggestion.
-
-Use the shared data and execution layer first. If the user asks a direct
-question, answer directly with provenance; if they ask to track, alert, share,
-or publish, route to the durable artifact / playbook tree instead.
+Other common subroutes are latest fact, contextual explanation, comparison/valuation,
+ranking or screen-in-text, and thesis check. They produce an answer, not an unsolicited build.
 
 Financial-analysis answer gate: before answering any Financial Analysis / Ask
 Question, read [user-facing-prose.md](references/user-facing-prose.md), then
@@ -410,30 +405,10 @@ are sourced facts, computed values, or inference.
 
 #### Useful Next Step After Ask
 
-After fully answering a one-off Ask, choose one outcome:
-
-- **Automation** when changing inputs can be reevaluated by the same method and
-  cadence, a trigger, or notification creates ongoing value. Push ideas also
-  need a meaningful-change and quiet-run boundary.
-- **One-off follow-up** when one concrete question would materially deepen,
-  test, compare, apply, or naturally extend the answer. It need not lead to
-  Automation.
-- **No suggestion** when neither option is specific, relevant, and clearly
-  useful. If uncertain, choose this and end the answer without a footer.
-
-Actively look for Automation, but hold both options to the same quality bar. If
-both pass, prefer Automation when recurring value justifies the setup; choose
-one-off only when it is clearly more useful now. Never recommend Automation
-merely because work is schedulable.
-
-When suggesting, append one short, opt-in sentence in the user's language.
-Describe the outcome and value, not the implementation; avoid generic
-conversation or product CTAs. Do not invent cadence, thresholds, tickers, KOL
-handles, portfolio state, account connections, or notification policy. Wait
-for acceptance, and do not repeat a declined suggestion unless the need changes.
-If Automation clears this bar or is already requested, apply
-[Preferred Automation Setup Skills](references/request-routing.md#preferred-automation-setup-skills)
-before suggesting or building it.
+After fully answering a one-off Ask, follow
+[Post-Ask Next Step](references/request-routing.md#post-ask-next-step). Suggest
+at most one specific, opt-in Automation or one-off follow-up; omit the footer
+when neither clearly helps.
 
 ### Durable Artifacts / Playbook Tree
 
@@ -663,22 +638,12 @@ reference before doing the task.
 
 ### Ask Question / Financial Analysis
 
-For "what is the latest price / P/E / funding rate / holdings / CPI print", "why
-did it move", "analyze this company", "is it cheap vs peers", or "rank these in
-text", start with financial analysis. For broad named-company analysis, apply
-the proactive Company Anomaly check defined in the Financial Analysis tree. Run
-preflight if needed, verify the relevant Data Skills or search route, use
-`alva run` when live computation or joins are needed, fetch or qualify any
-comparison baseline, read
-[user-facing-prose.md](references/user-facing-prose.md), apply the answer gate
-in the Financial Analysis tree, classify complex asks with
-[request-routing.md](references/request-routing.md), and answer with inline
-provenance. If a structured source returns stale or missing latest data, use
-[data-skills.md](references/data-skills.md#structured-feed-lag) before refusing
-when a known official release may be ahead of the feed; otherwise report the
-failure instead of substituting a web snippet or model memory. If the user then
-asks to track, alert, share, or publish, upgrade the route to a feed, signal,
-alert, or playbook.
+Start with the Financial Analysis tree and its answer gate. For broad analysis
+of one named equity, use [ticker-analysis.md](references/ticker-analysis.md).
+Verify the needed Data Skills/search route, compute live joins when needed, and
+fetch or qualify comparison baselines. For stale structured data around a known
+release, follow [data-skills.md](references/data-skills.md#structured-feed-lag).
+Only upgrade to an Automation, signal, alert, or playbook when the user asks.
 
 ### Hosted Playbook Workflow
 
@@ -783,6 +748,7 @@ Use this index to open only the file needed for the current task.
 | [preflight.md](references/preflight.md)                                               | Session start, Rule 0, CLI, auth, profile, Arrays JWT, memory load, user scope.                                                               |
 | [alva-knowledge.md](references/alva-knowledge.md)                                     | Required automation reasoning: bounded history, cross-run comparison, semantic notification novelty, quiet runs.                            |
 | [request-routing.md](references/request-routing.md)                                   | Route choice, post-Ask next steps, preferred Automation setup skills, Skillhub, Guided Planning, capability verification, completion gate.    |
+| [ticker-analysis.md](references/ticker-analysis.md)                                   | Default broad single-equity method: setup, WILF expectations, company events, anomaly context, thesis, catalysts, risks, and live debate.      |
 | [content-legitimacy.md](references/content-legitimacy.md)                             | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions.                                                           |
 | [data-skills.md](references/data-skills.md)                                           | Data Skills discovery, endpoint calls, Arrays auth, search/data routing.                                                                      |
 | [feed-lifecycle.md](references/feed-lifecycle.md)                                     | Feed build and automation publish lifecycle, modeling summary, push sidecars, `before-automation-publish`.                                    |
@@ -831,25 +797,7 @@ Runtime artifacts:
 
 ### Company Page Links
 
-In every user-facing Alva response, link the first high-confidence mention of
-each covered stock company to its Alva company page:
-`[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
-
-- Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
-  company names, common names, or localized aliases. Treat `Apple` as `AAPL`
-  when context refers to Apple Inc. Use semantic context, not token shape alone:
-  do not link `apple` when it means fruit, `Meta` as a general term, or `AI` as
-  a theme rather than a company.
-- Preserve the visible wording and use the canonical uppercase ticker only in
-  the URL. Prefer a company/ticker mapping already resolved by Alva data or
-  clearly established in the conversation. If the mapping, share class, or page
-  coverage is uncertain, leave it plain; do not call a tool just to add a link.
-- Link each company at most once per reply. Do not link non-company assets such
-  as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
-  quoted passages; or verbatim tool output.
-- Always use an absolute production URL under `https://alva.ai/company/`. Never
-  use a staging host or relative URL for a company page. Do not add a separate
-  company-page footer or explain that a link was added.
+Apply [Company Page Links](references/user-facing-prose.md#company-page-links) to every user-facing Alva response.
 
 Lead with the result, not the machinery. Say what the user got, what was
 verified, and what remains. Avoid raw ALFS paths, API payloads, job ids,

--- a/skills/alva/references/company-anomaly.md
+++ b/skills/alva/references/company-anomaly.md
@@ -255,7 +255,7 @@ as though it were a regular-session return.
 | `symbol`                                | Attributed company                                |
 | `headline`                              | Short likely-driver statement                     |
 | `summary`                               | Full attribution narrative                        |
-| `summaryWithCitationsMarkdown`          | Same narrative as `summary`, with inline Markdown source links (`([source](url))`) after sourced claims, drawn only from `supportingEvents` / `sourceLinks`; falls back to `summary` when absent |
+| `summaryWithCitationsMarkdown`          | Same narrative as `summary`, with inline Markdown source links after sourced claims, drawn only from `supportingEvents` / `sourceLinks`; falls back to `summary` when absent |
 | `driverMarket` / `driverSector` / `driverAssetSpecific` | Per-layer **narrative** ("why"), LLM-generated — the market, sector, and asset-specific drivers (no single `drivers` field) |
 | `decompositionJson`                     | Computed **quantitative** 3-way split ("how much") — `market.movePct`, `sector.beyondMarketPct`, `idiosyncratic.beyondSectorPct` (each with a `z`), plus `dominant` / `dominantOrder` |
 | `confidence`                            | Confidence classification                         |

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -12,7 +12,8 @@ Decision order:
    Skills, search, BYOD, `alva run` / jagent, and provenance checks are common
    to answers and artifacts.
 1. If the user wants an explanation, comparison, valuation, rank, or current
-   market fact in chat, route to Financial Analysis / Ask Question.
+   market fact in chat, route to Financial Analysis / Ask Question. Broad
+   analysis of one named equity uses the Ticker Analysis subroute.
 2. If the user wants persistence, cadence, alerting, trading signals, or a
    reusable dataset, route to the durable artifact that fits, not automatically
    to a playbook.
@@ -24,11 +25,39 @@ Decision order:
 | Request type | Objective |
 | --- | --- |
 | Financial Analysis / Ask Question | Answer market, asset, portfolio, valuation, comparison, and "why" questions with fresh data/search/`alva run` evidence. Comparison baselines are figures too: fetch or qualify them. Every answer must read [user-facing-prose.md](user-facing-prose.md), then pass the ask evidence gate. |
+| Financial Analysis: Ticker Analysis | For broad analysis of one named equity, read [ticker-analysis.md](ticker-analysis.md) and apply its setup, WILF expectations, company-information, anomaly, catalyst, risk, and live-debate method before answering. |
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. |
 | Automation / Push | Read [alva-knowledge.md](alva-knowledge.md) before design, build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |
+
+## Post-Ask Next Step
+
+After fully answering a one-off Ask, choose one outcome:
+
+- **Automation** when changing inputs can be reevaluated by the same method and
+  cadence, a trigger, or notification creates ongoing value. Push ideas also
+  need a meaningful-change and quiet-run boundary.
+- **One-off follow-up** when one concrete question would materially deepen,
+  test, compare, apply, or naturally extend the answer. It need not lead to
+  Automation.
+- **No suggestion** when neither option is specific, relevant, and clearly
+  useful. If uncertain, choose this and end the answer without a footer.
+
+Actively look for Automation, but hold both options to the same quality bar. If
+both pass, prefer Automation when recurring value justifies the setup; choose
+one-off only when it is clearly more useful now. Never recommend Automation
+merely because work is schedulable.
+
+When suggesting, append one short, opt-in sentence in the user's language.
+Describe the outcome and value, not the implementation; avoid generic
+conversation or product CTAs. Do not invent cadence, thresholds, tickers, KOL
+handles, portfolio state, account connections, or notification policy. Wait
+for acceptance, and do not repeat a declined suggestion unless the need changes.
+If Automation clears this bar or is already requested, apply
+[Preferred Automation Setup Skills](#preferred-automation-setup-skills) before
+suggesting or building it.
 
 ## Preferred Automation Setup Skills
 
@@ -103,6 +132,10 @@ or computing evidence, but first read
 sourced-vs-inference boundary. Simple asks can satisfy the gate with one hop.
 Simple/latest-fact asks stop there. Only complex judgment asks also pass the
 Complex Ask Router below before the answer is written.
+
+For a broad single-ticker equity ask, read [ticker-analysis.md](ticker-analysis.md)
+before research. It supplies the default method; the gates below still apply to
+every matching thesis, earnings, valuation, and news/social dimension.
 
 ### Complex Ask Router
 

--- a/skills/alva/references/ticker-analysis.md
+++ b/skills/alva/references/ticker-analysis.md
@@ -1,0 +1,286 @@
+# Ticker Analysis
+
+Use this chapter for broad analysis of one named equity, such as "analyze MU"
+or "what is the setup in META?" It is the default single-ticker research
+method, not a separate artifact route. Narrow latest-price, single-metric, or
+single-event questions can stay on their smaller Financial Analysis subroute.
+
+## Answer Contract
+
+Answer first. Do not make the user supply a thesis before receiving value. If
+the user's time horizon would materially change the conclusion, give the
+initial read and then offer an easy choice between the next catalyst and the
+6-12 month thesis.
+
+Assume the user can see the quote. Do not lead with the last price or the day's
+move unless it is unusual or changes the setup. Start with whether the setup
+looks buyable here, needs a pullback or confirmation, is extended, or has no
+clean entry. This is a conditional market setup, not an unconditional trade
+instruction.
+
+Use price relationally: trend structure, key levels, breakout quality, relative
+strength, volume, and volatility. State what would improve or break the setup,
+including the level, event, or evidence that invalidates the current read.
+
+Move naturally from setup into the company thesis, catalysts, and risks. Do not
+emit mechanical source-by-source sections. Keep the answer compact and
+human-sounding, follow [user-facing-prose.md](user-facing-prose.md), cite facts
+inline, and state confidence where missing evidence matters.
+
+## Required Research
+
+Before answering a broad single-ticker question:
+
+1. Review the relevant ticker in
+   [WILF](https://alva.ai/u/eddiid/playbooks/wilf). Use WILF as the expectations
+   baseline: identify what investors are waiting for, the live bull/bear
+   tension, and the evidence that could change the thesis. If earnings or
+   another material event is newer than the WILF snapshot, update the debate
+   with fresh evidence. If WILF has no exact-ticker entry, record that coverage
+   gap and continue; never substitute a sibling ticker's snapshot.
+2. Read [company-anomaly.md](company-anomaly.md), then test exact-ticker Company
+   Anomaly coverage. If covered, read the current anomaly state and the latest
+   attribution joined to the active episode. Mention it only when it changes
+   the setup; if attribution is uncertain, leave causality open. Missing
+   coverage does not block the ordinary analysis.
+3. Run the company-information sweep below. Select only recent developments
+   with material positive or negative impact on the thesis. `keptByPipeline`
+   means an item survived its source pipeline; it does not prove thesis
+   materiality.
+4. Make the live debate concrete when coverage exists. Look for one
+   identifiable investor, operator, analyst, or industry expert whose view
+   sharpens the thesis. Prefer the original post or source and explain why it
+   matters. One clear voice is usually enough.
+5. Use X/search to discover the live debate, but confirm company guidance,
+   financial figures, and event facts with stronger evidence. Apply every
+   matching [Complex Ask Router](request-routing.md#complex-ask-router) gate,
+   including fundamentals, earnings, valuation, or news/social requirements.
+
+Treat WILF, Company Anomaly, the company-information sweep, and other Alva data
+as research inputs rather than output headings. Translate the synthesis into
+plain market language without naming internal paths or producer feeds.
+
+## Company-Information Sweep
+
+Follow the current
+[EVENTS_FEED_HOWTO](https://github.com/Space-ID/alva-data-feed/blob/main/portfolio-watch-anomaly/EVENTS_FEED_HOWTO.md).
+Run a dedicated company-information feed for the ticker. Do not reuse or mutate
+a production `*-portfolio-watch-anomaly` feed.
+
+Run help-first preflight, identify `<owner>` from the current Alva identity,
+ensure the Arrays token, and verify that the exact ticker's watch config exists
+before executing the current watch-core entry point. If the config is missing,
+do not borrow another ticker's config: continue with the remaining research,
+state the sweep coverage gap, and lower confidence when it matters.
+
+```bash
+alva arrays token ensure
+
+alva run --entry-path "~/feeds/_watch-core/v1/src/index.js" --args '{
+  "driver": "daily",
+  "configPath": "/alva/home/<owner>/library/watch-config/<ticker-slug>.json",
+  "feedName": "<ticker-slug>-ticker-analysis-events",
+  "ownerUsername": "<owner>"
+}'
+```
+
+Read the complete latest persisted run and normalize it into a setup snapshot
+plus thesis-relevant events:
+
+```bash
+alva fs read \
+  --path "~/feeds/<ticker-slug>-ticker-analysis-events/v1/data/raw/records/@last/1" |
+python3 -c '
+import json, sys
+
+payload = json.load(sys.stdin)
+points = payload if isinstance(payload, list) else [payload]
+rows = []
+
+for point in points:
+    if isinstance(point, dict) and isinstance(point.get("items"), list):
+        for row in point["items"]:
+            if isinstance(row, dict):
+                row.setdefault("runAtMs", point.get("date"))
+                rows.append(row)
+    elif isinstance(point, dict):
+        rows.append(point)
+
+def kept(value):
+    return value is True or str(value).lower() == "true"
+
+def decode(value):
+    if isinstance(value, (dict, list)):
+        return value
+    if not isinstance(value, str) or value.endswith("...<truncated>"):
+        return None
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+def first(mapping, *keys):
+    if not isinstance(mapping, dict):
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+event_types = {
+    "market_news", "industry_news",
+    "indexed_x", "industry_x",
+    "analyst_target", "insider_form4", "congress_trade",
+    "earnings_actual", "earnings_estimate",
+    "earnings_guidance", "earnings_calendar",
+    "peer_move", "soxx_flow", "brave_expansion",
+    "macro_indicator", "macro_news", "dxi_index",
+    "dram_contract", "dram_spot_snapshot",
+    "nand_contract", "nand_spot_snapshot"
+}
+
+setup_types = {
+    "1min:ETH", "1min:ETH:volume_median",
+    "1min:current_volume", "intraday:summary",
+    "self_market_metric", "price_anomaly", "volume_anomaly"
+}
+
+events = []
+setup_rows = []
+
+for row in rows:
+    if not kept(row.get("keptByPipeline")):
+        continue
+    source_type = row.get("sourceType")
+    if source_type not in event_types | setup_types:
+        continue
+
+    raw_json = row.get("rawJson")
+    raw = decode(raw_json)
+    key_fields = decode(row.get("keyFieldsJson"))
+    item = {
+        "sourceType": source_type,
+        "title": row.get("title"),
+        "summary": row.get("summary"),
+        "url": row.get("url"),
+        "sourceTimestampMs": row.get("sourceTimestampMs"),
+        "runAtMs": row.get("runAtMs") or row.get("date"),
+        "keyFields": key_fields,
+        "raw": raw,
+        "rawJsonTruncated": (
+            isinstance(raw_json, str)
+            and raw_json.endswith("...<truncated>")
+        )
+    }
+
+    if source_type in {"indexed_x", "industry_x"}:
+        item["x"] = {
+            "authorName": first(raw, "display_name"),
+            "authorHandle": (
+                first(raw, "twitter_handle")
+                or first(key_fields, "handle")
+            ),
+            "text": first(raw, "full_text") or row.get("summary"),
+            "url": first(raw, "url") or row.get("url"),
+            "publishedAt": first(raw, "published_at"),
+            "contentType": (
+                first(raw, "content_type")
+                or first(key_fields, "contentType")
+            ),
+            "likes": first(raw, "like_count") or first(key_fields, "likes"),
+            "reposts": (
+                first(raw, "retweet_count")
+                or first(key_fields, "reposts")
+            ),
+            "views": first(raw, "view_count") or first(key_fields, "views")
+        }
+
+    if source_type in setup_types:
+        setup_rows.append(item)
+    else:
+        events.append(item)
+
+events.sort(
+    key=lambda row: int(row.get("sourceTimestampMs") or 0),
+    reverse=True
+)
+
+def setup_value(source_type, many=False):
+    matches = [row for row in setup_rows if row.get("sourceType") == source_type]
+    values = [row.get("keyFields") or row.get("raw") for row in matches]
+    return values if many else (values[0] if values else None)
+
+market_metrics = {}
+for row in setup_rows:
+    if row.get("sourceType") != "self_market_metric":
+        continue
+    value = row.get("keyFields") or row.get("raw") or {}
+    indicator = value.get("indicator")
+    if indicator:
+        market_metrics[indicator] = {
+            "value": value.get("value"),
+            "observedDate": value.get("observedDate")
+        }
+
+anomalies = []
+for row in setup_rows:
+    if row.get("sourceType") not in {"price_anomaly", "volume_anomaly"}:
+        continue
+    anomalies.append({
+        "sourceType": row.get("sourceType"),
+        "title": row.get("title"),
+        "summary": row.get("summary"),
+        "sourceTimestampMs": row.get("sourceTimestampMs"),
+        "details": row.get("keyFields") or row.get("raw")
+    })
+
+run_at_ms = max(
+    [int(row.get("runAtMs") or 0) for row in events + setup_rows],
+    default=0
+)
+
+output = {
+    "runAtMs": run_at_ms or None,
+    "setupSnapshot": {
+        "intraday": setup_value("intraday:summary"),
+        "latestExtendedHoursBar": setup_value("1min:ETH"),
+        "currentVolume": setup_value("1min:current_volume"),
+        "volumeBaselines": setup_value("1min:ETH:volume_median", many=True),
+        "marketMetrics": market_metrics,
+        "anomalies": anomalies
+    },
+    "events": events
+}
+
+json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+'
+```
+
+`@last/1` returns the complete latest persisted run, not one latest event. Check
+`runAtMs` before relying on freshness. Start the setup read from `setupSnapshot`
+and fetch extra bars or indicators only when they materially improve the answer.
+Source types are configuration-dependent; absent optional lanes are missing
+coverage, not zero evidence.
+
+## Synthesis Order
+
+Use this order as reasoning flow, not as mandatory visible headings:
+
+1. Setup now: entry quality, trend, levels, relative strength, volume,
+   volatility, and invalidation.
+2. Expectations: what WILF says investors await and which bull/bear claim is
+   under test.
+3. Fresh evidence: earnings, guidance, estimates, material events, Company
+   Anomaly context, and what changed after the expectation snapshot.
+4. Thesis and catalysts: why the evidence changes or preserves the forward
+   case, plus the next dated or observable catalyst.
+5. Risks and confidence: strongest disconfirming evidence, missing coverage,
+   and the condition that breaks the read.
+6. Live voice: one relevant market participant when the original source adds
+   information rather than decoration.
+
+Do not pad the answer with every collected event, repeat the visible quote, or
+force a causal story for an unattributed move. Use other Alva data when it
+materially improves the read, and stop when the evidence no longer changes the
+conclusion.

--- a/skills/alva/references/user-facing-prose.md
+++ b/skills/alva/references/user-facing-prose.md
@@ -124,6 +124,28 @@ answer like this:
 > the analysis five hours ago, but it still filed it under April 30, so the page
 > looked unchanged.
 
+## Company Page Links
+
+In every user-facing Alva response, link the first high-confidence mention of
+each covered stock company to its Alva company page:
+`[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
+
+- Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
+  company names, common names, or localized aliases. Treat `Apple` as `AAPL`
+  when context refers to Apple Inc. Use semantic context, not token shape alone:
+  do not link `apple` when it means fruit, `Meta` as a general term, or `AI` as
+  a theme rather than a company.
+- Preserve the visible wording and use the canonical uppercase ticker only in
+  the URL. Prefer a company/ticker mapping already resolved by Alva data or
+  clearly established in the conversation. If the mapping, share class, or page
+  coverage is uncertain, leave it plain; do not call a tool just to add a link.
+- Link each company at most once per reply. Do not link non-company assets such
+  as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
+  quoted passages; or verbatim tool output.
+- Always use an absolute production URL under `https://alva.ai/company/`. Never
+  use a staging host or relative URL for a company page. Do not add a separate
+  company-page footer or explain that a link was added.
+
 ## Voice
 
 User-facing prose in Alva should read like a sharp human analyst, not a


### PR DESCRIPTION
## Summary

- add a reusable `ticker-analysis.md` chapter for broad single-equity analysis, covering setup, WILF expectations, exact-ticker anomaly context, company events, thesis, catalysts, risks, and live market voices
- route prompts such as `分析一下 MU` through `Financial Analysis: Ticker Analysis` while preserving narrower latest-fact and metric routes
- add deterministic route, section, scenario, and mutation coverage; keep `SKILL.md` within its 850-line ceiling by moving detailed post-Ask and company-link guidance to their owning references

## Breaking Changes

None.

## Database Migrations

None.

## Merge Order

None.

## Related PRs

None.

## Verification

- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (`61/61` cases, `595/595` checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (`10/10` mutations)
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva` (no broken links or orphan references)
- JSON parse, mutation script syntax, embedded Python AST parse, `git diff --check`, and `SKILL.md` line ceiling checks passed

No runtime E2E was run because this is a documentation and deterministic routing-eval change with no service or executable product contract.