### PR TITLE
chore(alva): bump version to v1.20.1

### DIFF
--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.20.0
+  version: v1.20.1
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.20.0` → `v1.20.1` ahead of cutting the `v1.20.1` release. `rel/v1.20` and the `v1.20.1` tag will point at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)