### PR TITLE
fix(alva): use market URLs for company links

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -948,9 +948,10 @@
       "target": "skill",
       "description": "User-facing replies link high-confidence U.S.-listed company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
       "excludes": [
-        "https://stg.alva.ai/company/",
-        "https://stg.alva.xyz/company/",
-        "https://alva.ai/company/3986.HK"
+        "https://alva.ai/company/",
+        "https://stg.alva.ai/market/",
+        "https://stg.alva.xyz/market/",
+        "https://alva.ai/market/3986.HK"
       ],
       "section_includes": [
         {
@@ -960,7 +961,7 @@
           "includes": [
             "In every user-facing Alva response",
             "each covered U.S.-listed company to its Alva company page",
-            "[visible wording](https://alva.ai/company/{CANONICAL_TICKER})",
+            "[visible wording](https://alva.ai/market/{CANONICAL_TICKER})",
             "semantically clear company names",
             "common names, or localized aliases",
             "Apple",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -836,7 +836,7 @@ Runtime artifacts:
 
 In every user-facing Alva response, link the first high-confidence mention of
 each covered U.S.-listed company to its Alva company page:
-`[visible wording](https://alva.ai/company/{CANONICAL_TICKER})`.
+`[visible wording](https://alva.ai/market/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
   company names, common names, or localized aliases. Treat `Apple` as `AAPL`
@@ -854,7 +854,7 @@ each covered U.S.-listed company to its Alva company page:
 - Link each company at most once per reply. Do not link non-company assets such
   as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
   quoted passages; or verbatim tool output.
-- Always use an absolute production URL under `https://alva.ai/company/`. Never
+- Always use an absolute production URL under `https://alva.ai/market/`. Never
   use a staging host or relative URL for a company page. Do not add a separate
   company-page footer or explain that a link was added.
 


### PR DESCRIPTION
## Summary
- Generate company links under `https://alva.ai/market/{CANONICAL_TICKER}`.
- Update the doc eval contract to reject the legacy production `/company/` route and retain staging/non-US guards for `/market/`.

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related PRs
None.

## Verification
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (64/64 cases, 646/646 checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (12/12 mutations)

Broader suites were skipped because this is a localized skill-doc and eval-contract change; these are the repository CI checks for the affected surface.