### PR TITLE
chore(alva): bump version to v1.21.0

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1123,7 +1123,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.20.1",
+        "version: v1.21.0",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.20.1
+  version: v1.21.0
 ---
 
 # Alva


### PR DESCRIPTION
Bump `SKILL.md` frontmatter version `v1.20.1` → `v1.21.0` ahead of cutting the `v1.21.0` release. `rel/v1.21` and the `v1.21.0` tag will point at this commit.

Includes since `v1.20.1`: rich feed alert guidance (#595), advice request header (#594), automation publish side effects (#593), Lightweight Charts guidance for one-off artifacts (#591), feed selector alignment with synth (#592), company anomaly routed through SkillHub (#590).

🤖 Generated with [Claude Code](https://claude.com/claude-code)