### PR TITLE
docs(alva): teach declared feed alert outputs

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -239,6 +239,7 @@
         "alva playbooks trending",
         "annotation-driven edits",
         "feed_alert_ready",
+        "alertOutput(typeDoc)",
         "<|SKIP_NOTIFICATION|>",
         "subscriptions"
       ]
@@ -635,7 +636,7 @@
             "alva alert enable --automation",
             "alva alert enable --automation-ids",
             "There is no playbook alert target",
-            "read `@last/1` of the sidecar",
+            "read `@last/1` of the declared output",
             "do not claim push is set up"
           ]
         },
@@ -997,7 +998,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.19.0",
+        "version: v1.19.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -601,6 +601,8 @@
             "HTML fetches quantitative data from feeds, not inline literals",
             "Latest data from each referenced feed is fresh",
             "README exists, is current, and is passed via absolute `--readme-url`",
+            "New feeds declare push-worthy outputs with",
+            "existing Altra `signal/targets` or legacy",
             "alva lint playbook ./index.html"
           ]
         }

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -80,6 +80,12 @@ const MUTATIONS = [
     expectFailedCases: ["subscriptions.delivery-destination", "scenario.current-topic-channel-alert"],
   },
   {
+    id: "feed-alert-output-authoring",
+    file: "references/push-notifications.md",
+    remove: "1. Declare the intended output with `alertOutput(typeDoc)`. The TypeDoc must\n",
+    expectFailedCases: ["scenario.alert-push-monitor"],
+  },
+  {
     id: "ticker-read-first-tier-route",
     file: "SKILL.md",
     remove: "read [ticker-read.md](references/ticker-read.md) before source selection",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -148,14 +148,16 @@
           "feed-lifecycle.md"
         ],
         "behaviors": [
-          "Build or modify a feed that emits actionable `signal/targets` or `notify/message`",
+          "Build or modify a feed that declares actionable outputs with `alertOutput(typeDoc)`",
           "bounded history source and lookback window",
           "Notification deduplication is semantic",
           "If no material delta exists",
           "A push is set up only after all of these succeed",
           "alva deploy update --id <ID> --push-notify",
           "alva alert enable --automation",
-          "read `@last/1` of the sidecar",
+          "read `@last/1` of the declared output",
+          "A quiet V2 run does not append an alert record",
+          "`alva deploy trigger` is not a dry run",
           "do not claim push is set up"
         ],
         "sections": [
@@ -180,6 +182,13 @@
             "heading": "Routes",
             "includes": [
               "Read [alva-knowledge.md](alva-knowledge.md) before design"
+            ]
+          },
+          {
+            "file": "references/push-notifications.md",
+            "heading": "Configure And Verify",
+            "includes": [
+              "Declare the intended output with `alertOutput(typeDoc)`"
             ]
           }
         ],
@@ -218,7 +227,7 @@
           "Do not trigger the cronjob or wait for its next scheduled run solely to verify setup",
           "A successful enable proves that alert delivery is configured",
           "it does not prove that a message has already been delivered",
