### PR TITLE
fix(alva): limit company page links to U.S.-listed stocks

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -940,10 +940,11 @@
       "id": "communication.company-page-links",
       "group": "communication",
       "target": "skill",
-      "description": "User-facing replies link high-confidence company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
+      "description": "User-facing replies link high-confidence U.S.-listed company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
       "excludes": [
         "https://stg.alva.ai/company/",
-        "https://stg.alva.xyz/company/"
+        "https://stg.alva.xyz/company/",
+        "https://alva.ai/company/3986.HK"
       ],
       "section_includes": [
         {
@@ -952,14 +953,17 @@
           "label": "company page link contract",
           "includes": [
             "In every user-facing Alva response",
-            "each covered stock company to its Alva company page",
+            "each covered U.S.-listed company to its Alva company page",
             "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
             "semantically clear company names",
             "common names, or localized aliases",
             "Apple",
             "Use semantic context, not token shape alone",
-            "company/ticker mapping already resolved by Alva data",
-            "mapping, share class, or page coverage",
+            "Only link U.S.-listed companies",
+            "non-U.S. listings such as `3986.HK`",
+            "never strip or rewrite an exchange suffix",
+            "company/ticker mapping and U.S. listing status already resolved by Alva data",
+            "mapping, listing market, share class, or page coverage",
             "do not call a tool just to add a link",
             "Link each company at most once per reply",
             "non-company assets",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -834,7 +834,7 @@ Runtime artifacts:
 ### Company Page Links
 
 In every user-facing Alva response, link the first high-confidence mention of
-each covered stock company to its Alva company page:
+each covered U.S.-listed company to its Alva company page:
 `[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
@@ -842,10 +842,14 @@ each covered stock company to its Alva company page:
   when context refers to Apple Inc. Use semantic context, not token shape alone:
   do not link `apple` when it means fruit, `Meta` as a general term, or `AI` as
   a theme rather than a company.
+- Only link U.S.-listed companies. Leave non-U.S. listings such as `3986.HK`
+  plain even when the company is clear; never strip or rewrite an exchange
+  suffix to force a company-page match.
 - Preserve the visible wording and use the canonical uppercase ticker only in
-  the URL. Prefer a company/ticker mapping already resolved by Alva data or
-  clearly established in the conversation. If the mapping, share class, or page
-  coverage is uncertain, leave it plain; do not call a tool just to add a link.
+  the URL. Prefer a company/ticker mapping and U.S. listing status already
+  resolved by Alva data or clearly established in the conversation. If the
+  mapping, listing market, share class, or page coverage is uncertain, leave it
+  plain; do not call a tool just to add a link.
 - Link each company at most once per reply. Do not link non-company assets such
   as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
   quoted passages; or verbatim tool output.


### PR DESCRIPTION
## Summary

- Limit automatic Alva company page links to covered U.S.-listed companies.
- Keep non-U.S. listings such as `3986.HK` as plain text even when the company mapping is clear.
- Prevent stripping or rewriting exchange suffixes to force a company page match.
- Extend the scoped documentation regression case for the U.S.-listing boundary.

## Why

Alva company pages currently cover U.S. stocks. Linking a recognized non-U.S. listing can produce an unsupported path such as `https://alva.ai/company/3986.HK`, especially in external channels where the absolute URL is opened directly.

This is a narrow follow-up to #566. Entity understanding can still identify the company; only company-page link eligibility is restricted.

## Validation

- `jq empty evals/alva-skill-docs/cases.json`
- `git diff --check`
- `communication.company-page-links`: pass
- Full doc eval: 629/630 checks. The only miss is the pre-existing `target.mainline-updates` assertion, which still expects `version: v1.19.0` while current `main` is already `v1.19.1`.
