### PR TITLE
docs(alva): document automation publish side effects

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -129,6 +129,25 @@
       ]
     },
     {
+      "id": "target.automation-publish-side-effects",
+      "group": "target",
+      "target": "corpus",
+      "description": "Automation publish documents its owner binding and first-run side effects, including the run-only opt-out and duplicate-trigger guardrail.",
+      "section_includes": [
+        {
+          "file": "references/feed-lifecycle.md",
+          "heading": "Lifecycle",
+          "includes": [
+            "Publish creates an ACTIVE owner alert binding",
+            "Default: let publish start the producer",
+            "do not call `alva deploy trigger` again",
+            "`--skip-auto-trigger` suppresses only the publish-time run",
+            "It does not suppress the owner alert binding"
+          ]
+        }
+      ]
+    },
+    {
       "id": "retained.playbook-release",
       "group": "retained",
       "target": "corpus",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -65,6 +65,15 @@ const MUTATIONS = [
     expectFailedCases: ["scenario.alert-push-monitor"],
   },
   {
+    id: "automation-publish-side-effects",
+    file: "references/feed-lifecycle.md",
+    remove:
+      "`--skip-auto-trigger` suppresses only the publish-time run. It does not suppress\n" +
+      "the owner alert binding. Because the binding exists immediately after publish,\n" +
+      "an explicit `deploy trigger` may deliver a real alert.\n",
+    expectFailedCases: ["target.automation-publish-side-effects"],
+  },
+  {
     id: "automation-knowledge-required-reading",
     file: "SKILL.md",
     remove:

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -457,6 +457,8 @@ automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
 short creation lifecycle is: write schema and logic to ALFS, `alva run`,
 deploy, publish once with `alva automation publish`, then use its returned
 `feed_id` with `alva feed set-visibility` when public access is required.
+Publish creates an ACTIVE owner alert binding and starts the producer once by
+default; `--skip-auto-trigger` skips only that run, not the binding.
 For an existing automation, keep that identity: ALFS source edits are already
 live, while registered version, producer, or metadata changes use
 `alva automation update --id <feed_id>`. Never delete and recreate merely to
@@ -577,7 +579,7 @@ follows are independent and never enable or disable alerts. New feeds declare
 push-worthy outputs with `alertOutput(typeDoc)` and may use any valid,
 non-reserved `group/output` source. `--push-notify` lets successful scheduled
 and Run Now executions deliver those outputs; it does not subscribe users or
-bypass preferences.
+bypass preferences by itself.
 
 Open [push-notifications.md](references/push-notifications.md) for alert-output
 authoring, automation publish, alert setup, and verification. A quiet V2 run
@@ -724,8 +726,8 @@ generator behind the selected element rather than the rendered DOM.
 For a new recurring alert, design the declared `alertOutput(typeDoc)`, material
 branch, quiet branch that does not append, cadence, and subscriber first. Keep
 `signal/targets` or `notify/message` only when maintaining an existing
-recognized legacy producer. Verify an active automation binding, publisher `--push-notify`,
-and the intended alert binding. Do not trigger or wait solely to verify setup.
+recognized legacy producer. Verify the automation, publisher `--push-notify`, and alert binding. For explicit routing,
+use `--skip-auto-trigger`, route, and trigger at most once only if a real run is required; never trigger solely to verify setup.
 
 ### Chat-as-Artifact (`answer_only` / query mode)
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -757,9 +757,10 @@ All output data is also persisted under the feed's ALFS path (quote in CLI, e.g.
 
 `signal/targets` makes the feed push-capable, but delivery still requires the
 cronjob to be created or updated with `--push-notify` and
-`alva automation publish` to bind the feed to that cronjob. Actual delivery also
-requires an explicit alert binding to the automation's feed. A playbook follow
-does not enable alerts for its feeds. See
+`alva automation publish` to bind the feed to that cronjob. Initial publish
+creates the owner's alert binding and starts the producer once by default;
+other viewers or destinations require an explicit alert binding mutation. A
+playbook follow does not enable alerts for its feeds. See
 `references/deployment.md` for the deploy/publish flow.
 
 ---

--- a/skills/alva/references/api/release.md
+++ b/skills/alva/references/api/release.md
@@ -1,11 +1,11 @@
-# Release And Automation Publish — extras not in CLI help
+# Release And Automation Publish
 
 Run `alva release --help` for playbook workflows and `alva automation --help` for
 automation publish/update flags before acting. CLI help is authoritative for
-subcommands, flags, display-name conventions, and examples. This file covers
-only:
+subcommands, flags, display-name conventions, and examples. This file adds
+lifecycle guidance for:
 
-1. Automation publish `--description` wording rules
+1. Automation publish side effects and `--description` wording rules
 2. Playbook README content shape (the big one — referenced by SKILL.md and the
    `--readme-url` flag)
 3. `--trading-symbols` and `--tags` semantics, person-name discovery tags, and
@@ -17,6 +17,18 @@ only:
 existing automation, use `alva automation update --id <feed_id>` for registered
 metadata, version, or producer changes; ALFS source edits themselves need no
 republish. See [feed-lifecycle.md](../feed-lifecycle.md).
+
+## Automation Publish Side Effects
+
+Publishing a new automation creates an ACTIVE owner alert binding and then
+starts the producer once by default. The first run can deliver a real alert when
+the producer has `--push-notify` and emits a material alert output.
+
+Pass `--skip-auto-trigger` when the agent needs to route the binding or trigger
+the producer explicitly after publish. The flag suppresses only the automatic
+run; it does not suppress the owner binding. Do not follow a default publish
+with `alva deploy trigger` for the same verification, because that creates a
+duplicate full pipeline run.
 
 ## Automation Publish `--description` conventions
 

--- a/skills/alva/references/deployment.md
+++ b/skills/alva/references/deployment.md
@@ -52,10 +52,17 @@ only when the user explicitly asks.
 
 When `--push-notify` is set, every successful scheduled or Run Now execution
 may deliver records written to outputs declared with `alertOutput(typeDoc)`.
-The Feed still needs an active published automation binding, and delivery
-requires an explicit alert binding to that Feed. Following a playbook that
-references the Feed does not enable alerts; `--push-notify` does not subscribe
-the owner or any user.
+The Feed still needs an active published automation binding. `--push-notify`
+does not itself subscribe the owner or any user, but creating the automation
+with `alva automation publish` does create an ACTIVE owner alert binding before
+its default first run. Following a playbook that references the Feed does not
+enable alerts. Other viewers and destination changes require an explicit alert
+binding mutation.
+
+Publish with `--skip-auto-trigger` when the owner binding must be routed before
+the first real producer run or when the agent will trigger the producer
+explicitly. The flag does not suppress the binding. Do not manually trigger
+after a default publish for the same verification.
 
 `alva deploy trigger` is not a dry run. If publisher push and subscriber
 bindings are enabled, triggering the cronjob can send real notifications. Use

--- a/skills/alva/references/feed-lifecycle.md
+++ b/skills/alva/references/feed-lifecycle.md
@@ -20,13 +20,26 @@ Every feed follows the same path:
 3. Test with `alva run --entry-path '~/feeds/<name>/v1/src/index.js'`.
 4. Deploy the script with `alva deploy create`.
 5. Publish the automation with `alva automation publish` using the cronjob id
-   from deploy, and record the returned `feed_id`.
+   from deploy, and record the returned `feed_id`. Publish creates an ACTIVE
+   owner alert binding and, by default, starts the producer once.
 6. When a playbook or public user needs the feed, publish its visibility with
    `alva feed set-visibility --id <feed_id> --visibility public`.
 7. Verify an unauthenticated read of a public feed path returns HTTP 200.
 
 `automation publish` is create-only. Run it once to register a new automation;
 do not treat it as create-or-update.
+
+Choose exactly one first-run path:
+
+- Default: let publish start the producer, and do not call `alva deploy
+  trigger` again for the same verification.
+- Controlled routing or manual verification: publish with
+  `--skip-auto-trigger`, inspect or move the already-created owner alert
+  binding, then trigger the producer at most once if a real run is required.
+
+`--skip-auto-trigger` suppresses only the publish-time run. It does not suppress
+the owner alert binding. Because the binding exists immediately after publish,
+an explicit `deploy trigger` may deliver a real alert.
 
 ## Updating An Existing Automation
 
@@ -116,6 +129,9 @@ Before `alva automation publish`, verify:
 3. Output groups and fields match the feed contract.
 4. Evidence is fresh; if source changed after the run, rerun.
 5. The producer cronjob exists and its id is known.
+6. The first-run path is explicit: either rely on publish's automatic run, or
+   pass `--skip-auto-trigger` because the binding will be routed or the producer
+   will be triggered manually afterward.
 
 If any evidence is missing or stale, do not publish. Fix the feed, rerun, and
 re-enter the gate.
@@ -129,6 +145,10 @@ After publish, when public access is required, verify:
 3. Before building or releasing dependent HTML, at least one public `@last`
    path used by the HTML is non-empty.
 
+For push-capable automations, also verify the owner alert binding created by
+publish targets the intended destination. Move it with `alva alert enable`
+before an explicit trigger when the publish request used `--skip-auto-trigger`.
+
 ## Alert Outputs
 
 New push-capable feeds wrap the TypeDoc of each push-worthy output with
@@ -140,9 +160,10 @@ A top-level script execution may return at most one alert record per declared
 source and at most 16 alert records in total, including when it calls multiple
 successful `Feed.run()` callbacks. A quiet run appends nothing to the alert
 output. `--push-notify` marks the cronjob publisher as capable of delivering
-those records; it does not create an alert binding or bypass notification
-preferences. Scheduled runs and `alva deploy trigger` use the same delivery
-semantics.
+those records; that deploy flag alone does not create an alert binding or bypass
+notification preferences. Creating a new automation with `alva automation
+publish` does create an ACTIVE owner alert binding before its default first run.
+Scheduled runs and `alva deploy trigger` use the same delivery semantics.
 
 Existing `signal/targets` and `notify/message` producers remain compatible
 through legacy fanout. They are reserved sources and must not be wrapped in

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -223,9 +223,10 @@ Alert-output rules:
 - A callback failure reports no V2 alerts. Successful ALFS writes and delivery
   reporting are best-effort; a delivery bridge failure does not undo stored
   Feed data.
-- `--push-notify` enables publisher-side delivery but does not subscribe anyone.
-  Real delivery also requires an active published automation and an explicit
-  FEED alert binding.
+- `--push-notify` enables publisher-side delivery but does not itself subscribe
+  anyone. Publishing a new automation creates an ACTIVE owner FEED alert
+  binding before the default first run. Other viewers and destination changes
+  still require an explicit alert binding mutation.
 - Scheduled runs and `alva deploy trigger` both deliver eligible records.
   `deploy trigger` is not a dry run; use `alva run` for non-delivering script
   checks.
@@ -278,10 +279,12 @@ NO_MATERIAL_UPDATE.`);
 })();
 ```
 
-Deploy still requires a cronjob with `--push-notify`, an active
-`alva automation publish` binding, and an explicit FEED alert subscription.
-Publishing establishes the Feed/cronjob identity; adding or changing an alert
-output later does not require another publish.
+Deploy still requires a cronjob with `--push-notify` and an active
+`alva automation publish` binding. Initial publish creates the owner's FEED
+alert binding automatically; use `alva alert enable` to move it to a different
+destination or to bind another viewer. Publishing also starts the producer once
+unless `--skip-auto-trigger` is present. Adding or changing an alert output
+later does not require another publish.
 
 ### Legacy Compatibility
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -22,6 +22,12 @@ A personal FEED alert has one delivery binding per viewer and feed. Enabling
 the same alert for another destination moves the personal alert; it does not
 create a second copy. Choose the destination before mutating it:
 
+Creating a new automation with `alva automation publish` immediately creates
+the owner's ACTIVE binding. It uses the owned origin-session channel when one
+can be resolved and otherwise uses the default personal destination. Pass
+`--skip-auto-trigger` when this binding must be inspected or moved before the
+first producer run; the flag skips the run, not the binding.
+
 - **Default personal destination:** omit `--channel-id`. The service stores
   `channel_id=0`; web delivery is available immediately, and external DM
   delivery uses `active_im_provider` plus its matching username from
@@ -55,27 +61,33 @@ A push is set up only after all of these succeed:
    other fields remain ordinary ALFS data. Use a descriptive, non-reserved
    source such as `market/brief` or `monitor/anomaly`.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
-   `before-automation-publish`.
+   `before-automation-publish`. Publish creates the owner binding and starts the
+   producer once by default. When the destination must be selected explicitly,
+   publish with `--skip-auto-trigger`.
 3. Exercise a material branch with `alva run`, read `@last/1` of the declared
    output, and confirm it contains a non-empty `body`. Exercise a quiet branch
    and confirm it does not append a new record.
 4. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-5. Enable the FEED alert for the intended destination using
-   [Choose The Delivery Destination](#choose-the-delivery-destination). For the
-   default personal destination, use `alva alert enable --automation
-   <owner>/<feed>` or `alva alert enable --automation-ids <id,id>`. For the
-   current Alva topic channel, use `alva alert enable --automation-ids <id,id>
-   --channel-id <current_channel_id>`; never replace this with the
-   name-addressed default-personal command.
+5. Inspect the owner FEED alert created by publish and confirm its destination.
+   If it is already correct, do not re-enable it. To move it to the default
+   personal destination, use `alva alert enable --automation <owner>/<feed>` or
+   `alva alert enable --automation-ids <id,id>`. For the current Alva topic
+   channel, use `alva alert enable --automation-ids <id,id> --channel-id
+   <current_channel_id>`; never replace this with the name-addressed
+   default-personal command.
 
 Do not trigger the cronjob or wait for its next scheduled run solely to verify
-setup. `alva deploy trigger` is not a dry run: after publisher push and an alert
-binding are enabled, Run Now can notify real subscribers. Use `alva run` for
-non-delivering script checks before enablement. A successful enable proves that
-alert delivery is configured for the selected destination; it does not prove
-that a message has already been delivered. An ALFS record alone is also not
-delivery proof. Claim real delivery only when an existing
+setup. A default publish already admitted the first producer run; triggering it
+again duplicates the pipeline. `alva deploy trigger` is not a dry run: after
+publish creates the owner binding, Run Now can notify that destination. Use
+`alva run` for non-delivering script checks before publish. When publish used
+`--skip-auto-trigger`, route the binding first and trigger at most once only if
+a real delivery run is required. A successful enable proves that alert delivery
+is configured for the selected destination; an already-correct binding proves
+the same without another mutation. It does not prove that a message has already
+been delivered. An ALFS record alone is also not delivery proof.
+Claim real delivery only when an existing
 `alva alert history` row for the intended destination records the run as
 `sent`.
 


### PR DESCRIPTION
## Summary

- document that initial automation publish creates an ACTIVE owner alert binding and starts the producer once by default
- clarify that --push-notify alone does not subscribe users, while publish does auto-bind the owner
- teach the controlled flow: publish with --skip-auto-trigger, inspect or move the binding, then trigger at most once only when a real run is required
- remove guidance that could cause a duplicate full pipeline run after the default publish run
- add deterministic doc and mutation regressions for the contract

## Verification

- skill doc eval: 69/69 cases, 691/691 checks
- mutation smoke: 15/15 mutations failed as expected
- git diff --check

## Compatibility

- Breaking change: no
- Migration: none

## Merge order

1. Merge alva-ai/toolkit-ts#148.
2. Publish and roll the toolkit into the agent runtime.
3. Merge this documentation PR so the documented flag is available when agents follow it.

Related to alva-ai/mono-meta#812.