### PR TITLE
fix(alva): use live screener feed name

### DIFF
--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -441,7 +441,7 @@
     {
       "id": "scenario.remix-existing-playbook",
       "group": "scenarios.playbook",
-      "prompt": "<remix https://alva.ai/u/alva/playbooks/screener> make my own version",
+      "prompt": "<remix https://alva.ai/u/alva/playbooks/live-screener> make my own version",
       "description": "A remix reads source artifacts and preserves lineage instead of regenerating from memory.",
       "expect": {
         "route": "Debug / Edit",


### PR DESCRIPTION
## Summary
- point the existing playbook remix scenario at the live `live-screener` feed name

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related PRs
None.

## Verification
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (the updated `scenario.remix-existing-playbook` passed)
- `bash /Users/ming/workspace/alva/mono-meta/users/ming/skills/alva-skill-standard/scripts/audit.sh skills/alva`
- `git diff --check`

The full skill-doc eval has one pre-existing baseline failure: `target.mainline-updates` expects `version: v1.19.3`, while current `origin/main` contains `version: v1.20.1`; mutation smoke stops because that baseline is not green. This PR does not alter that unrelated version assertion.