### PR TITLE
chore(alva): bump version to v1.19.0

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.18.1
+  version: v1.19.0
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.18.1` → `v1.19.0` ahead of cutting the `v1.19.0` release. `rel/v1.19` and the `v1.19.0` tag will point at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)