### PR TITLE
docs(alva): add advice request header

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -885,15 +885,18 @@
       "id": "target.mandatory-investment-disclaimer",
       "group": "target",
       "target": "corpus",
-      "description": "Security-price and investment-strategy answers have one mandatory disclaimer contract wired into prose and routing.",
+      "description": "Security-price and investment-strategy answers have a mandatory disclaimer, while explicit advice requests also receive the required opening header.",
       "section_includes": [
         {
           "file": "SKILL.md",
           "heading": "First Principles",
           "label": "top-level requirement",
           "includes": [
-            "Mandatory disclaimer",
-            "Any answer involving a security price or investment strategy MUST include an investment disclaimer"
+            "Mandatory investment framing",
+            "Any answer involving a security price or investment strategy MUST include an investment disclaimer",
+            "financial advice",
+            "analyst advice",
+            "exact advice-request header"
           ]
         },
         {
@@ -903,7 +906,10 @@
           "includes": [
             "investment disclaimer is required",
             "security price or investment strategy",
-            "This content is for informational purposes only and does not constitute investment advice."
+            "This content is for informational purposes only and does not constitute investment advice.",
+            "begin the response with this exact header",
+            "I'll share an analysis, but keep in mind I'm not a licensed analyst or adviser, and this isn't personalized advice for you specifically.",
+            "This advice-request header is additive"
           ]
         },
         {

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -21,11 +21,26 @@ const MUTATIONS = [
   {
     id: "mandatory-investment-disclaimer",
     file: "SKILL.md",
-    remove: "10. **Mandatory disclaimer.** Any answer involving a security price or investment strategy MUST include an investment disclaimer. See [user-facing-prose.md](references/user-facing-prose.md#investment-disclaimer).\n",
+    remove: "10. **Mandatory investment framing.** Any answer involving a security price or investment strategy MUST include an investment disclaimer. If the user asks for any \"financial advice\" or \"analyst advice,\" the response MUST also begin with the exact advice-request header. See [user-facing-prose.md](references/user-facing-prose.md#investment-disclaimer).\n",
     expectFailedCases: [
       "target.mandatory-investment-disclaimer",
       "scenario.equity-price-disclaimer",
+      "scenario.explicit-analyst-advice-header",
       "scenario.backtest-strategy",
+    ],
+  },
+  {
+    id: "explicit-advice-request-header",
+    file: "references/user-facing-prose.md",
+    remove:
+      "If the user asks for any \"financial advice\" or \"analyst advice,\" begin the\n" +
+      "response with this exact header before providing the analysis:\n\n" +
+      "> I'll share an analysis, but keep in mind I'm not a licensed analyst or adviser, and this isn't personalized advice for you specifically.\n\n" +
+      "This advice-request header is additive: when the answer involves a security\n" +
+      "price or investment strategy, also include the investment disclaimer above.\n",
+    expectFailedCases: [
+      "target.mandatory-investment-disclaimer",
+      "scenario.explicit-analyst-advice-header",
     ],
   },
   {

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -41,6 +41,24 @@
       }
     },
     {
+      "id": "scenario.explicit-analyst-advice-header",
+      "group": "scenarios.ask",
+      "prompt": "Give me your analyst advice on whether I should buy NVDA.",
+      "description": "An explicit analyst-advice request begins with the required header and retains the investment disclaimer.",
+      "expect": {
+        "route": "Financial Analysis / Ask Question",
+        "references": [
+          "user-facing-prose.md"
+        ],
+        "behaviors": [
+          "If the user asks for any \"financial advice\" or \"analyst advice,\" the response MUST also begin with the exact advice-request header",
+          "I'll share an analysis, but keep in mind I'm not a licensed analyst or adviser, and this isn't personalized advice for you specifically.",
+          "This advice-request header is additive",
+          "This content is for informational purposes only and does not constitute investment advice."
+        ]
+      }
+    },
+    {
       "id": "scenario.complex-valuation-ask",
       "group": "scenarios.ask",
       "prompt": "Is NVDA cheap versus peers after the latest earnings revision?",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -144,7 +144,7 @@ These are the high-signal rules to remember.
 9. **References own depth.** Top-level sections tell you what the capability is,
    what rule is easy to miss, and which file to open. Long examples, commands,
    and checklists live in the linked reference.
-10. **Mandatory disclaimer.** Any answer involving a security price or investment strategy MUST include an investment disclaimer. See [user-facing-prose.md](references/user-facing-prose.md#investment-disclaimer).
+10. **Mandatory investment framing.** Any answer involving a security price or investment strategy MUST include an investment disclaimer. If the user asks for any "financial advice" or "analyst advice," the response MUST also begin with the exact advice-request header. See [user-facing-prose.md](references/user-facing-prose.md#investment-disclaimer).
 
 Two consequences are worth making explicit. First, a useful Alva answer can be
 small: a financial-analysis question should not become a playbook unless the

--- a/skills/alva/references/user-facing-prose.md
+++ b/skills/alva/references/user-facing-prose.md
@@ -131,6 +131,14 @@ security price or investment strategy.
 
 > This content is for informational purposes only and does not constitute investment advice.
 
+If the user asks for any "financial advice" or "analyst advice," begin the
+response with this exact header before providing the analysis:
+
+> I'll share an analysis, but keep in mind I'm not a licensed analyst or adviser, and this isn't personalized advice for you specifically.
+
+This advice-request header is additive: when the answer involves a security
+price or investment strategy, also include the investment disclaimer above.
+
 ## Voice
 
 User-facing prose in Alva should read like a sharp human analyst, not a


### PR DESCRIPTION
## Summary
- require explicit financial-advice or analyst-advice requests to begin with the prescribed analyst-status header
- keep the existing investment disclaimer additive for security-price and strategy answers
- add deterministic scenario and mutation coverage for the new framing rule

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related PRs
None.

## Verification
- git diff --check origin/main...HEAD
- node evals/alva-skill-docs/skill-doc-eval.mjs --out /tmp/alva-skill-advice-header-report.md (70/70 cases, 703/703 checks)
- node evals/alva-skill-docs/mutation-smoke.mjs (16/16 mutations failed as expected)

Broader suites skipped: this is a localized documentation and deterministic-eval change with no runtime package or external contract changes.