-          "A sidecar record alone is also not delivery proof",
+          "An ALFS record alone is also not delivery proof",
           "report it as an Alva web topic channel with its id"
         ],
         "forbidden_behaviors": [

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -178,6 +178,24 @@
             ]
           },
           {
+            "file": "SKILL.md",
+            "heading": "Push Monitor",
+            "includes": [
+              "declared `alertOutput(typeDoc)`",
+              "quiet branch that does not append",
+              "`signal/targets` or `notify/message` only when maintaining an existing",
+              "recognized legacy producer"
+            ]
+          },
+          {
+            "file": "SKILL.md",
+            "heading": "Action Layer: Alerts",
+            "includes": [
+              "New feeds declare push-worthy outputs with `alertOutput(typeDoc)`",
+              "legacy `signal/targets` or `notify/message` producer"
+            ]
+          },
+          {
             "file": "references/request-routing.md",
             "heading": "Routes",
             "includes": [

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -75,7 +75,7 @@ surface, a monitoring feed, a strategy, a thesis tracker, or a repeatable
 research process. It is also useful for single-shot questions, but the agent
 should not overbuild. A user asking "what is BTC doing now?" needs a fresh fetch
 and a concise answer. A user asking "track BTC dominance and alert me on
-breakouts" needs a feed, cadence, push sidecar, and verification.
+breakouts" needs a feed, cadence, declared alert output, and verification.
 
 Think in artifacts:
 
@@ -574,20 +574,22 @@ authentication, `alva functions` creator registration and allowance tools,
 #### Action Layer: Alerts
 
 Alerts are personal notification opt-ins for automations (feeds). Playbook
-follows are independent and never enable or disable alerts. A feed may emit
-`signal/targets` or `notify/message`; both dispatch `feed_alert_ready`.
-`--push-notify` only marks the publisher capable of alerts. It does not
-subscribe users or bypass preferences.
+follows are independent and never enable or disable alerts. New feeds declare
+push-worthy outputs with `alertOutput(typeDoc)` and may use any valid,
+non-reserved `group/output` source. `--push-notify` lets successful scheduled
+and Run Now executions deliver those outputs; it does not subscribe users or
+bypass preferences.
 
-Open [push-notifications.md](references/push-notifications.md) for sidecar creation,
-automation publish, alert setup, and verification. Quiet runs use `<|SKIP_NOTIFICATION|>`.
+Open [push-notifications.md](references/push-notifications.md) for alert-output
+authoring, automation publish, alert setup, and verification. A quiet V2 run
+does not append an alert record.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
 push-worthy. Recommend specific feeds, not generic "notifications". A push setup
-is not complete until the feed sidecar exists, `alva automation publish` ran
-after that sidecar was added, the publisher has `--push-notify`, and the
-intended alert binding is enabled. That proves configuration, not that a
-message has already been delivered.
+is not complete until the Feed declares an alert output, the automation has an
+active published binding, the publisher has `--push-notify`, and the intended
+alert binding is enabled. That proves configuration, not that a message has
+already been delivered.
 
 #### Playbook Subroute: Remix
 
@@ -786,9 +788,9 @@ Use this index to open only the file needed for the current task.
 | [request-routing.md](references/request-routing.md)                                   | Route choice, post-Ask next steps, preferred Automation setup skills, Skillhub, Guided Planning, capability verification, completion gate.    |
 | [content-legitimacy.md](references/content-legitimacy.md)                             | Data provenance, prohibited sources, chat-as-artifact, feed isolation, conventions.                                                           |
 | [data-skills.md](references/data-skills.md)                                           | Data Skills discovery, endpoint calls, Arrays auth, search/data routing.                                                                      |
-| [feed-lifecycle.md](references/feed-lifecycle.md)                                     | Feed build and automation publish lifecycle, modeling summary, push sidecars, `before-automation-publish`.                                    |
+| [feed-lifecycle.md](references/feed-lifecycle.md)                                     | Feed build and automation publish lifecycle, modeling summary, alert outputs, `before-automation-publish`.                                    |
 | [playbook-creation.md](references/playbook-creation.md)                               | HTML build, browser-safe reads, README, draft, release, screenshot, tier flow.                                                                |
-| [push-notifications.md](references/push-notifications.md)                             | Push-worthy feeds, sidecars, alerts, delivery verification.                                                                                   |
+| [push-notifications.md](references/push-notifications.md)                             | Push-worthy feeds, declared alert outputs, alert bindings, delivery verification.                                                             |
 | [operational-pitfalls.md](references/operational-pitfalls.md)                         | Runtime, ALFS, chart, watermark, and resource pitfalls.                                                                                       |
 | [jagent-runtime.md](references/jagent-runtime.md)                                     | V8 runtime, modules, async model, constraints, built-ins.                                                                                     |
 | [feed-sdk.md](references/feed-sdk.md)                                                 | Feed SDK API, schemas, time series, grouped records, upstreams, examples.                                                                     |

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -206,7 +206,7 @@ that section as mandatory, not optional debugging material.
 | dashboard, screener app, thesis tracker, hosted report, shareable surface                                                               | Playbook Creation                   | Build live feeds first, then read [playbook-creation.md](references/playbook-creation.md).                                                                                               |
 | `/use-skill:<username>/<name>`, user-referenced skill/method, or template-like research method                                          | Skillhub Blueprint                  | Fetch blueprint fresh; if it becomes a playbook, route through [playbook-creation.md](references/playbook-creation.md) and set `--skill-id`.                                             |
 | backtest, strategy, signal, rebalance, portfolio simulation                                                                             | Strategy / Trading Analysis         | Use Altra; package as answer, feed, or playbook only as the user goal requires.                                                                                                          |
-| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify the alert binding plus sidecar output.                                                  |
+| recurring digest, threshold tracker, alert, stream watch                                                                                | Automation / Push                   | Read [alva-knowledge.md](references/alva-knowledge.md), then build a push-capable feed and verify the alert binding plus its declared alert output. Preserve a recognized legacy producer only when maintaining an existing feed. |
 | `<remix ...>` or "remix this playbook"                                                                                                  | Remix                               | Read source files; preserve lineage and source UDFs.                                                                                                                                     |
 | `<annotation ...>` or "change this element"                                                                                             | Edit / Debug                        | Edit the generator behind the element, not rendered feed values.                                                                                                                         |
 | "does Alva have X?"                                                                                                                     | Capability Verification             | Run `alva data-skills list` and search for `<topic>` before saying no.                                                                                                                   |
@@ -585,11 +585,10 @@ authoring, automation publish, alert setup, and verification. A quiet V2 run
 does not append an alert record.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
-push-worthy. Recommend specific feeds, not generic "notifications". A push setup
-is not complete until the Feed declares an alert output, the automation has an
-active published binding, the publisher has `--push-notify`, and the intended
-alert binding is enabled. That proves configuration, not that a message has
-already been delivered.
+push-worthy. A push setup requires a declared alert output or a recognized
+legacy `signal/targets` or `notify/message` producer, plus an active published
+automation binding, publisher `--push-notify`, and the intended alert binding.
+That proves configuration, not that a message has already been delivered.
 
 #### Playbook Subroute: Remix
 
@@ -723,11 +722,11 @@ generator behind the selected element rather than the rendered DOM.
 
 ### Push Monitor
 
-For a recurring alert, design the feed output first: signal target or message,
-quiet-run sentinel, cadence, and subscriber. Publish the automation after adding
-the sidecar, then enable the intended alert. Do not trigger or wait for a run
-solely to verify setup. A cronjob with `--push-notify` and no alert binding is
-not a completed push setup.
+For a new recurring alert, design the declared `alertOutput(typeDoc)`, material
+branch, quiet branch that does not append, cadence, and subscriber first. Keep
+`signal/targets` or `notify/message` only when maintaining an existing
+recognized legacy producer. Verify an active automation binding, publisher `--push-notify`,
+and the intended alert binding. Do not trigger or wait solely to verify setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 
@@ -902,8 +901,9 @@ Before finishing an Alva task, ask:
 - Did design work read [design.md](references/design.md) and lint where needed?
 - Did Skillhub work fetch the blueprint fresh and set `--skill-id` if used?
 - Did backtesting or signal work use Altra?
-- Did push work verify the publisher sidecar plus the intended alert target
-  without claiming an unobserved delivery?
+- Did push work verify publisher `--push-notify`, an active automation binding,
+  the declared alert output (or recognized legacy producer), and the intended
+  alert target without claiming an unobserved delivery?
 - If Alva-owned behavior blocked the task, did I offer the confirmed feedback
   flow after reading [api/feedback.md](references/api/feedback.md)?
 - Did the final response describe the delivered result without leaking

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -45,18 +45,21 @@ alva deploy create --name btc-ema-update --path '~/feeds/btc-ema/v1/src/index.js
 | --cron        | string | yes      | Standard cron expression                                                      |
 | --name        | string | yes      | Job name (1–63 lowercase alphanumeric or hyphens, no leading/trailing hyphen) |
 | --args        | JSON   | no       | JSON passed to `require("env").args` on each execution                        |
-| --push-notify | flag   | no       | Let this cronjob emit feed alert events after successful feed runs            |
+| --push-notify | flag   | no       | Let successful Feed runs deliver declared alert outputs to subscribers         |
 
-When `--push-notify` is set, every successful cronjob execution checks the
-feed's push sidecars. `signal/targets` and `notify/message` both dispatch the
-canonical `feed_alert_ready` event with different feed-alert sources. The push
-body is read from the _published_ automation: a cronjob with `--push-notify` but
-no `alva automation publish` dispatches an empty body. Delivery also requires an
-explicit alert binding to the automation's feed.
-Following a playbook that references the feed does not enable alerts;
-`--push-notify` does not subscribe the owner or any user. For
-`notify/message`, `<|SKIP_NOTIFICATION|>` in `body`/`text` skips the user-visible
-push while advancing fanout.
+When `--push-notify` is set, every successful scheduled or Run Now execution
+may deliver records written to outputs declared with `alertOutput(typeDoc)`.
+The Feed still needs an active published automation binding, and delivery
+requires an explicit alert binding to that Feed. Following a playbook that
+references the Feed does not enable alerts; `--push-notify` does not subscribe
+the owner or any user.
+
+`alva deploy trigger` is not a dry run. If publisher push and subscriber
+bindings are enabled, triggering the cronjob can send real notifications. Use
+`alva run` to test the script without backend alert fanout.
+
+Existing `signal/targets` and `notify/message` feeds remain compatible through
+legacy fanout. New general-purpose feeds should use `alertOutput()` instead.
 
 The CLI validates that the entry path exists on the filesystem before creating
 the cronjob.

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -1,7 +1,7 @@
 # Feed Lifecycle
 
 Feeds are persistent data pipelines. Use them whenever data needs freshness,
-history, public reads, charts, playbook backing, push sidecars, or release.
+history, public reads, charts, playbook backing, alert outputs, or release.
 The feed is the object and identity; `alva automation` is the product-facing
 lifecycle CLI for that same feed, while an `alva deploy` cronjob is its
 subordinate data producer.
@@ -129,22 +129,25 @@ After publish, when public access is required, verify:
 3. Before building or releasing dependent HTML, at least one public `@last`
    path used by the HTML is non-empty.
 
-## Push Sidecars
+## Alert Outputs
 
-Push-capable feeds write one of these streams:
+New push-capable feeds wrap the TypeDoc of each push-worthy output with
+`alertOutput(typeDoc)`. The output source may be any valid, non-reserved
+`group/output`; its root `body` field is required and `title` is optional.
+Other declared fields remain available as ordinary ALFS data.
 
-| Output stream    | Use                                                                |
-| ---------------- | ------------------------------------------------------------------ |
-| `signal/targets` | Playbook signals, trading targets, actionable alerts.              |
-| `notify/message` | Feed results, AlvaAsk reports, heartbeat checks, proactive alerts. |
+A top-level script execution may return at most one alert record per declared
+source and at most 16 alert records in total, including when it calls multiple
+successful `Feed.run()` callbacks. A quiet run appends nothing to the alert
+output. `--push-notify` marks the cronjob publisher as capable of delivering
+those records; it does not create an alert binding or bypass notification
+preferences. Scheduled runs and `alva deploy trigger` use the same delivery
+semantics.
 
-Both dispatch `feed_alert_ready`. Do not use legacy names such as
-`playbook_data_ready` or `feed_run_complete` in new docs.
-
-`--push-notify` marks the cronjob publisher as capable of emitting alerts. It
-does not create an alert binding or bypass notification preferences. For
-`notify/message`, `<|SKIP_NOTIFICATION|>` advances fanout
-without sending a visible push.
+Existing `signal/targets` and `notify/message` producers remain compatible
+through legacy fanout. They are reserved sources and must not be wrapped in
+`alertOutput()`. Keep Altra-owned `signal/targets` unchanged. The
+`<|SKIP_NOTIFICATION|>` sentinel applies only to legacy `notify/message`.
 
 See [push-notifications.md](push-notifications.md) for alert destination and
 verification workflows.

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -162,15 +162,12 @@ await feed.run(async (ctx) => {
 
 Read `@last/N` (where N >= batch size) to get the most recent batch.
 
-### Pattern D: Signal Feed Push Notification
+### Pattern D: Declared Alert Output
 
-For feeds that produce actionable signals worth pushing to subscribed alert
-destinations. Write signal records to the **`signal`** group
-with a **`targets`** output -- the resulting path
-`~/feeds/{name}/v{major}/data/signal/targets` is one source the platform reads
-when dispatching the canonical `feed_alert_ready` notification event.
-
-The target format follows the same structure used by Altra trading strategies:
+New feeds opt an ordinary output into delivery by wrapping its TypeDoc with
+`alertOutput()`. The output keeps its normal ALFS representation; the wrapper
+only declares that a successful Feed execution may return the record for
+subscriber delivery.
 
 ```javascript
 const {
@@ -178,173 +175,124 @@ const {
   feedPath,
   makeDoc,
   str,
-  num,
-  obj,
-  arr,
-  fld,
+  alertOutput,
 } = require("@alva/feed");
 
-const feed = new Feed({ path: feedPath("my-signal") });
+const feed = new Feed({ path: feedPath("market-breakout") });
 
-feed.def("signal", {
-  targets: makeDoc(
-    "Signal Targets",
-    "Actionable signal alerts",
-    [
-      obj("instruction", [
-        str("type"), // "allocate" | "orders"
-        arr("weights", [
-          // for type: "allocate"
-          str("symbol"),
-          num("weight"),
-        ]),
-        arr("orders", [
-          // for type: "orders"
-          str("symbol"),
-          str("side"), // "buy" | "sell"
-          fld("amount", "object"),
-        ]),
-      ]),
-      obj("meta", [
-        str("reason"), // Markdown push-notification body
-      ]),
-    ],
+feed.def("market", {
+  brief: alertOutput(
+    makeDoc("Market Brief", "Material breakout alert", [
+      str("title"),
+      str("body"),
+      str("ticker"),
+    ]),
   ),
 });
 
-await feed.run(async (ctx) => {
-  const now = Date.now();
-
-  await ctx.self.ts("signal", "targets").append([
-    {
-      date: now,
-      instruction: {
-        type: "allocate",
-        weights: [
-          { symbol: "BINANCE_SPOT_BTC_USDT", weight: 0.6 },
-          { symbol: "BINANCE_SPOT_ETH_USDT", weight: 0.4 },
-        ],
-      },
-      meta: { reason: "EMA crossover: shift to 60/40 BTC/ETH" },
-    },
-  ]);
-});
-```
-
-When this feed runs as a cronjob with `--push-notify`, the platform reads
-`/data/signal/targets` and dispatches the signal content as `feed_alert_ready`
-to eligible FEED alert subscribers. Telegram delivery chunks long
-messages at the platform's per-message limit; the feed SDK does not require a
-500-character summary.
-
-**Key points:**
-
-- The group **must** be named `signal` and the output **must** be named
-  `targets` -- this is the path the notification system looks for.
-- `--push-notify` and `alva automation publish --cronjob-id ...` only make the
-  feed publisher capable of emitting alerts. They do **not** create an alert
-  binding.
-- Real delivery requires an explicit FEED alert: `alva alert enable
-  --automation <owner>/<feed>` or — from inside a playbook iframe — a
-  parent-confirmed `window.alva.subscribe.propose()` (see
-  `references/api/udf-runtime.md` § Feed Subscribe Proposal). A playbook must
-  never call a subscribe API directly.
-- Use `meta.reason` to provide the push-notification body -- this is what
-  recipients see when the signal is delivered.
-- `meta.reason` is **Markdown**. Write it as the push body itself, using
-  Markdown for emphasis, lists, and links; the platform renders Markdown on the
-  delivery side (Telegram, in-app surfaces). Keep it short and push-friendly --
-  headings and heavy formatting don't translate well to a notification.
-- Keep `meta.reason` close to the user-facing feed output when the feed is
-  notification-native. Use a push-safe projection only when a channel has a real
-  hard limit or cannot render the feed's richer format.
-- One record per run is typical; the platform reads `@last/1`.
-- Altra strategies write to this path automatically. Use this pattern only for
-  non-Altra feeds that want to produce push-worthy signals.
-
-### Pattern E: AlvaAsk + Feed Notification (notify/message)
-
-**Preferred pattern for scheduled tasks.** Use `@alva/alvaask` instead of a
-custom alpi loop for cronjob feeds when you need Alva's full agent behavior —
-it's simpler (no sandbox/session management) and the `ask()` call handles tool
-use, web search, and ALFS access automatically.
-
-For feeds that use `@alva/alvaask` to call Alva's agent and publish the result
-as a feed completion notification. Common use cases: scheduled market reports,
-periodic research summaries, heartbeat monitoring, and proactive alerts.
-
-Write the agent's response to the **`notify`** group with a **`message`**
-output. When the cronjob completes with `--push-notify`, the platform reads this
-path and dispatches `feed_alert_ready` to eligible alert destinations.
-
-```javascript
-const { ask } = require("@alva/alvaask");
-const { Feed, feedPath, makeDoc, str } = require("@alva/feed");
-
-const feed = new Feed({ path: feedPath("daily-briefing") });
-feed.def("notify", {
-  message: makeDoc("Notification", "Agent-generated push content", [
-    str("title"),
-    str("body"),
-  ]),
-});
-
 (async () => {
-  const result = ask(`Give a brief crypto market update with key levels.
-If there is no material update worth notifying about, output only
-<|SKIP_NOTIFICATION|>.`);
-
   await feed.run(async (ctx) => {
-    await ctx.self.ts("notify", "message").append([
+    const breakout = getMaterialBreakout();
+    if (!breakout) return; // Quiet run: do not append an alert record.
+
+    await ctx.self.ts("market", "brief").append([
       {
         date: Date.now(),
-        title: "Daily Crypto Briefing",
-        body: result.text,
+        title: `${breakout.ticker} breakout`,
+        body: breakout.summary,
+        ticker: breakout.ticker,
       },
     ]);
   });
 })();
 ```
 
-Deploy requires **two steps** — cronjob + feed registration:
+Alert-output rules:
 
-```bash
-# 1. Create the cronjob with push notification enabled
-alva deploy create --name daily-briefing \
-  --path '~/feeds/daily-briefing/v1/src/index.js' \
-  --cron "0 8 * * *" --push-notify
+- The TypeDoc must declare a root `body` string. A root `title` string is
+  optional. Additional fields such as `ticker`, `url`, or structured analysis
+  remain available in ALFS but do not change the standard notification text.
+- Use any descriptive, valid `group/output` except the reserved legacy sources
+  `signal/targets` and `notify/message`.
+- A top-level script execution may return at most one alert record for a given
+  source and at most 16 alert records across all sources. If a script calls
+  multiple successful `Feed.run()` callbacks, do not emit the same alert source
+  from more than one callback.
+- Declare outputs before `feed.run()`. Do not call `feed.def()` conditionally or
+  from inside the callback.
+- A callback failure reports no V2 alerts. Successful ALFS writes and delivery
+  reporting are best-effort; a delivery bridge failure does not undo stored
+  Feed data.
+- `--push-notify` enables publisher-side delivery but does not subscribe anyone.
+  Real delivery also requires an active published automation and an explicit
+  FEED alert binding.
+- Scheduled runs and `alva deploy trigger` both deliver eligible records.
+  `deploy trigger` is not a dry run; use `alva run` for non-delivering script
+  checks.
+- Changing the declaration or source in an already active Feed does not require
+  republishing. The next run uses the current script and declarations.
 
-# 2. Publish the automation (REQUIRED for push content to work)
-# Without this, notifications arrive without title/text content.
-alva automation publish --name daily-briefing --version 1.0.0 \
-  --cronjob-id <ID_FROM_STEP_1> \
-  --description "Generates a morning briefing each day at 08:00 summarizing overnight crypto market moves and pushes it as a notification"
+### Pattern E: AlvaAsk + Declared Alert Output
+
+Use `@alva/alvaask` when a scheduled Feed needs Alva's full agent behavior.
+Store its push-worthy result in a descriptive alert output rather than the
+legacy `notify/message` path.
+
+```javascript
+const { ask } = require("@alva/alvaask");
+const {
+  Feed,
+  feedPath,
+  makeDoc,
+  str,
+  alertOutput,
+} = require("@alva/feed");
+
+const feed = new Feed({ path: feedPath("daily-briefing") });
+feed.def("reports", {
+  briefing: alertOutput(
+    makeDoc("Daily Briefing", "Agent-generated market briefing", [
+      str("title"),
+      str("body"),
+    ]),
+  ),
+});
+
+(async () => {
+  const result = ask(`Give a brief crypto market update with key levels.
+If there is no material update worth notifying about, output only
+NO_MATERIAL_UPDATE.`);
+
+  await feed.run(async (ctx) => {
+    const body = result.text.trim();
+    if (!body || body === "NO_MATERIAL_UPDATE") return;
+
+    await ctx.self.ts("reports", "briefing").append([
+      {
+        date: Date.now(),
+        title: "Daily Crypto Briefing",
+        body,
+      },
+    ]);
+  });
+})();
 ```
 
-**Key points:**
+Deploy still requires a cronjob with `--push-notify`, an active
+`alva automation publish` binding, and an explicit FEED alert subscription.
+Publishing establishes the Feed/cronjob identity; adding or changing an alert
+output later does not require another publish.
 
-- The group **must** be named `notify` and the output **must** be named
-  `message` — this is the path the notification system looks for.
-- `title` is optional — if provided, the notification renders as
-  `**title**\n\nbody`.
-- `body` is the notification body (required for content push). The legacy field
-  name `text` is still accepted for backwards compatibility, but `body` is the
-  canonical name and matches FCM / APNS / Web Push / HTTP / email convention —
-  prefer `body` in new feeds. If both `body` and `text` are set on the same
-  record, `body` wins.
-- If `body`/`text` contains `<|SKIP_NOTIFICATION|>`, fanout state advances but
-  no user-visible notification is sent. Teach AlvaAsk to output this sentinel
-  when there is no material update.
-- **`alva automation publish` is required** — without it, the push is still
-  dispatched but arrives with an empty body (no `title`/`body`).
-- `--push-notify` only enables publisher-side fanout. It does **not** create
-  alert bindings.
-- Real delivery requires an explicit FEED alert such as `alva alert enable
-  --automation <owner>/<feed>`. Following a playbook does not subscribe any of
-  its feeds. For inventory and unsubscribe (including deleted feed rows), see
-  [push-notifications.md](push-notifications.md) § Inventory And Unsubscribe.
-- Combine with Pattern D if you want both feed completion notifications and
-  signal-style notifications.
+### Legacy Compatibility
+
+Existing `signal/targets` and `notify/message` feeds continue to work through
+legacy fanout. Keep them when maintaining an existing producer, and keep
+Altra-owned `signal/targets` unchanged. Do not wrap either reserved source in
+`alertOutput()` and do not copy them into new general-purpose Feed templates.
+
+The `<|SKIP_NOTIFICATION|>` body sentinel and legacy `text` fallback apply only
+to `notify/message`. New V2 alert outputs require `body` and express a quiet run
+by not appending.
 
 ### Deduplication
 

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -194,8 +194,9 @@ Before `alva release playbook`, verify:
 8. Target user namespace is correct.
 9. README exists, is current, and is passed via absolute `--readme-url`.
 10. Push-only feeds with `push_notify: true` have an active published
-    automation binding and declare their push-worthy outputs with
-    `alertOutput(typeDoc)`.
+    automation binding. New feeds declare push-worthy outputs with
+    `alertOutput(typeDoc)`; existing Altra `signal/targets` or legacy
+    `notify/message` producers may retain those reserved sources.
 11. `alva lint playbook ./index.html` passes, or an intentional `--bypass-lint`
     is documented.
 12. Header duplication has been reviewed. If the iframe repeats the outer

--- a/skills/alva/references/playbook-creation.md
+++ b/skills/alva/references/playbook-creation.md
@@ -193,8 +193,9 @@ Before `alva release playbook`, verify:
    cronjobs.
 8. Target user namespace is correct.
 9. README exists, is current, and is passed via absolute `--readme-url`.
-10. Push-only feeds with `push_notify: true` have a current
-    `alva automation publish` after the push sidecar was added.
+10. Push-only feeds with `push_notify: true` have an active published
+    automation binding and declare their push-worthy outputs with
+    `alertOutput(typeDoc)`.
 11. `alva lint playbook ./index.html` passes, or an intentional `--bypass-lint`
     is documented.
 12. Header duplication has been reviewed. If the iframe repeats the outer

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -13,7 +13,8 @@ Skip static fundamentals, historical snapshots, and low-frequency reference
 data.
 
 For heartbeat/watchlist/monitor feeds, recommend quiet behavior: notify only on
-material changes and emit `<|SKIP_NOTIFICATION|>` otherwise.
+material changes. In a new V2 feed, return without appending to the declared
+alert output when there is nothing worth sending.
 
 ## Choose The Delivery Destination
 
@@ -48,14 +49,15 @@ Discord, or Slack at <https://alva.ai/settings>.
 
 A push is set up only after all of these succeed:
 
-1. Add the intended push sidecar:
-   - `signal/targets` for playbook signals and trading targets.
-   - `notify/message` for feed completion, AlvaAsk reports, heartbeat checks,
-     and proactive alerts.
+1. Declare the intended output with `alertOutput(typeDoc)`. The TypeDoc must
+   have a root `body` string field and may have a root `title` string field;
+   other fields remain ordinary ALFS data. Use a descriptive, non-reserved
+   source such as `market/brief` or `monitor/anomaly`.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-automation-publish`.
-3. Read `@last/1` of the sidecar written by the lifecycle test and confirm the
-   message is non-empty or contains `<|SKIP_NOTIFICATION|>` for a quiet run.
+3. Exercise a material branch with `alva run`, read `@last/1` of the declared
+   output, and confirm it contains a non-empty `body`. Exercise a quiet branch
+   and confirm it does not append a new record.
 4. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
 5. Enable the FEED alert for the intended destination using
@@ -67,14 +69,18 @@ A push is set up only after all of these succeed:
    name-addressed default-personal command.
 
 Do not trigger the cronjob or wait for its next scheduled run solely to verify
-setup. A successful enable proves that alert delivery is configured for the
-selected destination; it does not prove that a message has already been
-delivered. A sidecar record alone is also not delivery proof. Claim real
-delivery only when an existing `alva alert history` row for the intended
-destination records the run as `sent`.
+setup. `alva deploy trigger` is not a dry run: after publisher push and an alert
+binding are enabled, Run Now can notify real subscribers. Use `alva run` for
+non-delivering script checks before enablement. A successful enable proves that
+alert delivery is configured for the selected destination; it does not prove
+that a message has already been delivered. An ALFS record alone is also not
+delivery proof. Claim real delivery only when an existing
+`alva alert history` row for the intended destination records the run as
+`sent`.
 
-If the automation is unpublished, the feed has no sidecar record, or the record
-has an empty body, do not claim push is set up. Diagnose and fix first.
+If the automation is unpublished, the feed has no declared alert output, or
+the material test record has an empty body, do not claim push is set up.
+Diagnose and fix first.
 
 Confirm to the user with specifics: which automation alerts are enabled, the
 intended destination, what the next push will say, and when it will fire. A
@@ -88,6 +94,21 @@ changes alerts. If the user explicitly asks to enable every current automation
 behind a playbook, resolve the feed ids from that playbook's latest release and
 submit those ids with `alva alert enable --automation-ids <id,id>`. Treat this
 as a snapshot: feeds added by a later release are not subscribed automatically.
+
+## Legacy Compatibility
+
+Existing `signal/targets` and `notify/message` producers continue to dispatch
+through the legacy fanout path. Keep existing Altra/trading producers intact:
+Altra owns `signal/targets`. Do not wrap either reserved source in
+`alertOutput()`, and do not use these paths as templates for a new general Feed.
+V2 and legacy deliveries both enter the canonical `feed_alert_ready`
+notification domain.
+
+`<|SKIP_NOTIFICATION|>` remains a legacy `notify/message` sentinel only. New
+V2 feeds express a quiet run by not appending to an alert output. Changing,
+adding, or removing an `alertOutput()` declaration in an already active Feed
+does not require republishing; the next successful scheduled or Run Now
+execution carries the current declarations and writes.
 
 ## Inventory And Unsubscribe
 

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -26,7 +26,7 @@ Decision order:
 | Financial Analysis / Ask Question | Answer market, asset, portfolio, valuation, comparison, single-ticker, and "why" questions with fresh data/search/`alva run` evidence. A named-ticker read first opens [ticker-read.md](ticker-read.md). Comparison baselines are figures too: fetch or qualify them. Every answer must read [user-facing-prose.md](user-facing-prose.md), then pass the ask evidence gate. |
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. |
-| Automation / Push | Read [alva-knowledge.md](alva-knowledge.md) before design, build or modify a feed that emits actionable `signal/targets` or `notify/message`, then verify subscription and delivery path. |
+| Automation / Push | Read [alva-knowledge.md](alva-knowledge.md) before design, build or modify a feed that declares actionable outputs with `alertOutput(typeDoc)`, then verify publisher, subscription, and delivery paths. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |
 


### PR DESCRIPTION
## Summary

- make `alertOutput(typeDoc)` the canonical authoring pattern for new push-capable Feeds
- keep `signal/targets` and `notify/message` only as concise legacy compatibility guidance
- document quiet runs, Run Now delivery semantics, per-execution limits, and active automation/subscriber requirements
- update regression scenarios and mutation smoke coverage

## Compatibility

Existing Altra `signal/targets` and legacy `notify/message` producers remain supported and are not migrated by this PR. There are no schema changes, migrations, or version bumps.

## Verification

- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva`
- `bash skills/alva/scripts/version_check.sh`
- `git diff --check`

## Related implementation

- https://github.com/alva-ai/backtest-js/pull/391
- https://github.com/alva-ai/jagent/pull/804
- https://github.com/alva-ai/alva-backend/pull/1907
