### PR TITLE
chore(alva): bump version to v1.19.0

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -927,7 +927,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.18.1",
+        "version: v1.19.0",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.18.1
+  version: v1.19.0
 ---
 
 # Alva


### PR DESCRIPTION
## Summary
- set the Alva skill metadata version to `v1.19.0`
- prepare the current reviewed skill contents, including the global Useful Next Step After Ask policy, for an immutable GitHub release
- leave the existing `v1.18.1` tag untouched

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
Merge before creating the `v1.19.0` GitHub Release and before pinning sandbox-agent-ts.

## Related PRs
- alva-ai/skills#564
- alva-ai/skills#566

## Verification
- Ruby YAML frontmatter validation (`metadata.version=v1.19.0`)
- `jq empty evals/alva-skill-docs/cases.json`
- `bash -n skills/alva/scripts/version_check.sh`
- `git diff --check`

## Known release blocker
The doc eval currently fails only `target.top-level-size`: current `main` is 902 lines against the existing 850-line ceiling. The same check is already red on the base commit (`45fd6f5`); `v1.18.1` was 849 lines and the growth came from the already-merged #564 and #566. This version-only PR does not raise the ceiling or force-merge around the gate; release requires a separate top-level compression decision.