### PR TITLE
Add Lightweight Charts guidance for one-off artifacts

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1091,6 +1091,36 @@
       ]
     },
     {
+      "id": "target.one-off-lightweight-charts",
+      "group": "target",
+      "target": "corpus",
+      "description": "One-off OHLC artifacts use a concise pinned Lightweight Charts v5 reference without changing Playbook rendering.",
+      "file_includes": [
+        {
+          "file": "references/design-widgets.md",
+          "includes": [
+            "Renderer Routing",
+            "OHLC, candlestick, price-volume, or technical analysis",
+            "lightweight-charts.md",
+            "Existing Playbook charts remain on ECharts"
+          ]
+        },
+        {
+          "file": "references/lightweight-charts.md",
+          "includes": [
+            "lightweight-charts@5.2.0/dist/lightweight-charts.standalone.production.js",
+            "window.LightweightCharts",
+            "chart.addSeries(LightweightCharts.CandlestickSeries",
+            "chart.addSeries(LightweightCharts.LineSeries",
+            "LightweightCharts.HistogramSeries",
+            "Unix timestamps are seconds, not milliseconds",
+            "chart.timeScale().fitContent()",
+            "createPriceLine()"
+          ]
+        }
+      ]
+    },
+    {
       "id": "target.auto-trade-consent-exemption",
       "group": "target",
       "target": "skill",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -489,6 +489,25 @@
       }
     },
     {
+      "id": "scenario.one-off-technical-chart",
+      "group": "scenarios.ask",
+      "prompt": "Draw a one-off BTC candlestick chart with volume, EMA20, support, and resistance in this chat.",
+      "description": "A one-off technical chart stays in chat, routes financial time-series rendering to Lightweight Charts, and does not become a Playbook.",
+      "expect": {
+        "route": "Financial Analysis / Ask Question",
+        "references": [
+          "design-widgets.md",
+          "lightweight-charts.md"
+        ],
+        "behaviors": [
+          "TradingView Lightweight Charts",
+          "OHLC, candlestick, price-volume, or technical analysis",
+          "Use ECharts for other chart types",
+          "Existing Playbook charts remain on ECharts"
+        ]
+      }
+    },
+    {
       "id": "scenario.udf-strict-opt-in",
       "group": "scenarios.udf",
       "prompt": "Add a button so viewers can run my custom analysis function.",

--- a/skills/alva/references/design-widgets.md
+++ b/skills/alva/references/design-widgets.md
@@ -261,6 +261,11 @@ No border/outline on widgets (only Tag elements may have borders). Background:
 | Table Card  | None (transparent)         |
 | Others      | `var(--grey-g01)`          |
 
+Exception: a one-off chat artifact rendered with TradingView Lightweight
+Charts may use the solid financial-chart surface described in
+[lightweight-charts.md](./lightweight-charts.md). This does not change Playbook
+Chart Cards or other ECharts charts.
+
 ### Divider
 
 Use `.divider-v` / `.divider-h` — both ends align with content padding (not full
@@ -269,6 +274,15 @@ width). Do not use `border-bottom` / `border-right` for widget dividers.
 ---
 
 ## Chart Card
+
+### Renderer Routing
+
+- For one-off chat artifacts whose main view is OHLC, candlestick,
+  price-volume, or technical analysis, use **TradingView Lightweight Charts**
+  and follow [lightweight-charts.md](./lightweight-charts.md).
+- Use ECharts for other chart types. Existing Playbook charts remain on ECharts
+  unless the user explicitly asks otherwise.
+- Plain HTML/CSS remains appropriate for small KPI and table-only layouts.
 
 ### CSS
 
@@ -386,7 +400,12 @@ Legend marker class by chart type:
 
 ### Chart Rules
 
-1. Use ECharts. Legend and chart must not overlap.
+The rules below are the ECharts and Playbook defaults. The one-off Lightweight
+Charts variant follows [lightweight-charts.md](./lightweight-charts.md), including
+its narrowly scoped solid-background exception.
+
+1. Use ECharts except for the one-off financial charts covered by Renderer
+   Routing. Legend and chart must not overlap.
 2. Do NOT set ECharts `backgroundColor` — dotted pattern handles it.
 3. Colors from chart palette in [design-tokens.css](./design-tokens.css). No
    duplicates. Grey (`--chart-grey-*`) only when ≥ 3 series.

--- a/skills/alva/references/lightweight-charts.md
+++ b/skills/alva/references/lightweight-charts.md
@@ -1,0 +1,96 @@
+# TradingView Lightweight Charts For One-Off Artifacts
+
+Use **TradingView Lightweight Charts** for a one-off chat artifact whose main
+view is OHLC, candlestick, price-volume, or technical analysis. Use **Lightweight
+Charts** thereafter. Keep ECharts for other chart types and for Playbooks unless
+the user explicitly asks otherwise.
+
+## Load The Standalone v5 Build
+
+One-off artifacts are plain HTML without a bundler. Use the pinned standalone
+build; it exposes `window.LightweightCharts`:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/lightweight-charts@5.2.0/dist/lightweight-charts.standalone.production.js"></script>
+```
+
+Do not use a floating version. The snippets below target v5 only:
+
+```js
+const chart = LightweightCharts.createChart(container, {
+  autoSize: true,
+});
+
+const candles = chart.addSeries(LightweightCharts.CandlestickSeries, {}, 0);
+const movingAverage = chart.addSeries(LightweightCharts.LineSeries, {}, 0);
+const volume = chart.addSeries(
+  LightweightCharts.HistogramSeries,
+  { priceFormat: { type: "volume" } },
+  1,
+);
+```
+
+Never copy v4 APIs such as `chart.addCandlestickSeries()`,
+`chart.addLineSeries()`, or `series.setMarkers()`. If markers are needed, use
+`LightweightCharts.createSeriesMarkers(series, markers)`.
+
+## Data Contract
+
+- Inline the already-resolved one-off data in the HTML.
+- Sort every series strictly ascending by `time` and remove duplicate times.
+- Unix timestamps are seconds, not milliseconds. Convert with
+  `Math.floor(milliseconds / 1000)` when needed.
+- Use one time representation per series: Unix seconds or `YYYY-MM-DD`, never a
+  mixture.
+- For a static artifact, call `setData()` once for each series, then
+  `chart.timeScale().fitContent()`. Realtime `update()` loops are out of scope.
+- Put volume in pane `1` and give that pane an explicit, compact height when it
+  exists: `chart.panes()[1].setHeight(100)` (adjust to the artifact height).
+
+## Technical Overlays
+
+Use normal series for indicators such as EMA/SMA. Use `createPriceLine()` for
+support, resistance, stop, target, and other horizontal levels; its axis label
+produces the TradingView-style price badge.
+
+```js
+candles.createPriceLine({
+  price: 128,
+  color: "#2bb3a3",
+  lineWidth: 1,
+  lineStyle: LightweightCharts.LineStyle.Solid,
+  axisLabelVisible: true,
+  title: "Buy above",
+});
+```
+
+For shaded price zones, use a canvas overlay or a pane/series primitive when
+necessary. Convert values with public APIs such as `series.priceToCoordinate()`
+and `chart.timeScale().timeToCoordinate()`; never infer price or time from DOM
+or canvas geometry. Redraw overlays after resize and visible-range changes.
+
+## Layout And Completion
+
+- Give the chart container an explicit responsive height. `autoSize: true`
+  handles width/height changes when `ResizeObserver` is available; otherwise
+  observe the container and call `chart.resize(width, height)`.
+- A one-off financial chart may use a solid light or dark plot background to
+  match the native financial-chart surface. This exception does not change the
+  dotted Chart Card background required for Playbooks and other ECharts charts.
+- Keep Alva's compact card framing, typography, source/as-of note, and required
+  `.alva-watermark`. Keep the library's default TradingView logo visible.
+- Lightweight Charts has no ECharts `finished` event. After every `setData()`
+  call has completed and `fitContent()` has run, call
+  `reportAlvaChartHeight()`. Call it again from the resize observer.
+
+## Review Before Publish
+
+Before finalizing the artifact, verify that:
+
+1. Candles, indicators, levels, zones, and volume use the intended scales and
+   panes, with no clipped axis badges.
+2. Data is visible after `fitContent()` and remains visible after a resize.
+3. Both the Alva watermark and the library's default TradingView logo remain
+   visible.
+4. The existing one-review publish flow reports no relevant runtime error and
+   the preview image is visually complete.


### PR DESCRIPTION
## Summary

- route one-off OHLC, candlestick, price-volume, and technical-analysis chart artifacts to TradingView Lightweight Charts
- keep ECharts as the default for other chart types and existing Playbooks
- add a concise Alva reference for the pinned v5.2.0 standalone CDN, v5 APIs, data ordering, panes, levels, resizing, and runtime review
- add deterministic documentation and scenario coverage

## Why

One-off financial chart artifacts benefit from Lightweight Charts' native financial rendering and price-axis labels. This keeps the existing Playbook renderer and publish/screenshot flow unchanged while giving the agent a focused implementation reference.

## Validation

- Alva skill validation: passed
- deterministic skill eval: 68/68 cases, 686/686 checks
- Chrome smoke: candlesticks, EMA, volume pane, and price line rendered from the pinned CDN with no page or console errors
