### PR TITLE
docs(alva): teach rich feed alerts

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -264,6 +264,48 @@
       ]
     },
     {
+      "id": "alerts.portable-actions-and-cards",
+      "group": "alerts",
+      "target": "corpus",
+      "description": "Declared Feed alerts can carry portable CTA actions and card presentation without confusing them with conversational PresentActions.",
+      "section_includes": [
+        {
+          "file": "SKILL.md",
+          "heading": "Action Layer: Alerts",
+          "label": "rich alert summary",
+          "includes": [
+            "portable actions and card presentation",
+            "[push-notifications.md](references/push-notifications.md)"
+          ]
+        },
+        {
+          "file": "references/feed-sdk.md",
+          "heading": "Portable Actions And Card Presentation",
+          "label": "Feed SDK rich alert authoring",
+          "includes": [
+            "messageActionsField()",
+            "messagePresentationField()",
+            "openUrlAction(",
+            "sendPromptAction(",
+            "cardPresentation(",
+            "accentColor",
+            "Discord can render the card and both action kinds on the same final message",
+            "never call it from a Feed script"
+          ]
+        },
+        {
+          "file": "references/push-notifications.md",
+          "heading": "Configure And Verify",
+          "label": "rich alert delivery boundary",
+          "includes": [
+            "A free-standing `url` field does not become a button",
+            "conversational `PresentActions` must not be used by a Feed",
+            "falls back to canonical `title` + `body`"
+          ]
+        }
+      ]
+    },
+    {
       "id": "retained.memory-secrets",
       "group": "retained",
       "target": "corpus",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -120,6 +120,15 @@ const MUTATIONS = [
     expectFailedCases: ["scenario.alert-push-monitor"],
   },
   {
+    id: "feed-rich-alert-authoring",
+    file: "references/feed-sdk.md",
+    remove: "#### Portable Actions And Card Presentation\n",
+    expectFailedCases: [
+      "alerts.portable-actions-and-cards",
+      "scenario.rich-feed-alert",
+    ],
+  },
+  {
     id: "ticker-read-first-tier-route",
     file: "SKILL.md",
     remove: "read [ticker-read.md](references/ticker-read.md) before source selection",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -259,6 +259,45 @@
       }
     },
     {
+      "id": "scenario.rich-feed-alert",
+      "group": "scenarios.push",
+      "prompt": "Create a scheduled market Feed alert with a red Discord card, a View report link button, and an Analyze impact follow-up button.",
+      "description": "A rich Feed alert uses the declared portable action and presentation fields, preserving title/body fallback and keeping PresentActions out of Feed code.",
+      "expect": {
+        "route": "Automation / Push",
+        "references": [
+          "feed-sdk.md",
+          "push-notifications.md"
+        ],
+        "behaviors": [
+          "messageActionsField()",
+          "messagePresentationField()",
+          "openUrlAction(",
+          "sendPromptAction(",
+          "cardPresentation(",
+          "Discord can render the card and both action kinds on the same final message",
+          "Clients without card support retain `title` + `body`",
+          "`PresentActions` is a conversation-reply tool, not a Feed API"
+        ],
+        "forbidden_behaviors": [
+          "A free-standing `url` field does not become a button",
+          "never call it from a Feed script"
+        ],
+        "sections": [
+          {
+            "file": "references/feed-sdk.md",
+            "heading": "Portable Actions And Card Presentation",
+            "includes": [
+              "accentColor: \"#FF2020\"",
+              "openUrlAction(\"View report\"",
+              "sendPromptAction(",
+              "cardPresentation({"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": "scenario.current-topic-channel-alert",
       "group": "scenarios.push",
       "prompt": "<session-prefill-channel-memory channel-id=\"44\" root=\"/alva/home/ymchcom/channels/research/memory\"> Notify this channel every minute with hello111.",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -582,8 +582,8 @@ and Run Now executions deliver those outputs; it does not subscribe users or
 bypass preferences by itself.
 
 Open [push-notifications.md](references/push-notifications.md) for alert-output
-authoring, automation publish, alert setup, and verification. A quiet V2 run
-does not append an alert record.
+authoring, portable actions and card presentation, automation publish, alert
+setup, and verification. A quiet V2 run does not append an alert record.
 
 After releasing or keeping a playbook as draft, scan whether any backing feed is
 push-worthy. A push setup requires a declared alert output or a recognized

--- a/skills/alva/references/feed-sdk.md
+++ b/skills/alva/references/feed-sdk.md
@@ -210,8 +210,10 @@ feed.def("market", {
 Alert-output rules:
 
 - The TypeDoc must declare a root `body` string. A root `title` string is
-  optional. Additional fields such as `ticker`, `url`, or structured analysis
-  remain available in ALFS but do not change the standard notification text.
+  optional. Ordinary additional fields such as `ticker`, a free-standing
+  `url`, or structured analysis remain available in ALFS but do not change the
+  notification. Only the SDK's declared `actions` and `presentation` fields
+  opt into portable buttons and card rendering.
 - Use any descriptive, valid `group/output` except the reserved legacy sources
   `signal/targets` and `notify/message`.
 - A top-level script execution may return at most one alert record for a given
@@ -232,6 +234,80 @@ Alert-output rules:
   checks.
 - Changing the declaration or source in an already active Feed does not require
   republishing. The next run uses the current script and declarations.
+
+#### Portable Actions And Card Presentation
+
+Declare optional message actions with `messageActionsField()` and an optional
+card with `messagePresentationField()`. Build records with the matching helpers;
+do not hand-shape platform payloads:
+
+```javascript
+const {
+  Feed,
+  feedPath,
+  makeDoc,
+  str,
+  alertOutput,
+  messageActionsField,
+  messagePresentationField,
+  openUrlAction,
+  sendPromptAction,
+  cardPresentation,
+} = require("@alva/feed");
+
+const feed = new Feed({ path: feedPath("market-radar") });
+feed.def("market", {
+  alerts: alertOutput(
+    makeDoc("Market Alert", "Push-ready market event", [
+      str("title"),
+      str("body"),
+      messageActionsField(),
+      messagePresentationField(),
+    ]),
+  ),
+});
+
+await feed.run(async (ctx) => {
+  const event = getMaterialEvent();
+  if (!event) return;
+
+  await ctx.self.ts("market", "alerts").append([
+    {
+      date: Date.now(),
+      title: `${event.ticker} halted down`,
+      body: `Price: ${event.price}\nChange: ${event.change}`,
+      actions: [
+        openUrlAction("View report", event.reportUrl),
+        sendPromptAction(
+          "Analyze impact",
+          `Analyze the impact of this ${event.ticker} alert.`,
+        ),
+      ],
+      presentation: cardPresentation({
+        accentColor: "#FF2020",
+        url: event.reportUrl,
+        thumbnailUrl: event.logoUrl,
+        footer: "Market Radar",
+        fields: [
+          { label: "Volume", value: event.volume, inline: true },
+          { label: "Status", value: event.status, inline: true },
+        ],
+      }),
+    },
+  ]);
+});
+```
+
+`openUrlAction()` creates an HTTPS destination action. `sendPromptAction()`
+creates a follow-up in the same Alva conversation; never place secrets in its
+prompt. A card uses the alert `title` and `body` as its canonical title and
+description, with optional `accentColor`, `url`, `thumbnailUrl`, `footer`, and
+up to 25 `fields`.
+
+Discord can render the card and both action kinds on the same final message.
+Clients without card support retain `title` + `body`, and delivery remains
+useful even when presentation is unavailable. `PresentActions` is a
+conversation-reply tool, not a Feed API; never call it from a Feed script.
 
 ### Pattern E: AlvaAsk + Declared Alert Output
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -58,8 +58,17 @@ A push is set up only after all of these succeed:
 
 1. Declare the intended output with `alertOutput(typeDoc)`. The TypeDoc must
    have a root `body` string field and may have a root `title` string field;
-   other fields remain ordinary ALFS data. Use a descriptive, non-reserved
-   source such as `market/brief` or `monitor/anomaly`.
+   ordinary extra fields remain ALFS data. For portable buttons, also declare
+   `messageActionsField()` and write `openUrlAction()` or
+   `sendPromptAction()` values. For a platform-neutral card, declare
+   `messagePresentationField()` and write `cardPresentation()`. Discord renders
+   the card as one Embed and can attach both action kinds to it; unsupported
+   presentation falls back to canonical `title` + `body`. A free-standing
+   `url` field does not become a button, and conversational `PresentActions`
+   must not be used by a Feed. See
+   [Portable Actions And Card Presentation](feed-sdk.md#portable-actions-and-card-presentation).
+   Use a descriptive, non-reserved source such as `market/brief` or
+   `monitor/anomaly`.
 2. Run the feed through [feed-lifecycle.md](feed-lifecycle.md), including
    `before-automation-publish`. Publish creates the owner binding and starts the
    producer once by default. When the destination must be selected explicitly,


### PR DESCRIPTION
## Summary
- document Feed Alert V2 portable `actions` and card `presentation` helpers
- clarify Discord Embed/button rendering and title/body fallback
- keep conversational `PresentActions` out of Feed scripts
- add regression and mutation coverage for rich Feed alerts

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related PRs
None.

## Verification
- `python3 -m json.tool evals/alva-skill-docs/{cases,scenarios}.json`
- `git diff --check`
- skill-creator `quick_validate.py skills/alva`
- `node evals/alva-skill-docs/skill-doc-eval.mjs` (72/72 cases)
- `node evals/alva-skill-docs/mutation-smoke.mjs` (17/17 mutations)