### PR TITLE
docs(alva): use IM provider terminology

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -662,7 +662,8 @@
       "excludes": [
         "External IM group",
         "alva alert group",
-        "group-subscriptions"
+        "group-subscriptions",
+        "active_channel"
       ],
       "section_includes": [
         {
@@ -678,6 +679,8 @@
             "delivery is web-only",
             "current Alva topic channel (channel id <id>)",
             "`channel_id=0`",
+            "`active_im_provider`",
+            "active IM provider",
             "moves the personal alert"
           ]
         },
@@ -1000,7 +1003,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.19.1",
+        "version: v1.19.3",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.19.2
+  version: v1.19.3
 ---
 
 # Alva
@@ -120,7 +120,7 @@ make it this one.
    flags, response fields, and examples. Read
    [preflight.md](references/preflight.md) at session start.
 2. **Fresh identity and memory.** Run `alva whoami`, capture `username`,
-   `subscription_tier`, delivery channel fields, and Arrays JWT status. Load
+   `subscription_tier`, IM provider fields, and Arrays JWT status. Load
    `~/memory/MEMORY.md` if not already read. Memory is a *claim*, not truth.
 3. **Pipeline, not oracle.** Financial values must come from Data Skills,
    published Alva feeds, or validated BYOD sources. WebSearch, LLM output, agent
@@ -744,7 +744,7 @@ text does not fully cover.
 
 | Command / surface    | Purpose and extra reference                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `whoami` / `user`    | Identity, subscription tier, channels, username. See [preflight.md](references/preflight.md).                                                                                         |
+| `whoami` / `user`    | Identity, subscription tier, active IM provider, username. See [preflight.md](references/preflight.md).                                                                               |
 | `auth` / `configure` | Sign in, API key, profile configuration.                                                                                                                                              |
 | `arrays`             | Provision / refresh `ARRAYS_JWT`. See [preflight.md](references/preflight.md).                                                                                                        |
 | `data-skills`        | Structured Arrays endpoint discovery. See [data-skills.md](references/data-skills.md).                                                                                                |

--- a/skills/alva/references/preflight.md
+++ b/skills/alva/references/preflight.md
@@ -75,8 +75,8 @@ Capture these session variables:
 
 - `username`: public URLs and ALFS paths.
 - `subscription_tier`: `pro` or `free`; controls private/paid playbook flow.
-- `active_channel`: `telegram`, `discord`, `slack`, or null; web notifications
-  always work, external delivery depends on this field.
+- `active_im_provider`: `telegram`, `discord`, `slack`, or empty; web
+  notifications always work, external delivery depends on this field.
 - `telegram_username` / `discord_username` / `slack_username`: external IM
   display fields.
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -24,7 +24,8 @@ create a second copy. Choose the destination before mutating it:
 
 - **Default personal destination:** omit `--channel-id`. The service stores
   `channel_id=0`; web delivery is available immediately, and external DM
-  delivery uses `active_channel` plus its matching username from `alva whoami`.
+  delivery uses `active_im_provider` plus its matching username from
+  `alva whoami`.
 - **Alva topic channel:** resolve the feed id and run
   `alva alert enable --automation-ids <id,id> --channel-id <channel_id>`. This
   binds the alert to that in-product web channel. Its channel id is not a
@@ -41,7 +42,7 @@ Do not infer Telegram, Discord, Slack, or another transport from the generic
 explicitly identifies it; otherwise describe a topic destination as the
 `current Alva topic channel (channel id <id>)`.
 
-If no active IM channel exists for the default personal destination, say web
+If no active IM provider exists for the default personal destination, say web
 notifications will work immediately and the user can connect Telegram,
 Discord, or Slack at <https://alva.ai/settings>.
 


### PR DESCRIPTION
## Summary

- teach agents to read `active_im_provider` from `alva whoami`
- distinguish an active external IM provider from an Alva topic channel
- bump the Alva Skill to `v1.19.3`
- extend deterministic eval coverage to require the new term and reject `active_channel`

## Breaking Changes

None in the Skill itself. This documentation requires the CLI contract from toolkit-ts #140.

## Database Migrations

None.

## Merge Order

1. Merge alva-ai/toolkit-ts#140 and publish a toolkit release containing it.
2. Merge this PR.

## Related PRs

- alva-ai/toolkit-ts#140

## Verification

- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (64/64 cases, 645/645 checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (12/12 expected failures detected)
- scoped legacy-terminology search
- `git diff --check`
- E2E not run because this PR changes only Skill instructions and deterministic evals.
