### PR TITLE
fix(alva): use /markets/ URLs for company page links

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -995,9 +995,9 @@
       "description": "User-facing replies link high-confidence U.S.-listed company mentions to production Alva company pages without extra lookups or ambiguous company matches.",
       "excludes": [
         "https://alva.ai/company/",
-        "https://stg.alva.ai/market/",
-        "https://stg.alva.xyz/market/",
-        "https://alva.ai/market/3986.HK"
+        "https://stg.alva.ai/markets/",
+        "https://stg.alva.xyz/markets/",
+        "https://alva.ai/markets/3986.HK"
       ],
       "section_includes": [
         {
@@ -1007,7 +1007,7 @@
           "includes": [
             "In every user-facing Alva response",
             "each covered U.S.-listed company to its Alva company page",
-            "[visible wording](https://alva.ai/market/{CANONICAL_TICKER})",
+            "[visible wording](https://alva.ai/markets/{CANONICAL_TICKER})",
             "semantically clear company names",
             "common names, or localized aliases",
             "Apple",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -835,7 +835,7 @@ Runtime artifacts:
 
 In every user-facing Alva response, link the first high-confidence mention of
 each covered U.S.-listed company to its Alva company page:
-`[visible wording](https://alva.ai/market/{CANONICAL_TICKER})`.
+`[visible wording](https://alva.ai/markets/{CANONICAL_TICKER})`.
 
 - Recognize explicit tickers such as `AAPL` or `$AAPL` and semantically clear
   company names, common names, or localized aliases. Treat `Apple` as `AAPL`
@@ -853,7 +853,7 @@ each covered U.S.-listed company to its Alva company page:
 - Link each company at most once per reply. Do not link non-company assets such
   as ETFs, indices, crypto, FX, or commodities; code; raw URLs; existing links;
   quoted passages; or verbatim tool output.
-- Always use an absolute production URL under `https://alva.ai/market/`. Never
+- Always use an absolute production URL under `https://alva.ai/markets/`. Never
   use a staging host or relative URL for a company page. Do not add a separate
   company-page footer or explain that a link was added.
 


### PR DESCRIPTION
## Summary
- Update company-page link contract from `https://alva.ai/market/{TICKER}` to `https://alva.ai/markets/{TICKER}`
- Keep the doc eval case includes/excludes aligned with the new path

## Test plan
- [ ] Confirm Company Page Links section in `skills/alva/SKILL.md` uses `/markets/`
- [ ] Confirm `evals/alva-skill-docs/cases.json` `communication.company-page-links` assertions match


Made with [Cursor](https://cursor.com)