### PR TITLE
Draft: integrate Alva Markets context into ticker reads

### DIFF
--- a/proposals/markets-context-routing/README.md
+++ b/proposals/markets-context-routing/README.md
@@ -1,0 +1,70 @@
+# Markets Context Routing Proposal
+
+Status: review-only proposal. Nothing in this directory is loaded by the
+current Alva Skill.
+
+## Goal
+
+Make the company context already available in Markets readable from every Alva
+conversation surface: alva.ai chat, supported IM channels, and direct Agent
+Skill calls.
+
+The proposal adds two internal consumer references to the existing top-level
+`alva` Skill:
+
+- [Company Narrative](references/company-narrative.md): reads the Markets
+  Narrative/WILF feed, including versions, change semantics, timestamps, and
+  gaps.
+- [Earnings Context](references/earnings.md): resolves one fiscal event and
+  reads every eligible Pre-Earnings, Official Release, Transcript, and
+  Post-Earnings stage.
+
+These are not proposed as separate installable Skills. They are internal
+modules selected by the existing Alva ticker router.
+
+## Why This Lives Under `proposals/`
+
+The first review should not modify `skills/alva/**`. Engineering can review the
+feed contracts, time boundaries, fallback behavior, and routing shape before
+integrating them into the live Skill.
+
+The proposed production destination after approval is:
+
+```text
+skills/alva/
+├── SKILL.md
+└── references/
+    ├── request-routing.md
+    ├── ticker-read.md
+    ├── company-narrative.md   # new
+    └── earnings.md            # new
+```
+
+## Design Decisions
+
+1. Keep one top-level `alva` Skill. Narrative and Earnings are reference
+   modules, not independently triggered Skills.
+2. Treat WILF as the base Narrative record, while preserving Markets-only
+   version and `narrative_change_log` semantics.
+3. Treat Earnings as one lifecycle workflow rather than four modules. Resolve
+   one fiscal event, calculate an information cutoff, then read every stage
+   that existed by that cutoff.
+4. Missing one source must not erase other valid context. Return typed stage
+   gaps and continue.
+5. Use the feeds and Data Skills directly. Do not scrape the Markets UI.
+6. Apply the same normalized contracts in web, IM, and direct Skill calls.
+
+## What Engineering Should Review
+
+- Environment owner configuration and absolute ALFS paths.
+- Canonical ticker-to-feed-slug resolver, especially share classes and non-US
+  symbols.
+- Shared fiscal-event selector for broad company questions.
+- Publication timestamps used for release and transcript point-in-time gates.
+- Transcript retrieval/filtering outside model context.
+- Whether current runtime tools expose all required reads in every supported
+  channel.
+- Evaluation coverage before merging into `skills/alva/**`.
+
+See [routing-integration.md](routing-integration.md) for the exact proposed
+router changes and acceptance tests.

--- a/proposals/markets-context-routing/README.md
+++ b/proposals/markets-context-routing/README.md
@@ -1,70 +1,42 @@
-# Markets Context Routing Proposal
+# Markets Company Context RFC
 
-Status: review-only proposal. Nothing in this directory is loaded by the
+Status: API-first design proposal. Nothing in this directory is loaded by the
 current Alva Skill.
 
 ## Goal
 
-Make the company context already available in Markets readable from every Alva
-conversation surface: alva.ai chat, supported IM channels, and direct Agent
-Skill calls.
+Let a user ask about a company from alva.ai, an IM channel, or a direct Skill
+call and receive the same Markets context: Company Narrative plus the relevant
+Earnings lifecycle.
 
-The proposal adds two internal consumer references to the existing top-level
-`alva` Skill:
-
-- [Company Narrative](references/company-narrative.md): reads the Markets
-  Narrative/WILF feed, including versions, change semantics, timestamps, and
-  gaps.
-- [Earnings Context](references/earnings.md): resolves one fiscal event and
-  reads every eligible Pre-Earnings, Official Release, Transcript, and
-  Post-Earnings stage.
-
-These are not proposed as separate installable Skills. They are internal
-modules selected by the existing Alva ticker router.
-
-## Why This Lives Under `proposals/`
-
-The first review should not modify `skills/alva/**`. Engineering can review the
-feed contracts, time boundaries, fallback behavior, and routing shape before
-integrating them into the live Skill.
-
-The proposed production destination after approval is:
+## Proposed Boundary
 
 ```text
-skills/alva/
-├── SKILL.md
-└── references/
-    ├── request-routing.md
-    ├── ticker-read.md
-    ├── company-narrative.md   # new
-    └── earnings.md            # new
+Ticker intent router
+  -> stable Company Context API / Toolkit command
+  -> backend CompanyService
+  -> validated Narrative and Earnings sources
 ```
 
-## Design Decisions
+- Keep one installable `alva` Skill.
+- Make `ticker-read.md` the sole owner of company-context intent routing.
+- Keep Narrative and Earnings as internal consumer contracts, not separate
+  Skills.
+- Keep source addressing, event selection, point-in-time enforcement, status
+  normalization, and transcript bounding behind the API.
+- Let the Skill request bounded context and synthesize the answer.
 
-1. Keep one top-level `alva` Skill. Narrative and Earnings are reference
-   modules, not independently triggered Skills.
-2. Treat WILF as the base Narrative record, while preserving Markets-only
-   version and `narrative_change_log` semantics.
-3. Treat Earnings as one lifecycle workflow rather than four modules. Resolve
-   one fiscal event, calculate an information cutoff, then read every stage
-   that existed by that cutoff.
-4. Missing one source must not erase other valid context. Return typed stage
-   gaps and continue.
-5. Use the feeds and Data Skills directly. Do not scrape the Markets UI.
-6. Apply the same normalized contracts in web, IM, and direct Skill calls.
+The Skill must not read the Markets web page or reconstruct backend selection
+logic from storage records.
 
-## What Engineering Should Review
+## Documents
 
-- Environment owner configuration and absolute ALFS paths.
-- Canonical ticker-to-feed-slug resolver, especially share classes and non-US
-  symbols.
-- Shared fiscal-event selector for broad company questions.
-- Publication timestamps used for release and transcript point-in-time gates.
-- Transcript retrieval/filtering outside model context.
-- Whether current runtime tools expose all required reads in every supported
-  channel.
-- Evaluation coverage before merging into `skills/alva/**`.
+- [Routing integration](routing-integration.md): ownership, API surface,
+  rollout sequence, and acceptance criteria.
+- [Company Narrative](references/company-narrative.md): normalized Narrative
+  contract and synthesis rules.
+- [Earnings Context](references/earnings.md): unified Pre, Release, Transcript,
+  and Post contract.
 
-See [routing-integration.md](routing-integration.md) for the exact proposed
-router changes and acceptance tests.
+The proposal can move into `skills/alva/references/` only after producer,
+backend, Toolkit, and cross-channel parity checks pass.

--- a/proposals/markets-context-routing/README.md
+++ b/proposals/markets-context-routing/README.md
@@ -1,42 +1,36 @@
-# Markets Company Context RFC
+# Markets Context Skill Integration
 
-Status: API-first design proposal. Nothing in this directory is loaded by the
+Status: review-only proposal. Nothing in this directory is loaded by the
 current Alva Skill.
 
 ## Goal
 
-Let a user ask about a company from alva.ai, an IM channel, or a direct Skill
-call and receive the same Markets context: Company Narrative plus the relevant
-Earnings lifecycle.
+Let users receive the same current Markets company context from alva.ai, IM
+channels, and direct Skill calls.
 
-## Proposed Boundary
+The canonical Toolkit surface already exists:
 
 ```text
-Ticker intent router
-  -> stable Company Context API / Toolkit command
-  -> backend CompanyService
-  -> validated Narrative and Earnings sources
+alva markets narrative --ticker <TICKER>
+alva markets earnings --ticker <TICKER> [event selector]
 ```
+
+This proposal therefore does not invent a new Company Context API or ask the
+Skill to read underlying records. It defines how the existing `alva` Skill
+routes to these commands and synthesizes their normalized output.
+
+## Decisions
 
 - Keep one installable `alva` Skill.
 - Make `ticker-read.md` the sole owner of company-context intent routing.
-- Keep Narrative and Earnings as internal consumer contracts, not separate
-  Skills.
-- Keep source addressing, event selection, point-in-time enforcement, status
-  normalization, and transcript bounding behind the API.
-- Let the Skill request bounded context and synthesize the answer.
+- Keep Narrative and Earnings as internal references, not separate Skills.
+- Use the current backend view only; historical point-in-time reads are not yet
+  supported.
+- Keep source resolution, fiscal-event selection, and data normalization behind
+  `alva markets`.
 
-The Skill must not read the Markets web page or reconstruct backend selection
-logic from storage records.
+See [routing-integration.md](routing-integration.md) for rollout gates and the
+two consumer contracts for synthesis behavior:
 
-## Documents
-
-- [Routing integration](routing-integration.md): ownership, API surface,
-  rollout sequence, and acceptance criteria.
-- [Company Narrative](references/company-narrative.md): normalized Narrative
-  contract and synthesis rules.
-- [Earnings Context](references/earnings.md): unified Pre, Release, Transcript,
-  and Post contract.
-
-The proposal can move into `skills/alva/references/` only after producer,
-backend, Toolkit, and cross-channel parity checks pass.
+- [Company Narrative](references/company-narrative.md)
+- [Earnings Context](references/earnings.md)

--- a/proposals/markets-context-routing/references/company-narrative.md
+++ b/proposals/markets-context-routing/references/company-narrative.md
@@ -1,119 +1,79 @@
 # Company Narrative Context
 
-Status: proposed consumer contract. The canonical API does not yet expose all
-required selection and point-in-time behavior.
+Status: proposed Skill consumer contract for the current Markets backend view.
 
 ## Contents
 
-- [Purpose and boundary](#purpose-and-boundary)
-- [Request](#request)
-- [Response](#response)
-- [Selection and time rules](#selection-and-time-rules)
-- [Change semantics](#change-semantics)
-- [Synthesis and degradation](#synthesis-and-degradation)
+- [Command](#command)
+- [What it supplies](#what-it-supplies)
+- [Consumption rules](#consumption-rules)
+- [Synthesis](#synthesis)
+- [Failure and degradation](#failure-and-degradation)
 
-## Purpose And Boundary
+## Command
 
-Company Narrative supplies the Markets view of the investor debate: the dated
-one-line read, current questions, competitive context, what would move the
-debate, recent changes, and known evidence gaps.
-
-It is analytical context, not authority for live price, official results,
-guidance, filings, event timing, or raw news. The Skill consumes a normalized
-API result; it does not read the page, locate a source record, select a version,
-or parse legacy storage shapes.
-
-## Request
-
-```json
-{
-  "symbol": "AAPL",
-  "query_as_of": "optional ISO-8601 timestamp",
-  "version": { "generated_at": "optional exact version timestamp" },
-  "detail": "summary | evidence"
-}
+```text
+alva markets narrative --ticker <CANONICAL_TICKER>
 ```
 
-- No cutoff means the latest valid version available now.
-- An exact version is used for page-selected history.
-- `summary` is the default for broad company questions.
-- `evidence` adds bounded change history and supporting fields when requested.
+The command accepts only `--ticker`. The Toolkit/backend owns company
+resolution and source normalization. The Skill must not construct source paths,
+derive source-specific slugs, or scrape the Markets page.
 
-## Response
+## What It Supplies
 
-```json
-{
-  "status": "AVAILABLE | NOT_AVAILABLE_YET | UNAVAILABLE",
-  "unavailable_reason": null,
-  "symbol": "AAPL",
-  "selected_version": {
-    "generated_at": "ISO-8601",
-    "evidence_cutoff_at": "ISO-8601",
-    "selection_reason": "LATEST_VALID | EXACT_VERSION | AS_OF"
-  },
-  "summary": {
-    "oneliner": "...",
-    "focusing_now": ["..."],
-    "competitive_landscape": ["..."],
-    "what_would_move": ["..."],
-    "street_stands": ["..."]
-  },
-  "changes": {
-    "run_change_summary": [],
-    "material_narrative_changes": []
-  },
-  "gaps": [],
-  "warnings": []
-}
-```
+The normalized Narrative response is expected to cover:
 
-The backend may retain additional provenance internally. The Toolkit should
-return only the bounded fields needed by the caller.
+- current market narrative and investor questions;
+- bullish and bearish catalysts;
+- focus across the latest four reported quarters;
+- changes in Street expectations;
+- comparable companies;
+- dated Narrative snapshots and material change records;
+- data gaps and warnings when present.
 
-## Selection And Time Rules
+Narrative is Alva analysis. It is not authority for live price, official
+results, guidance, filing contents, or earnings timing.
 
-The backend must:
+## Consumption Rules
 
-1. Resolve the canonical security and reject a mismatched record.
-2. Select latest valid, exact version, or newest valid version at
-   `query_as_of`.
-3. Require both `generated_at` and `evidence_cutoff_at` to be at or before an
-   explicit historical cutoff.
-4. Exclude a record whose evidence cannot be proven to respect its cutoff.
-5. Return the selection reason, timestamp, gaps, and any legacy normalization
-   warning.
+- Use the current record for present-tense investor-focus questions.
+- Use returned history only to explain changes leading to the current record.
+- Keep ordinary version changes distinct from material narrative changes.
+- Treat an empty material-change log as “no recorded material change,” not proof
+  that the thesis is unchanged.
+- Preserve Narrative timestamps and disclose staleness or material gaps.
+- Do not answer a historical point-in-time question from the latest record.
 
-The Skill must not simulate these checks in prompting. A later record cannot
-be used merely because it discusses an earlier event.
+The current command has no exact-version or `query_as_of` selector. A question
+such as “What did Alva believe on January 15?” is unsupported even when the
+response contains historical snapshots, because later knowledge may affect the
+current normalized view.
 
-## Change Semantics
+## Synthesis
 
-Keep two products distinct:
+For a broad company answer, use only:
 
-| Field | Meaning |
-| --- | --- |
-| `run_change_summary` | Ordinary differences between generated Narrative versions. |
-| `material_narrative_changes` | An event changed the investor question, mechanism, or decision variable. |
-
-An empty material-change list is normal; it does not prove that “nothing
-happened” or that the thesis is unchanged. Legacy string arrays, object arrays,
-null values, and malformed entries are normalized or rejected by the backend,
-not interpreted ad hoc by each channel.
-
-## Synthesis And Degradation
-
-For a broad answer, use at most:
-
-1. The dated one-line view.
-2. Two or three current investor questions.
-3. The decision variables most likely to change the debate.
-4. A material recent change only when relevant.
+1. The dated one-line market view.
+2. Two or three decision-relevant investor questions.
+3. The catalysts or evidence that would change the view.
+4. One material recent Narrative change when relevant.
 5. Material gaps or staleness.
 
-Label the content as Alva analysis and preserve its timestamp. Fetch current
-facts from their authoritative sources.
+For a narrow Narrative question, add only the relevant competitive, Street, or
+change-history detail. Do not dump every Narrative section.
 
-If Narrative is unavailable, continue with other company evidence but do not
-claim “Alva's current narrative.” Return one of these reasons with
-`UNAVAILABLE`: `SOURCE_MISSING`, `NOT_ENTITLED`, `INVALID_SOURCE`,
-`UPSTREAM_FAILURE`, or `OUTSIDE_AS_OF`.
+Label conclusions as Alva analysis and source current factual claims
+separately.
+
+## Failure And Degradation
+
+- If current Narrative is available but one history row is invalid, the backend
+  should preserve the current result and return the history problem as a typed
+  gap.
+- If the command fails or the current record is invalid, continue with other
+  company sources but do not claim “Alva's current Narrative.”
+- Missing history does not make a valid current Narrative unavailable; it only
+  limits change analysis.
+- A mismatched security, malformed current record, or upstream failure must not
+  be rephrased as a neutral market view.

--- a/proposals/markets-context-routing/references/company-narrative.md
+++ b/proposals/markets-context-routing/references/company-narrative.md
@@ -1,244 +1,119 @@
 # Company Narrative Context
 
-Use this reference when a single-company question needs the context shown in
-Markets > Narrative: the current investor debate, what investors are focusing
-on, what could move the stock, recent changes in that debate, competitive
-context, or Street positioning.
+Status: proposed consumer contract. The canonical API does not yet expose all
+required selection and point-in-time behavior.
 
-This is a read-only consumer contract. It does not generate a new WILF card,
-run the narrative producer, or scrape the Markets page. The page and the agent
-must consume the same underlying feed so the same context is available in web,
-IM, chat, and direct Skill calls.
+## Contents
 
-## Boundary: Narrative Is Built On WILF, But Is Not Only WILF
+- [Purpose and boundary](#purpose-and-boundary)
+- [Request](#request)
+- [Response](#response)
+- [Selection and time rules](#selection-and-time-rules)
+- [Change semantics](#change-semantics)
+- [Synthesis and degradation](#synthesis-and-degradation)
 
-The WILF card is the base company narrative record. Markets adds version and
-change semantics that the older published WILF method may not document:
+## Purpose And Boundary
 
-- the current one-line read and six narrative sections;
-- the card's `date` and analytical `as_of` timestamps;
-- weekly card-to-card changes in `change_summary`;
-- material event-driven changes in `narrative_change_log`;
-- version selection and historical point-in-time reads;
-- explicit gaps and coverage state.
+Company Narrative supplies the Markets view of the investor debate: the dated
+one-line read, current questions, competitive context, what would move the
+debate, recent changes, and known evidence gaps.
 
-Therefore, do not implement Markets Narrative by calling only the documented
-fields of `alva/what-investors-are-looking-for`. Read the current raw record and
-apply this contract. The published WILF method can still be used as the source
-method, but this reference owns the consumer behavior required for Markets
-parity.
+It is analytical context, not authority for live price, official results,
+guidance, filings, event timing, or raw news. The Skill consumes a normalized
+API result; it does not read the page, locate a source record, select a version,
+or parse legacy storage shapes.
 
-Narrative is analytical context, not a source of live price, official earnings
-actuals, current event timing, estimates, filings, or raw news. Fetch those
-from Data Skills or primary sources when the question needs them.
-
-## When To Read It
-
-Read Company Narrative for requests such as:
-
-- "How does Alva view AMD?"
-- "What are investors focused on for AAPL?"
-- "What is the current debate?"
-- "What changed in the narrative?"
-- "What would make the stock work or fail?"
-- "How does the competitive landscape look?"
-- "Where does the Street stand?"
-
-For a broad ticker read, Company Narrative is one context layer. Combine it
-with live price, fundamentals, earnings, or anomaly evidence only when those
-layers are relevant to the user's question. Do not load every company source by
-default.
-
-## Inputs And Resolution
-
-Required inputs:
-
-| Input | Rule |
-| --- | --- |
-| `ticker` | Resolve the canonical listed symbol before constructing a path. |
-| `feed_slug` | Lowercase the canonical symbol and replace `.` with `-`, for example `BRK.B` -> `brk-b`. Preserve the canonical symbol separately for validation. |
-| `query_as_of` | User's explicit historical cutoff, page-selected version time, or current time when no cutoff is supplied. |
-| `environment` | Active Alva profile/environment. Never infer it from the hostname alone. |
-| `owner` | Environment-configured Markets feed owner. Production is currently `eddiid`; other environments must provide their configured owner. Never silently reuse the production owner in staging. |
-
-If ticker resolution is ambiguous, resolve it through company detail/search
-before reading the feed. Never fall back to a different share class, exchange,
-or similarly named company.
-
-## Feed Path And Queries
-
-Base output:
-
-```text
-/alva/home/{owner}/feeds/wilf-{feed_slug}/v1/data/wilf/card
-```
-
-Use an absolute path. Do not use `~/feeds/...`, because `~` resolves to the
-caller's home rather than the Markets feed owner.
-
-| Intent | Query | Rule |
-| --- | --- | --- |
-| Current narrative | `.../card/@last/1` | The result is an array. Use its last element, never assume the first element is newest. |
-| What changed | `.../card/@last/{N}` | Use the smallest bounded history that answers the question. Results are chronological, oldest first. |
-| Exact Markets version | `.../card/@range/{dateMs-1}..{dateMs}` | `@range` has an exclusive lower bound. Select and validate the record whose `date` equals `dateMs`. |
-| Historical cutoff | bounded `@before` or `@range` | Select the newest record whose `date <= query_as_of`; never use a later card. |
-
-Do not use `@last/1` for a page-selected historical version. Do not use an
-unbounded history read. See the existing
-[ALFS reference](../../../skills/alva/references/api/filesystem.md) for supported
-synth-mount suffixes.
-
-## Record Contract
-
-The current feed record contains the following fields. Consumers must tolerate
-legacy records that predate later fields, but must not silently ignore a field
-present in the current record.
-
-| Field | Type at rest | Consumer meaning |
-| --- | --- | --- |
-| `date` | integer timestamp | Time-series key and version selector. |
-| `symbol` | string | Canonical company symbol used to validate the record. |
-| `name` | string | Company display name. |
-| `as_of` | string/datetime | Analytical information cutoff of the card. It is not necessarily equal to `date`. |
-| `oneliner` | string | Concise current investor read. |
-| `brief` | string | Source-of-truth narrative document from which the six section mirrors are derived. |
-| `focusing_now` | string | Current investor questions and decision variables. |
-| `competitive_landscape` | string | Peer, positioning, and competitive context. |
-| `what_would_move` | string | Bullish/bearish evidence or events that would change the debate. |
-| `market_focus` | string | Focus across recent reported quarters. |
-| `recent_events` | string | Recent official events included by the producer. Not an exhaustive current-news feed. |
-| `street_stands` | string | Street expectations and positioning context available to the producer. |
-| `news_feed_keywords` | JSON-encoded string | Search terms associated with the narrative. Parse before use. |
-| `changed` | boolean | Whether the generated card changed versus the comparison used by the producer. It does not itself prove a material narrative change. |
-| `change_summary` | JSON-encoded string | Weekly/card-run change reasoning. Parse before use. |
-| `gaps` | JSON-encoded string | Missing evidence or unresolved coverage gaps. Parse and surface when material. |
-| `narrative_change_log` | JSON-encoded string or legacy null/missing | Material event-driven investor-question changes. Parse before use. |
-
-`brief` is the authored source of truth. The six split section fields are
-mirrors for structured display and retrieval. If both are present but materially
-conflict, mark the record `invalid_schema` rather than choosing whichever text
-is more convenient.
-
-Parse JSON-encoded fields defensively:
-
-- valid JSON string -> parsed value;
-- legacy `null` or missing `narrative_change_log` -> empty history with
-  `legacy_schema=true`;
-- malformed JSON -> preserve the raw field, mark `invalid_schema`, and do not
-  invent a parsed value;
-- malformed `gaps` must not be interpreted as "no gaps."
-
-## Narrative Change Semantics
-
-`change_summary` and `narrative_change_log` are different products:
-
-| Field | Meaning | Typical cadence |
-| --- | --- | --- |
-| `change_summary` | What changed between generated WILF cards, including ordinary edits. | Card/weekly refresh. |
-| `narrative_change_log` | A material event changed the investor question, mechanism, or decision variable. | Event-driven scan; usually no entry. |
-
-An unchanged or empty change log is normal. It must not be rewritten as
-"nothing happened" or "the thesis is unchanged" without supporting evidence.
-
-Each `narrative_change_log` entry has this shape:
+## Request
 
 ```json
 {
-  "at": "ISO-8601 timestamp",
-  "narrative": "Exact bullet added to focusing_now",
-  "change_type": "new_question | rewritten_mechanism | resolved_question",
-  "prior_debate": "...",
-  "post_event_debate": "...",
-  "changed_mechanism_or_decision_variable": "...",
-  "event_key": "...",
-  "source_links": ["..."]
+  "symbol": "AAPL",
+  "query_as_of": "optional ISO-8601 timestamp",
+  "version": { "generated_at": "optional exact version timestamp" },
+  "detail": "summary | evidence"
 }
 ```
 
-Entries are newest first and the record retains at most the latest 10. The
-`narrative` value should be byte-identical to the corresponding appended bullet
-in `focusing_now`. If it is not, retain the entry but add a schema warning.
+- No cutoff means the latest valid version available now.
+- An exact version is used for page-selected history.
+- `summary` is the default for broad company questions.
+- `evidence` adds bounded change history and supporting fields when requested.
 
-The scan audit feed is producer health telemetry. Do not load it for an
-ordinary company answer.
-
-## Read Algorithm
-
-1. Resolve canonical ticker, feed slug, environment owner, and `query_as_of`.
-2. Choose current, bounded-history, or exact-version query from the intent.
-3. Read the absolute ALFS path.
-4. Normalize grouped ALFS output if returned as `{date, items: [...]}`.
-5. Select the record and validate `symbol`, `date`, and `as_of`.
-6. Parse every JSON-encoded field and retain parse warnings.
-7. Validate `brief` against the structured section mirrors when both exist.
-8. For change questions, compare selected records and separately interpret
-   `change_summary` and `narrative_change_log`.
-9. Return normalized context plus gaps, freshness, selection reason, and source
-   path to the answer synthesizer.
-
-Suggested normalized internal result:
+## Response
 
 ```json
 {
-  "status": "available",
-  "ticker": "AAPL",
-  "selected_version_ms": 0,
-  "query_as_of": "ISO-8601",
-  "selection_reason": "latest | historical_cutoff | exact_version",
-  "source_path": "/alva/home/.../card/@last/1",
-  "record": {},
-  "parsed": {
-    "news_feed_keywords": [],
-    "change_summary": {},
-    "gaps": [],
-    "narrative_change_log": []
+  "status": "AVAILABLE | NOT_AVAILABLE_YET | UNAVAILABLE",
+  "unavailable_reason": null,
+  "symbol": "AAPL",
+  "selected_version": {
+    "generated_at": "ISO-8601",
+    "evidence_cutoff_at": "ISO-8601",
+    "selection_reason": "LATEST_VALID | EXACT_VERSION | AS_OF"
   },
+  "summary": {
+    "oneliner": "...",
+    "focusing_now": ["..."],
+    "competitive_landscape": ["..."],
+    "what_would_move": ["..."],
+    "street_stands": ["..."]
+  },
+  "changes": {
+    "run_change_summary": [],
+    "material_narrative_changes": []
+  },
+  "gaps": [],
   "warnings": []
 }
 ```
 
-Allowed `status` values are `available`, `not_covered`, `empty`,
-`not_entitled`, `invalid_schema`, and `failed`.
+The backend may retain additional provenance internally. The Toolkit should
+return only the bounded fields needed by the caller.
 
-## Point-In-Time Rules
+## Selection And Time Rules
 
-- An explicit historical date is a hard upper bound on both `date` and the
-  evidence represented by `as_of`.
-- If the selected record has `as_of > query_as_of`, exclude it and select an
-  earlier valid record.
-- A later record cannot be used merely because it describes an earlier event.
-- A current `@last/1` read is allowed only when the user asks for the present
-  view and no historical page version was supplied.
-- Preserve the card's timestamp in the answer. Never describe a weekly card as
-  real-time.
+The backend must:
 
-## Synthesis Contract
+1. Resolve the canonical security and reject a mismatched record.
+2. Select latest valid, exact version, or newest valid version at
+   `query_as_of`.
+3. Require both `generated_at` and `evidence_cutoff_at` to be at or before an
+   explicit historical cutoff.
+4. Exclude a record whose evidence cannot be proven to respect its cutoff.
+5. Return the selection reason, timestamp, gaps, and any legacy normalization
+   warning.
 
-Do not return the raw card as the answer. Synthesize only the sections relevant
-to the question, and keep these layers distinct:
+The Skill must not simulate these checks in prompting. A later record cannot
+be used merely because it discusses an earlier event.
 
-1. **Current debate:** the dated one-line read and the most relevant current
-   investor questions.
-2. **What could change it:** the explicit decision variables or evidence from
-   `what_would_move`.
-3. **What changed:** material change-log entries first, then ordinary weekly
-   card changes when relevant.
-4. **Evidence gaps:** unresolved `gaps`, stale timestamps, or missing history.
+## Change Semantics
 
-Label Narrative statements as Alva analysis. When the answer makes a current
-price, earnings, filing, guidance, or event claim, source that claim separately.
+Keep two products distinct:
 
-## Failure And Fallback
-
-| Condition | Required behavior |
+| Field | Meaning |
 | --- | --- |
-| `PATH_NOT_FOUND` | Report `not_covered` only after confirming owner, environment, and slug. A wrong owner is configuration failure, not missing company coverage. |
-| Empty result | Report `empty`; do not interpret it as a neutral narrative. |
-| Permission/entitlement error | Report `not_entitled`; continue with other authorized sources. |
-| Symbol mismatch | Reject the record as `invalid_schema`; never answer for the wrong security. |
-| Malformed JSON or conflicting mirrors | Preserve raw evidence, add a warning, and use only fields that remain valid. |
-| Stale card | State the timestamp and use it only as dated baseline context. Add current sources when the question requires current facts. |
+| `run_change_summary` | Ordinary differences between generated Narrative versions. |
+| `material_narrative_changes` | An event changed the investor question, mechanism, or decision variable. |
 
-Missing Narrative must not block a useful company answer when other evidence is
-available. It does block claims such as "Alva's current narrative is..." because
-that claim requires a valid Narrative record.
+An empty material-change list is normal; it does not prove that “nothing
+happened” or that the thesis is unchanged. Legacy string arrays, object arrays,
+null values, and malformed entries are normalized or rejected by the backend,
+not interpreted ad hoc by each channel.
+
+## Synthesis And Degradation
+
+For a broad answer, use at most:
+
+1. The dated one-line view.
+2. Two or three current investor questions.
+3. The decision variables most likely to change the debate.
+4. A material recent change only when relevant.
+5. Material gaps or staleness.
+
+Label the content as Alva analysis and preserve its timestamp. Fetch current
+facts from their authoritative sources.
+
+If Narrative is unavailable, continue with other company evidence but do not
+claim “Alva's current narrative.” Return one of these reasons with
+`UNAVAILABLE`: `SOURCE_MISSING`, `NOT_ENTITLED`, `INVALID_SOURCE`,
+`UPSTREAM_FAILURE`, or `OUTSIDE_AS_OF`.

--- a/proposals/markets-context-routing/references/company-narrative.md
+++ b/proposals/markets-context-routing/references/company-narrative.md
@@ -1,0 +1,244 @@
+# Company Narrative Context
+
+Use this reference when a single-company question needs the context shown in
+Markets > Narrative: the current investor debate, what investors are focusing
+on, what could move the stock, recent changes in that debate, competitive
+context, or Street positioning.
+
+This is a read-only consumer contract. It does not generate a new WILF card,
+run the narrative producer, or scrape the Markets page. The page and the agent
+must consume the same underlying feed so the same context is available in web,
+IM, chat, and direct Skill calls.
+
+## Boundary: Narrative Is Built On WILF, But Is Not Only WILF
+
+The WILF card is the base company narrative record. Markets adds version and
+change semantics that the older published WILF method may not document:
+
+- the current one-line read and six narrative sections;
+- the card's `date` and analytical `as_of` timestamps;
+- weekly card-to-card changes in `change_summary`;
+- material event-driven changes in `narrative_change_log`;
+- version selection and historical point-in-time reads;
+- explicit gaps and coverage state.
+
+Therefore, do not implement Markets Narrative by calling only the documented
+fields of `alva/what-investors-are-looking-for`. Read the current raw record and
+apply this contract. The published WILF method can still be used as the source
+method, but this reference owns the consumer behavior required for Markets
+parity.
+
+Narrative is analytical context, not a source of live price, official earnings
+actuals, current event timing, estimates, filings, or raw news. Fetch those
+from Data Skills or primary sources when the question needs them.
+
+## When To Read It
+
+Read Company Narrative for requests such as:
+
+- "How does Alva view AMD?"
+- "What are investors focused on for AAPL?"
+- "What is the current debate?"
+- "What changed in the narrative?"
+- "What would make the stock work or fail?"
+- "How does the competitive landscape look?"
+- "Where does the Street stand?"
+
+For a broad ticker read, Company Narrative is one context layer. Combine it
+with live price, fundamentals, earnings, or anomaly evidence only when those
+layers are relevant to the user's question. Do not load every company source by
+default.
+
+## Inputs And Resolution
+
+Required inputs:
+
+| Input | Rule |
+| --- | --- |
+| `ticker` | Resolve the canonical listed symbol before constructing a path. |
+| `feed_slug` | Lowercase the canonical symbol and replace `.` with `-`, for example `BRK.B` -> `brk-b`. Preserve the canonical symbol separately for validation. |
+| `query_as_of` | User's explicit historical cutoff, page-selected version time, or current time when no cutoff is supplied. |
+| `environment` | Active Alva profile/environment. Never infer it from the hostname alone. |
+| `owner` | Environment-configured Markets feed owner. Production is currently `eddiid`; other environments must provide their configured owner. Never silently reuse the production owner in staging. |
+
+If ticker resolution is ambiguous, resolve it through company detail/search
+before reading the feed. Never fall back to a different share class, exchange,
+or similarly named company.
+
+## Feed Path And Queries
+
+Base output:
+
+```text
+/alva/home/{owner}/feeds/wilf-{feed_slug}/v1/data/wilf/card
+```
+
+Use an absolute path. Do not use `~/feeds/...`, because `~` resolves to the
+caller's home rather than the Markets feed owner.
+
+| Intent | Query | Rule |
+| --- | --- | --- |
+| Current narrative | `.../card/@last/1` | The result is an array. Use its last element, never assume the first element is newest. |
+| What changed | `.../card/@last/{N}` | Use the smallest bounded history that answers the question. Results are chronological, oldest first. |
+| Exact Markets version | `.../card/@range/{dateMs-1}..{dateMs}` | `@range` has an exclusive lower bound. Select and validate the record whose `date` equals `dateMs`. |
+| Historical cutoff | bounded `@before` or `@range` | Select the newest record whose `date <= query_as_of`; never use a later card. |
+
+Do not use `@last/1` for a page-selected historical version. Do not use an
+unbounded history read. See the existing
+[ALFS reference](../../../skills/alva/references/api/filesystem.md) for supported
+synth-mount suffixes.
+
+## Record Contract
+
+The current feed record contains the following fields. Consumers must tolerate
+legacy records that predate later fields, but must not silently ignore a field
+present in the current record.
+
+| Field | Type at rest | Consumer meaning |
+| --- | --- | --- |
+| `date` | integer timestamp | Time-series key and version selector. |
+| `symbol` | string | Canonical company symbol used to validate the record. |
+| `name` | string | Company display name. |
+| `as_of` | string/datetime | Analytical information cutoff of the card. It is not necessarily equal to `date`. |
+| `oneliner` | string | Concise current investor read. |
+| `brief` | string | Source-of-truth narrative document from which the six section mirrors are derived. |
+| `focusing_now` | string | Current investor questions and decision variables. |
+| `competitive_landscape` | string | Peer, positioning, and competitive context. |
+| `what_would_move` | string | Bullish/bearish evidence or events that would change the debate. |
+| `market_focus` | string | Focus across recent reported quarters. |
+| `recent_events` | string | Recent official events included by the producer. Not an exhaustive current-news feed. |
+| `street_stands` | string | Street expectations and positioning context available to the producer. |
+| `news_feed_keywords` | JSON-encoded string | Search terms associated with the narrative. Parse before use. |
+| `changed` | boolean | Whether the generated card changed versus the comparison used by the producer. It does not itself prove a material narrative change. |
+| `change_summary` | JSON-encoded string | Weekly/card-run change reasoning. Parse before use. |
+| `gaps` | JSON-encoded string | Missing evidence or unresolved coverage gaps. Parse and surface when material. |
+| `narrative_change_log` | JSON-encoded string or legacy null/missing | Material event-driven investor-question changes. Parse before use. |
+
+`brief` is the authored source of truth. The six split section fields are
+mirrors for structured display and retrieval. If both are present but materially
+conflict, mark the record `invalid_schema` rather than choosing whichever text
+is more convenient.
+
+Parse JSON-encoded fields defensively:
+
+- valid JSON string -> parsed value;
+- legacy `null` or missing `narrative_change_log` -> empty history with
+  `legacy_schema=true`;
+- malformed JSON -> preserve the raw field, mark `invalid_schema`, and do not
+  invent a parsed value;
+- malformed `gaps` must not be interpreted as "no gaps."
+
+## Narrative Change Semantics
+
+`change_summary` and `narrative_change_log` are different products:
+
+| Field | Meaning | Typical cadence |
+| --- | --- | --- |
+| `change_summary` | What changed between generated WILF cards, including ordinary edits. | Card/weekly refresh. |
+| `narrative_change_log` | A material event changed the investor question, mechanism, or decision variable. | Event-driven scan; usually no entry. |
+
+An unchanged or empty change log is normal. It must not be rewritten as
+"nothing happened" or "the thesis is unchanged" without supporting evidence.
+
+Each `narrative_change_log` entry has this shape:
+
+```json
+{
+  "at": "ISO-8601 timestamp",
+  "narrative": "Exact bullet added to focusing_now",
+  "change_type": "new_question | rewritten_mechanism | resolved_question",
+  "prior_debate": "...",
+  "post_event_debate": "...",
+  "changed_mechanism_or_decision_variable": "...",
+  "event_key": "...",
+  "source_links": ["..."]
+}
+```
+
+Entries are newest first and the record retains at most the latest 10. The
+`narrative` value should be byte-identical to the corresponding appended bullet
+in `focusing_now`. If it is not, retain the entry but add a schema warning.
+
+The scan audit feed is producer health telemetry. Do not load it for an
+ordinary company answer.
+
+## Read Algorithm
+
+1. Resolve canonical ticker, feed slug, environment owner, and `query_as_of`.
+2. Choose current, bounded-history, or exact-version query from the intent.
+3. Read the absolute ALFS path.
+4. Normalize grouped ALFS output if returned as `{date, items: [...]}`.
+5. Select the record and validate `symbol`, `date`, and `as_of`.
+6. Parse every JSON-encoded field and retain parse warnings.
+7. Validate `brief` against the structured section mirrors when both exist.
+8. For change questions, compare selected records and separately interpret
+   `change_summary` and `narrative_change_log`.
+9. Return normalized context plus gaps, freshness, selection reason, and source
+   path to the answer synthesizer.
+
+Suggested normalized internal result:
+
+```json
+{
+  "status": "available",
+  "ticker": "AAPL",
+  "selected_version_ms": 0,
+  "query_as_of": "ISO-8601",
+  "selection_reason": "latest | historical_cutoff | exact_version",
+  "source_path": "/alva/home/.../card/@last/1",
+  "record": {},
+  "parsed": {
+    "news_feed_keywords": [],
+    "change_summary": {},
+    "gaps": [],
+    "narrative_change_log": []
+  },
+  "warnings": []
+}
+```
+
+Allowed `status` values are `available`, `not_covered`, `empty`,
+`not_entitled`, `invalid_schema`, and `failed`.
+
+## Point-In-Time Rules
+
+- An explicit historical date is a hard upper bound on both `date` and the
+  evidence represented by `as_of`.
+- If the selected record has `as_of > query_as_of`, exclude it and select an
+  earlier valid record.
+- A later record cannot be used merely because it describes an earlier event.
+- A current `@last/1` read is allowed only when the user asks for the present
+  view and no historical page version was supplied.
+- Preserve the card's timestamp in the answer. Never describe a weekly card as
+  real-time.
+
+## Synthesis Contract
+
+Do not return the raw card as the answer. Synthesize only the sections relevant
+to the question, and keep these layers distinct:
+
+1. **Current debate:** the dated one-line read and the most relevant current
+   investor questions.
+2. **What could change it:** the explicit decision variables or evidence from
+   `what_would_move`.
+3. **What changed:** material change-log entries first, then ordinary weekly
+   card changes when relevant.
+4. **Evidence gaps:** unresolved `gaps`, stale timestamps, or missing history.
+
+Label Narrative statements as Alva analysis. When the answer makes a current
+price, earnings, filing, guidance, or event claim, source that claim separately.
+
+## Failure And Fallback
+
+| Condition | Required behavior |
+| --- | --- |
+| `PATH_NOT_FOUND` | Report `not_covered` only after confirming owner, environment, and slug. A wrong owner is configuration failure, not missing company coverage. |
+| Empty result | Report `empty`; do not interpret it as a neutral narrative. |
+| Permission/entitlement error | Report `not_entitled`; continue with other authorized sources. |
+| Symbol mismatch | Reject the record as `invalid_schema`; never answer for the wrong security. |
+| Malformed JSON or conflicting mirrors | Preserve raw evidence, add a warning, and use only fields that remain valid. |
+| Stale card | State the timestamp and use it only as dated baseline context. Add current sources when the question requires current facts. |
+
+Missing Narrative must not block a useful company answer when other evidence is
+available. It does block claims such as "Alva's current narrative is..." because
+that claim requires a valid Narrative record.

--- a/proposals/markets-context-routing/references/earnings.md
+++ b/proposals/markets-context-routing/references/earnings.md
@@ -1,0 +1,405 @@
+# Earnings Context
+
+Use this reference for every single-company earnings question: pre-earnings
+expectations, the earnings release, reported results, the call transcript,
+post-earnings interpretation, or a broad company question for which the latest
+earnings event is material.
+
+Earnings is one logical workflow, not four separate top-level Skills. The
+workflow resolves one fiscal event, determines which evidence stages were
+available at the user's information cutoff, reads every eligible stage, and
+then emphasizes the stage relevant to the question.
+
+The four stages are:
+
+```text
+Pre-Earnings -> Official Release -> Earnings Transcript -> Post-Earnings
+```
+
+This is a read-only consumer contract. It does not regenerate analysis, scrape
+the Markets page, or write a feed. Markets, IM integrations, alva.ai chat, and
+direct Skill callers should all invoke this same contract so they receive the
+same event context.
+
+## Routing Invariant
+
+User wording changes emphasis, not the underlying event pipeline.
+
+| User intent | Resolve | Eligible stages to inspect |
+| --- | --- | --- |
+| "What should I watch into earnings?" | Next confirmed event | Pre only, bounded immediately before release. |
+| "What did the company report?" | Latest completed or explicit event | Pre + Release; add Transcript/Post when already available. |
+| "What did management say on the call?" | Latest completed or explicit event | Pre + Release + Transcript; add Post when available. |
+| "How did the quarter change the thesis?" | Latest completed or explicit event | All available stages. |
+| "How does Alva view AMD?" | Shared company router chooses the relevant earnings event | All eligible stages, but earnings remains one layer of the broader company answer. |
+
+Never call only Post-Earnings for a post-event question when the official
+release is available. Never treat Pre-Earnings as current after the release;
+preserve it as the frozen expectation baseline.
+
+## Required Inputs
+
+```text
+ticker
+event_selector?       # fiscal year/quarter, fiscal period end, release date,
+                      # page-selected event, next confirmed, latest completed
+query_as_of?          # explicit historical cutoff or current time
+environment
+owner                 # Markets earnings-feed owner for that environment
+user_intent
+```
+
+Confirmed owners for the current Markets feeds:
+
+| Environment | Owner |
+| --- | --- |
+| Production | `eddiid` |
+| Staging | `zal` |
+
+Owner must come from environment configuration. A cross-environment hardcode
+can look like missing coverage and must be reported as configuration failure.
+
+## Step 1: Establish The Information Cutoff
+
+Compute `query_as_of` before reading evidence:
+
+1. Explicit date/time from the user or calling page wins.
+2. "Pre-earnings", "going into earnings", or equivalent means the instant
+   immediately before the confirmed release publication. Later stages are
+   ineligible even if they exist today.
+3. "Before the call" means the instant immediately before `call_start_at`.
+4. Otherwise use current time.
+
+Date-only cutoffs are not enough to adjudicate same-day releases or calls. If
+the exact time cannot be resolved, use verified release timing
+(`before_open`, `after_close`, `time_unconfirmed`), retain the uncertainty, and
+do not include evidence that may have arrived later that day.
+
+## Step 2: Resolve Exactly One Fiscal Event
+
+Resolve event identity in this order:
+
+1. Page-selected event or explicit `fiscal_period_end`.
+2. Explicit fiscal year and quarter.
+3. Explicit release date mapped to the company's fiscal period.
+4. Pre-earnings intent -> next confirmed event.
+5. Release, transcript, or post-earnings intent -> latest completed event.
+6. Broad company intent -> the platform's shared event selector, with its
+   `selection_reason` preserved.
+
+If the shared selector cannot distinguish a recently completed event from the
+next scheduled event, return `ambiguous_event` rather than merging two events.
+The caller may present both choices, but each must be read independently.
+
+Stable event identity is:
+
+```text
+canonical ticker + fiscal year + fiscal quarter + fiscal period end
+```
+
+Release dates may move and are lookup attributes, not the sole event key.
+Always resolve fiscal period before reading Pre/Post feeds, release documents,
+transcripts, actuals, or estimates. Read the existing
+[fiscal-period reference](../../../skills/alva/references/fundamentals-periods.md)
+for fiscal/calendar rules.
+
+Use live Data Skills discovery for event resolution:
+
+```text
+alva data-skills list
+alva data-skills summary arrays-data-api-equity-fundamentals
+alva data-skills endpoint arrays-data-api-equity-fundamentals <company-detail-file>
+alva data-skills endpoint arrays-data-api-equity-fundamentals <fiscal-dates-file>
+alva data-skills summary arrays-data-api-equity-events
+alva data-skills endpoint arrays-data-api-equity-events <earnings-calendar-file>
+```
+
+File names and endpoint schemas must be taken from the current catalog, not
+from this reference or memory. Follow the existing
+[Data Skills reference](../../../skills/alva/references/data-skills.md).
+
+## Step 3: Determine Stage Eligibility
+
+A stage can be read only when its evidence existed by `query_as_of`.
+
+| Lifecycle state at cutoff | Pre | Release | Transcript | Post |
+| --- | --- | --- | --- | --- |
+| Scheduled; release not published | Read | Not yet available | Not yet available | Not yet available |
+| Official release published; call incomplete | Read frozen baseline | Read | Not yet available | Read `initial_print` if available |
+| Prepared remarks/Q&A available | Read frozen baseline | Read | Read | Read `post_call` if available |
+| A feed or provider is missing | Read other eligible stages | Read other eligible stages | Read other eligible stages | Read other eligible stages |
+
+Use these internal stage statuses:
+
+- `available`
+- `not_yet_available`
+- `missing`
+- `not_entitled`
+- `invalid`
+- `failed`
+
+Missing one stage never erases the other stages. It becomes a typed gap in the
+normalized result and, when material, in the answer.
+
+## Step 4: Read Pre-Earnings Analysis
+
+The Markets Pre-Earnings record is keyed by fiscal period end, not release date.
+
+```text
+/alva/home/{owner}/feeds/pre-earnings-{feed_slug}/v1/data/earnings/pre/
+  @range/{fiscalEndMs-1}..{fiscalEndMs}
+```
+
+Rules:
+
+- `feed_slug` must come from the same canonical Markets slug resolver used by
+  the producer. For simple US symbols it is lowercase. Do not guess the path
+  for a special share class if the resolver is unavailable.
+- `fiscalEndMs` is UTC midnight at `fiscal_period_end` / `fiscalDateEnding`.
+- The range lower bound is exclusive, hence `fiscalEndMs-1`.
+- Never use earnings date, call date, filing date, current time, or a calendar
+  quarter-end as the path timestamp.
+- `@last/1` is allowed only for an unambiguous latest-event convenience read,
+  and the returned event identity must still match the resolved event. Exact
+  event reads use the range above.
+- Use absolute paths. `~/feeds/...` reads the caller's home and is wrong.
+
+Validate:
+
+- canonical ticker;
+- fiscal year, fiscal quarter, and period end;
+- `analysis_as_of` / `as_of` is before the actual release publication;
+- every estimate, guidance item, price, options observation, quote, and
+  revision used by the analysis was available by the pre-event cutoff.
+
+A pre analysis created after the event can be used only if it records a
+separate historical evidence cutoff and every visible input respects that
+cutoff. Otherwise mark it `invalid` for point-in-time use.
+
+Pre is the expectation baseline: central debate, consensus bar, company guide,
+key KPIs, scenario framework, historical reactions, options-implied move, and
+evidence gaps when present. It is not the source of reported actuals.
+
+## Step 5: Read The Official Earnings Release
+
+Discover the current Equity Events release locator each session, conventionally
+under `arrays-data-api-equity-events` and the catalog endpoint corresponding to
+`/api/v1/stocks/sec-earnings-release`.
+
+The locator is not itself always the full earnings release. The consumer must:
+
+1. Resolve the exact fiscal event.
+2. Read the returned official document metadata and publication timestamp.
+3. If the filing is an 8-K or 6-K, follow the earnings-results exhibit,
+   commonly Exhibit 99.1, rather than treating the filing cover page as the
+   results.
+4. If the SEC locator lags, use the company's official investor-relations
+   release or official newswire copy and label the fallback.
+5. Exclude the release when `published_at > query_as_of`.
+
+The official release or filed earnings exhibit is source of truth for:
+
+- reported actuals;
+- company guidance;
+- reported KPIs;
+- accounting basis and units;
+- release quotations.
+
+Structured income statement, balance sheet, cash-flow, and company-KPI Data
+Skills may supplement or reconcile the release after ingestion. They do not
+override event-time official figures without an explicit reconciliation note.
+
+## Step 6: Read The Earnings Transcript
+
+Discover the current transcript endpoint under
+`arrays-data-api-equity-events`, conventionally corresponding to
+`/api/v1/stocks/earnings-transcript`.
+
+Transcript rules:
+
+- Match canonical ticker, fiscal year, fiscal quarter, and period end.
+- Require the transcript publication/availability time to be on or before
+  `query_as_of`.
+- Preserve speaker name, speaker title, and section
+  (`prepared_remarks` or `qa`) for every passage used.
+- A Pro/entitlement failure is `not_entitled`, not `missing`.
+- An empty or absent transcript means Post remains `initial_print`; never imply
+  that the call was reviewed.
+- For a strict historical read, a transcript without a defensible availability
+  timestamp is ineligible. For a current read it may be used with an explicit
+  timestamp warning.
+
+Do not inject an entire transcript into model context merely to find relevant
+passages. The runtime should select outside model context when the provider
+returns a full document:
+
+1. Build search terms from the user question, Pre central debate/KPIs, Release
+   variances/guidance, and Post claims that require verification.
+2. Retrieve or filter to relevant prepared remarks and Q&A turns.
+3. Default context budget: at most 12 speaker turns and 12,000 characters total.
+   This is a configurable safety default, not a provider limitation.
+4. Preserve continuous passages; do not splice words from separate turns into
+   one quote.
+5. If the cap omits material sections, summarize the selection boundary and
+   fetch a second targeted window instead of silently truncating evidence.
+
+## Step 7: Read Post-Earnings Analysis
+
+The Markets Post-Earnings record uses the same fiscal-period key:
+
+```text
+/alva/home/{owner}/feeds/post-earnings-{feed_slug}/v1/data/earnings/post/
+  @range/{fiscalEndMs-1}..{fiscalEndMs}
+```
+
+Apply the same absolute-path, slug, timestamp, range, and event-identity rules
+as Pre.
+
+Post has two valid evidence states:
+
+| State | Minimum evidence | Allowed claim |
+| --- | --- | --- |
+| `initial_print` | Official release is available; call is incomplete | Interpret the print, variances, guidance, and known KPIs. Do not claim call/Q&A insight. |
+| `post_call` | Relevant prepared remarks and/or Q&A are available | Interpret the print plus management explanation and call evidence. |
+
+Validate Post `as_of`, `evidence_state`, source URLs, quoted passages, fiscal
+event identity, and evidence gaps. A stored `post_call` analysis may remain
+readable when the current caller lacks transcript entitlement, but the answer
+must distinguish "Alva's stored post-call analysis" from transcript passages
+independently re-read in the current request.
+
+## Normalized Result
+
+Every caller should receive the same internal shape regardless of channel:
+
+```json
+{
+  "status": "available | partial | ambiguous_event | failed",
+  "ticker": "AAPL",
+  "event": {
+    "fiscal_year": 2026,
+    "fiscal_quarter": "Q3",
+    "fiscal_period_end": "2026-06-27",
+    "release_date": "2026-07-30",
+    "release_timing": "after_close",
+    "release_published_at": null,
+    "call_start_at": null
+  },
+  "query_as_of": "ISO-8601",
+  "selection_reason": "explicit_period | page_selected | next_confirmed | latest_completed | shared_selector",
+  "stages": {
+    "pre": {"status": "available", "as_of": null, "source": {}, "data": {}},
+    "release": {"status": "available", "published_at": null, "source": {}, "data": {}},
+    "transcript": {"status": "not_yet_available", "published_at": null, "source": {}, "data": {}},
+    "post": {"status": "available", "as_of": null, "evidence_state": "initial_print", "source": {}, "data": {}}
+  },
+  "gaps": [],
+  "warnings": []
+}
+```
+
+Use top-level `partial` when at least one eligible stage is usable and at least
+one eligible stage is missing, invalid, not entitled, or failed. A future stage
+marked `not_yet_available` does not by itself make a pre-event result partial.
+
+For each stage source retain, when available:
+
+```text
+source_type, source_name, source_url, source_id,
+published_at/as_of, retrieved_at, status, confidence
+```
+
+For each financial fact retain:
+
+```text
+value, unit, currency, fiscal period, accounting/per-share basis,
+as_of, source reference
+```
+
+Derived facts must also retain method and input references.
+
+## Source Priority And Conflict Rules
+
+Use this order:
+
+1. Reported figures and formal guidance: official release or filed exhibit.
+2. Management explanation and quotes: official release, prepared remarks, then
+   Q&A transcript with speaker metadata.
+3. Consensus: one compatible provider, fiscal period, currency, unit,
+   accounting basis, and per-share basis frozen before release.
+4. Structured statements/KPIs: reconciliation and history after ingestion.
+5. Pre/Post feed records: Alva's dated analytical interpretation.
+6. Company Narrative/WILF: investor-focus baseline only.
+
+Never calculate a beat/miss or revision across incompatible periods,
+currencies, units, accounting bases, or per-share definitions. If sources
+conflict, show the official value, identify the conflicting source and basis,
+and do not average them.
+
+## Point-In-Time Rules
+
+These rules are hard gates:
+
+- No source, record, quote, estimate, price, guidance item, transcript passage,
+  or analysis with an availability time after `query_as_of` may enter the
+  answer.
+- Pre-print consensus is the latest compatible observation strictly before the
+  official release publication.
+- A current feed record cannot be used in a historical answer simply because
+  it discusses the correct fiscal quarter.
+- If only a date is known for same-day evidence, prefer exclusion over leakage
+  and state the gap.
+- Preserve both analysis generation time and evidence cutoff when they differ.
+- WILF/Narrative is never the authority for event timing or actuals.
+
+## Synthesis Contract
+
+Answer the user's question rather than returning four disconnected source
+summaries. When all stages are relevant, synthesize in this order:
+
+1. **Expectation before the print:** the central debate and measurable bar from
+   Pre.
+2. **What officially happened:** actuals, guide, and KPI variances from the
+   Release.
+3. **Why management says it happened:** relevant prepared remarks and Q&A from
+   the Transcript.
+4. **What changed for investors:** dated Alva interpretation from Post, with
+   remaining uncertainties.
+
+Always include event identity and the evidence cutoff. Surface missing stages
+when they would change the conclusion. Separate sourced facts, calculations,
+management claims, and Alva analysis.
+
+Market reaction is a separate evidence layer. Fetch price and benchmark data
+only when the user asks about the reaction or it is necessary to answer the
+question. Align the reaction window to `release_timing`; do not read a raw price
+move from the earnings analysis as if it were a live quote.
+
+## Failure And Fallback
+
+| Condition | Required behavior |
+| --- | --- |
+| Wrong owner or environment | Return configuration error. Do not relabel it as missing coverage. |
+| Pre/Post `PATH_NOT_FOUND` | Recheck owner, slug, fiscal period end, and millisecond calculation; then mark only that stage `missing`. |
+| Event identity mismatch | Reject that stage as `invalid`; never merge it into the selected event. |
+| Release locator lags | Use official IR/newswire or filed exhibit, label fallback, and keep the structured lag warning. |
+| Transcript entitlement error | Mark Transcript `not_entitled`; continue with Release and eligible Pre/Post. |
+| Transcript unavailable | Mark `not_yet_available` before the call or `missing` after expected availability; keep Post at `initial_print` unless stored evidence proves `post_call`. |
+| Post missing | Synthesize Pre + Release + Transcript and say Alva Post analysis is unavailable. Do not generate one silently. |
+| Pre contaminated by later data | Mark Pre `invalid` and reconstruct only the sourced expectation baseline if the question requires it. Do not call the reconstruction the stored Pre analysis. |
+| One stage fails | Continue all independent eligible reads and return `partial`. |
+
+## Implementation Boundary
+
+The Skill needs read access to ALFS, Data Skills discovery/calls, and official
+document retrieval. The calling product may wrap these in platform tools, but
+must preserve this event selector, normalized result, stage statuses,
+point-in-time gates, and source priority.
+
+If a required platform capability is unavailable, return a typed stage gap. Do
+not scrape the Markets UI, substitute model memory, generate a feed, or claim
+that a stage was read when it was not.
+
+This reference defines consumption and synthesis. Producer schemas, feed
+generation, UI rendering, schedule logic, and analysis prompt design remain
+separate contracts.

--- a/proposals/markets-context-routing/references/earnings.md
+++ b/proposals/markets-context-routing/references/earnings.md
@@ -1,405 +1,199 @@
 # Earnings Context
 
-Use this reference for every single-company earnings question: pre-earnings
-expectations, the earnings release, reported results, the call transcript,
-post-earnings interpretation, or a broad company question for which the latest
-earnings event is material.
+Status: proposed consumer contract. Producer integrity, server-side
+point-in-time enforcement, and bounded transcript retrieval must ship before
+the live Skill adopts it.
 
-Earnings is one logical workflow, not four separate top-level Skills. The
-workflow resolves one fiscal event, determines which evidence stages were
-available at the user's information cutoff, reads every eligible stage, and
-then emphasizes the stage relevant to the question.
+## Contents
 
-The four stages are:
+- [Purpose and invariant](#purpose-and-invariant)
+- [Request and event selection](#request-and-event-selection)
+- [Stage eligibility](#stage-eligibility)
+- [Normalized response](#normalized-response)
+- [Stage contracts](#stage-contracts)
+- [Point-in-time enforcement](#point-in-time-enforcement)
+- [Synthesis and degradation](#synthesis-and-degradation)
+
+## Purpose And Invariant
+
+Earnings is one lifecycle, not four Skills:
 
 ```text
 Pre-Earnings -> Official Release -> Earnings Transcript -> Post-Earnings
 ```
 
-This is a read-only consumer contract. It does not regenerate analysis, scrape
-the Markets page, or write a feed. Markets, IM integrations, alva.ai chat, and
-direct Skill callers should all invoke this same contract so they receive the
-same event context.
+The backend resolves one fiscal event, applies an information cutoff, and
+returns every eligible stage that is valid and available. User intent changes
+emphasis, not event identity. Pre remains the frozen expectation baseline after
+the release; it never becomes a source of reported actuals.
 
-## Routing Invariant
+The Skill does not locate records, map symbols, select fiscal events, determine
+publication time, filter full transcripts, or enforce point-in-time rules.
 
-User wording changes emphasis, not the underlying event pipeline.
-
-| User intent | Resolve | Eligible stages to inspect |
-| --- | --- | --- |
-| "What should I watch into earnings?" | Next confirmed event | Pre only, bounded immediately before release. |
-| "What did the company report?" | Latest completed or explicit event | Pre + Release; add Transcript/Post when already available. |
-| "What did management say on the call?" | Latest completed or explicit event | Pre + Release + Transcript; add Post when available. |
-| "How did the quarter change the thesis?" | Latest completed or explicit event | All available stages. |
-| "How does Alva view AMD?" | Shared company router chooses the relevant earnings event | All eligible stages, but earnings remains one layer of the broader company answer. |
-
-Never call only Post-Earnings for a post-event question when the official
-release is available. Never treat Pre-Earnings as current after the release;
-preserve it as the frozen expectation baseline.
-
-## Required Inputs
-
-```text
-ticker
-event_selector?       # fiscal year/quarter, fiscal period end, release date,
-                      # page-selected event, next confirmed, latest completed
-query_as_of?          # explicit historical cutoff or current time
-environment
-owner                 # Markets earnings-feed owner for that environment
-user_intent
-```
-
-Confirmed owners for the current Markets feeds:
-
-| Environment | Owner |
-| --- | --- |
-| Production | `eddiid` |
-| Staging | `zal` |
-
-Owner must come from environment configuration. A cross-environment hardcode
-can look like missing coverage and must be reported as configuration failure.
-
-## Step 1: Establish The Information Cutoff
-
-Compute `query_as_of` before reading evidence:
-
-1. Explicit date/time from the user or calling page wins.
-2. "Pre-earnings", "going into earnings", or equivalent means the instant
-   immediately before the confirmed release publication. Later stages are
-   ineligible even if they exist today.
-3. "Before the call" means the instant immediately before `call_start_at`.
-4. Otherwise use current time.
-
-Date-only cutoffs are not enough to adjudicate same-day releases or calls. If
-the exact time cannot be resolved, use verified release timing
-(`before_open`, `after_close`, `time_unconfirmed`), retain the uncertainty, and
-do not include evidence that may have arrived later that day.
-
-## Step 2: Resolve Exactly One Fiscal Event
-
-Resolve event identity in this order:
-
-1. Page-selected event or explicit `fiscal_period_end`.
-2. Explicit fiscal year and quarter.
-3. Explicit release date mapped to the company's fiscal period.
-4. Pre-earnings intent -> next confirmed event.
-5. Release, transcript, or post-earnings intent -> latest completed event.
-6. Broad company intent -> the platform's shared event selector, with its
-   `selection_reason` preserved.
-
-If the shared selector cannot distinguish a recently completed event from the
-next scheduled event, return `ambiguous_event` rather than merging two events.
-The caller may present both choices, but each must be read independently.
-
-Stable event identity is:
-
-```text
-canonical ticker + fiscal year + fiscal quarter + fiscal period end
-```
-
-Release dates may move and are lookup attributes, not the sole event key.
-Always resolve fiscal period before reading Pre/Post feeds, release documents,
-transcripts, actuals, or estimates. Read the existing
-[fiscal-period reference](../../../skills/alva/references/fundamentals-periods.md)
-for fiscal/calendar rules.
-
-Use live Data Skills discovery for event resolution:
-
-```text
-alva data-skills list
-alva data-skills summary arrays-data-api-equity-fundamentals
-alva data-skills endpoint arrays-data-api-equity-fundamentals <company-detail-file>
-alva data-skills endpoint arrays-data-api-equity-fundamentals <fiscal-dates-file>
-alva data-skills summary arrays-data-api-equity-events
-alva data-skills endpoint arrays-data-api-equity-events <earnings-calendar-file>
-```
-
-File names and endpoint schemas must be taken from the current catalog, not
-from this reference or memory. Follow the existing
-[Data Skills reference](../../../skills/alva/references/data-skills.md).
-
-## Step 3: Determine Stage Eligibility
-
-A stage can be read only when its evidence existed by `query_as_of`.
-
-| Lifecycle state at cutoff | Pre | Release | Transcript | Post |
-| --- | --- | --- | --- | --- |
-| Scheduled; release not published | Read | Not yet available | Not yet available | Not yet available |
-| Official release published; call incomplete | Read frozen baseline | Read | Not yet available | Read `initial_print` if available |
-| Prepared remarks/Q&A available | Read frozen baseline | Read | Read | Read `post_call` if available |
-| A feed or provider is missing | Read other eligible stages | Read other eligible stages | Read other eligible stages | Read other eligible stages |
-
-Use these internal stage statuses:
-
-- `available`
-- `not_yet_available`
-- `missing`
-- `not_entitled`
-- `invalid`
-- `failed`
-
-Missing one stage never erases the other stages. It becomes a typed gap in the
-normalized result and, when material, in the answer.
-
-## Step 4: Read Pre-Earnings Analysis
-
-The Markets Pre-Earnings record is keyed by fiscal period end, not release date.
-
-```text
-/alva/home/{owner}/feeds/pre-earnings-{feed_slug}/v1/data/earnings/pre/
-  @range/{fiscalEndMs-1}..{fiscalEndMs}
-```
-
-Rules:
-
-- `feed_slug` must come from the same canonical Markets slug resolver used by
-  the producer. For simple US symbols it is lowercase. Do not guess the path
-  for a special share class if the resolver is unavailable.
-- `fiscalEndMs` is UTC midnight at `fiscal_period_end` / `fiscalDateEnding`.
-- The range lower bound is exclusive, hence `fiscalEndMs-1`.
-- Never use earnings date, call date, filing date, current time, or a calendar
-  quarter-end as the path timestamp.
-- `@last/1` is allowed only for an unambiguous latest-event convenience read,
-  and the returned event identity must still match the resolved event. Exact
-  event reads use the range above.
-- Use absolute paths. `~/feeds/...` reads the caller's home and is wrong.
-
-Validate:
-
-- canonical ticker;
-- fiscal year, fiscal quarter, and period end;
-- `analysis_as_of` / `as_of` is before the actual release publication;
-- every estimate, guidance item, price, options observation, quote, and
-  revision used by the analysis was available by the pre-event cutoff.
-
-A pre analysis created after the event can be used only if it records a
-separate historical evidence cutoff and every visible input respects that
-cutoff. Otherwise mark it `invalid` for point-in-time use.
-
-Pre is the expectation baseline: central debate, consensus bar, company guide,
-key KPIs, scenario framework, historical reactions, options-implied move, and
-evidence gaps when present. It is not the source of reported actuals.
-
-## Step 5: Read The Official Earnings Release
-
-Discover the current Equity Events release locator each session, conventionally
-under `arrays-data-api-equity-events` and the catalog endpoint corresponding to
-`/api/v1/stocks/sec-earnings-release`.
-
-The locator is not itself always the full earnings release. The consumer must:
-
-1. Resolve the exact fiscal event.
-2. Read the returned official document metadata and publication timestamp.
-3. If the filing is an 8-K or 6-K, follow the earnings-results exhibit,
-   commonly Exhibit 99.1, rather than treating the filing cover page as the
-   results.
-4. If the SEC locator lags, use the company's official investor-relations
-   release or official newswire copy and label the fallback.
-5. Exclude the release when `published_at > query_as_of`.
-
-The official release or filed earnings exhibit is source of truth for:
-
-- reported actuals;
-- company guidance;
-- reported KPIs;
-- accounting basis and units;
-- release quotations.
-
-Structured income statement, balance sheet, cash-flow, and company-KPI Data
-Skills may supplement or reconcile the release after ingestion. They do not
-override event-time official figures without an explicit reconciliation note.
-
-## Step 6: Read The Earnings Transcript
-
-Discover the current transcript endpoint under
-`arrays-data-api-equity-events`, conventionally corresponding to
-`/api/v1/stocks/earnings-transcript`.
-
-Transcript rules:
-
-- Match canonical ticker, fiscal year, fiscal quarter, and period end.
-- Require the transcript publication/availability time to be on or before
-  `query_as_of`.
-- Preserve speaker name, speaker title, and section
-  (`prepared_remarks` or `qa`) for every passage used.
-- A Pro/entitlement failure is `not_entitled`, not `missing`.
-- An empty or absent transcript means Post remains `initial_print`; never imply
-  that the call was reviewed.
-- For a strict historical read, a transcript without a defensible availability
-  timestamp is ineligible. For a current read it may be used with an explicit
-  timestamp warning.
-
-Do not inject an entire transcript into model context merely to find relevant
-passages. The runtime should select outside model context when the provider
-returns a full document:
-
-1. Build search terms from the user question, Pre central debate/KPIs, Release
-   variances/guidance, and Post claims that require verification.
-2. Retrieve or filter to relevant prepared remarks and Q&A turns.
-3. Default context budget: at most 12 speaker turns and 12,000 characters total.
-   This is a configurable safety default, not a provider limitation.
-4. Preserve continuous passages; do not splice words from separate turns into
-   one quote.
-5. If the cap omits material sections, summarize the selection boundary and
-   fetch a second targeted window instead of silently truncating evidence.
-
-## Step 7: Read Post-Earnings Analysis
-
-The Markets Post-Earnings record uses the same fiscal-period key:
-
-```text
-/alva/home/{owner}/feeds/post-earnings-{feed_slug}/v1/data/earnings/post/
-  @range/{fiscalEndMs-1}..{fiscalEndMs}
-```
-
-Apply the same absolute-path, slug, timestamp, range, and event-identity rules
-as Pre.
-
-Post has two valid evidence states:
-
-| State | Minimum evidence | Allowed claim |
-| --- | --- | --- |
-| `initial_print` | Official release is available; call is incomplete | Interpret the print, variances, guidance, and known KPIs. Do not claim call/Q&A insight. |
-| `post_call` | Relevant prepared remarks and/or Q&A are available | Interpret the print plus management explanation and call evidence. |
-
-Validate Post `as_of`, `evidence_state`, source URLs, quoted passages, fiscal
-event identity, and evidence gaps. A stored `post_call` analysis may remain
-readable when the current caller lacks transcript entitlement, but the answer
-must distinguish "Alva's stored post-call analysis" from transcript passages
-independently re-read in the current request.
-
-## Normalized Result
-
-Every caller should receive the same internal shape regardless of channel:
+## Request And Event Selection
 
 ```json
 {
-  "status": "available | partial | ambiguous_event | failed",
-  "ticker": "AAPL",
+  "symbol": "AMD",
+  "query_as_of": "optional ISO-8601 timestamp",
   "event": {
+    "fiscal_year": "optional",
+    "fiscal_quarter": "optional",
+    "fiscal_period_end": "optional",
+    "selection": "NEXT_CONFIRMED | LATEST_COMPLETED | PAGE_SELECTED"
+  },
+  "intent": "SETUP | RESULTS | CALL | THESIS_IMPACT | BROAD",
+  "detail": "summary | evidence"
+}
+```
+
+Backend selection order:
+
+1. Page-selected event or exact fiscal-period identity.
+2. Explicit fiscal year and quarter.
+3. Explicit release mapped to its fiscal period.
+4. Setup intent selects next confirmed event.
+5. Results, call, and thesis-impact intents select latest completed event.
+6. Broad intent uses the canonical company-event selector.
+
+Stable identity includes canonical symbol, fiscal year, fiscal quarter, and
+fiscal period end. Release date alone is not an event key. If selection is
+ambiguous, return a typed gap instead of merging adjacent events.
+
+## Stage Eligibility
+
+Eligibility is determined by what existed at `query_as_of`:
+
+| State at cutoff | Pre | Release | Transcript | Post |
+| --- | --- | --- | --- | --- |
+| Before official release | Eligible | Not yet | Not yet | Not yet |
+| Release published, call unavailable | Frozen baseline | Eligible | Not yet | Initial print if valid |
+| Transcript available | Frozen baseline | Eligible | Eligible | Post-call if valid |
+| One source fails | Preserve other eligible stages | Preserve | Preserve | Preserve |
+
+Every stage returns:
+
+- `content_status`: `AVAILABLE`, `NOT_AVAILABLE_YET`, or `UNAVAILABLE`;
+- `unavailable_reason` when relevant: `SOURCE_MISSING`, `NOT_ENTITLED`,
+  `INVALID_SOURCE`, `UPSTREAM_FAILURE`, or `OUTSIDE_AS_OF`;
+- event identity, source publication/availability time, evidence cutoff, and
+  warnings.
+
+## Normalized Response
+
+```json
+{
+  "event": {
+    "symbol": "AMD",
     "fiscal_year": 2026,
-    "fiscal_quarter": "Q3",
-    "fiscal_period_end": "2026-06-27",
-    "release_date": "2026-07-30",
-    "release_timing": "after_close",
-    "release_published_at": null,
-    "call_start_at": null
+    "fiscal_quarter": 2,
+    "fiscal_period_end": "YYYY-MM-DD",
+    "release_published_at": "ISO-8601",
+    "selection_reason": "LATEST_COMPLETED"
   },
   "query_as_of": "ISO-8601",
-  "selection_reason": "explicit_period | page_selected | next_confirmed | latest_completed | shared_selector",
   "stages": {
-    "pre": {"status": "available", "as_of": null, "source": {}, "data": {}},
-    "release": {"status": "available", "published_at": null, "source": {}, "data": {}},
-    "transcript": {"status": "not_yet_available", "published_at": null, "source": {}, "data": {}},
-    "post": {"status": "available", "as_of": null, "evidence_state": "initial_print", "source": {}, "data": {}}
+    "pre": { "content_status": "AVAILABLE", "summary": {} },
+    "release": { "content_status": "AVAILABLE", "summary": {} },
+    "transcript": { "content_status": "NOT_AVAILABLE_YET" },
+    "post": { "content_status": "AVAILABLE", "analysis_state": "INITIAL_PRINT", "summary": {} }
   },
   "gaps": [],
   "warnings": []
 }
 ```
 
-Use top-level `partial` when at least one eligible stage is usable and at least
-one eligible stage is missing, invalid, not entitled, or failed. A future stage
-marked `not_yet_available` does not by itself make a pre-event result partial.
+`summary` is bounded for default broad answers. `evidence` may include detailed
+KPI comparisons, source-backed variances, and selected transcript passages;
+it must not return an unbounded document.
 
-For each stage source retain, when available:
+## Stage Contracts
 
-```text
-source_type, source_name, source_url, source_id,
-published_at/as_of, retrieved_at, status, confidence
-```
+### Pre-Earnings
 
-For each financial fact retain:
+The producer must attach:
 
-```text
-value, unit, currency, fiscal period, accounting/per-share basis,
-as_of, source reference
-```
+- exact fiscal-event identity;
+- `generated_at` and `evidence_cutoff_at`;
+- the consensus snapshot and observation times used;
+- the company guidance, KPI expectations, scenario framework, and material
+  evidence gaps.
 
-Derived facts must also retain method and input references.
+Every estimate, price, option observation, quote, revision, and event included
+must have been available by `evidence_cutoff_at`. A record generated after the
+release is valid only if all visible evidence is independently bounded to the
+pre-release cutoff. Otherwise the backend returns `INVALID_SOURCE` and the
+record must be repaired or backfilled.
 
-## Source Priority And Conflict Rules
+### Official Release
 
-Use this order:
+Use the official release or filed results exhibit as authority for actuals,
+guidance, KPIs, accounting basis, units, and release quotations. Structured
+data can reconcile or supplement it but cannot silently override event-time
+official figures.
 
-1. Reported figures and formal guidance: official release or filed exhibit.
-2. Management explanation and quotes: official release, prepared remarks, then
-   Q&A transcript with speaker metadata.
-3. Consensus: one compatible provider, fiscal period, currency, unit,
-   accounting basis, and per-share basis frozen before release.
-4. Structured statements/KPIs: reconciliation and history after ingestion.
-5. Pre/Post feed records: Alva's dated analytical interpretation.
-6. Company Narrative/WILF: investor-focus baseline only.
+The backend records `release_published_at` and excludes the stage when it is
+later than `query_as_of`. A locator or filing cover page is not equivalent to
+the underlying results document.
 
-Never calculate a beat/miss or revision across incompatible periods,
-currencies, units, accounting bases, or per-share definitions. If sources
-conflict, show the official value, identify the conflicting source and basis,
-and do not average them.
+### Earnings Transcript
 
-## Point-In-Time Rules
+The backend matches the exact fiscal event and requires a defensible
+availability time. It returns only relevant continuous passages with speaker,
+title, and section metadata.
 
-These rules are hard gates:
+Selection terms may come from the user question, Pre decision variables,
+Release variances, guidance, and Post claims requiring verification. The API
+must enforce a configurable passage/character budget and support a second
+targeted window when the first omits a material topic. The Skill never loads a
+full transcript merely to search it.
 
-- No source, record, quote, estimate, price, guidance item, transcript passage,
-  or analysis with an availability time after `query_as_of` may enter the
-  answer.
-- Pre-print consensus is the latest compatible observation strictly before the
-  official release publication.
-- A current feed record cannot be used in a historical answer simply because
-  it discusses the correct fiscal quarter.
-- If only a date is known for same-day evidence, prefer exclusion over leakage
-  and state the gap.
-- Preserve both analysis generation time and evidence cutoff when they differ.
-- WILF/Narrative is never the authority for event timing or actuals.
+### Post-Earnings
 
-## Synthesis Contract
+Post has two explicit states:
 
-Answer the user's question rather than returning four disconnected source
-summaries. When all stages are relevant, synthesize in this order:
+| State | Minimum evidence | Allowed interpretation |
+| --- | --- | --- |
+| `INITIAL_PRINT` | Official release | Results, guidance, immediate debate change; no call claims. |
+| `POST_CALL` | Release plus transcript | Management framing, prepared remarks, Q&A, and call-informed thesis change. |
 
-1. **Expectation before the print:** the central debate and measurable bar from
-   Pre.
-2. **What officially happened:** actuals, guide, and KPI variances from the
-   Release.
-3. **Why management says it happened:** relevant prepared remarks and Q&A from
-   the Transcript.
-4. **What changed for investors:** dated Alva interpretation from Post, with
-   remaining uncertainties.
+Post must carry the same fiscal-event identity, `generated_at`,
+`evidence_cutoff_at`, and evidence-state label. A post-call claim without an
+eligible transcript is invalid.
 
-Always include event identity and the evidence cutoff. Surface missing stages
-when they would change the conclusion. Separate sourced facts, calculations,
-management claims, and Alva analysis.
+## Point-In-Time Enforcement
 
-Market reaction is a separate evidence layer. Fetch price and benchmark data
-only when the user asks about the reaction or it is necessary to answer the
-question. Align the reaction window to `release_timing`; do not read a raw price
-move from the earnings analysis as if it were a live quote.
+`query_as_of` is a hard server-side boundary. The backend must ensure:
 
-## Failure And Fallback
+1. Every stage existed by the cutoff.
+2. Every generated analysis has `generated_at` and `evidence_cutoff_at` no
+   later than the cutoff.
+3. Every cited or structured input was observed or published no later than the
+   stage's evidence cutoff.
+4. Later revisions, transcripts, estimates, or analysis are excluded even when
+   they discuss the selected historical event.
+5. Uncertain same-day timing is returned as a warning and cannot be treated as
+   proof that later evidence was available.
 
-| Condition | Required behavior |
-| --- | --- |
-| Wrong owner or environment | Return configuration error. Do not relabel it as missing coverage. |
-| Pre/Post `PATH_NOT_FOUND` | Recheck owner, slug, fiscal period end, and millisecond calculation; then mark only that stage `missing`. |
-| Event identity mismatch | Reject that stage as `invalid`; never merge it into the selected event. |
-| Release locator lags | Use official IR/newswire or filed exhibit, label fallback, and keep the structured lag warning. |
-| Transcript entitlement error | Mark Transcript `not_entitled`; continue with Release and eligible Pre/Post. |
-| Transcript unavailable | Mark `not_yet_available` before the call or `missing` after expected availability; keep Post at `initial_print` unless stored evidence proves `post_call`. |
-| Post missing | Synthesize Pre + Release + Transcript and say Alva Post analysis is unavailable. Do not generate one silently. |
-| Pre contaminated by later data | Mark Pre `invalid` and reconstruct only the sourced expectation baseline if the question requires it. Do not call the reconstruction the stored Pre analysis. |
-| One stage fails | Continue all independent eligible reads and return `partial`. |
+These checks must be executable backend rules and contract tests, not prompt
+instructions.
 
-## Implementation Boundary
+## Synthesis And Degradation
 
-The Skill needs read access to ALFS, Data Skills discovery/calls, and official
-document retrieval. The calling product may wrap these in platform tools, but
-must preserve this event selector, normalized result, stage statuses,
-point-in-time gates, and source priority.
+For broad company questions, return a compact lifecycle delta:
 
-If a required platform capability is unavailable, return a typed stage gap. Do
-not scrape the Markets UI, substitute model memory, generate a feed, or claim
-that a stage was read when it was not.
+1. What the pre-event bar was.
+2. What the company officially reported and guided.
+3. What management emphasized on the call, if eligible.
+4. How the event changed the investor debate, separating initial print from
+   post-call interpretation.
+5. Which stages or evidence remain unavailable.
 
-This reference defines consumption and synthesis. Producer schemas, feed
-generation, UI rendering, schedule logic, and analysis prompt design remain
-separate contracts.
+For narrow questions, emphasize the requested stage but retain enough adjacent
+context to avoid false interpretation. Release actuals and guidance outrank
+generated analysis; transcript evidence outranks a Post characterization of
+what management said.
+
+Missing or unauthorized stages do not suppress valid stages. If no valid stage
+is available, return the typed status and reason without inventing a neutral
+earnings view.

--- a/proposals/markets-context-routing/references/earnings.md
+++ b/proposals/markets-context-routing/references/earnings.md
@@ -1,199 +1,132 @@
 # Earnings Context
 
-Status: proposed consumer contract. Producer integrity, server-side
-point-in-time enforcement, and bounded transcript retrieval must ship before
-the live Skill adopts it.
+Status: proposed Skill consumer contract for the current Markets backend view.
 
 ## Contents
 
-- [Purpose and invariant](#purpose-and-invariant)
-- [Request and event selection](#request-and-event-selection)
-- [Stage eligibility](#stage-eligibility)
-- [Normalized response](#normalized-response)
-- [Stage contracts](#stage-contracts)
-- [Point-in-time enforcement](#point-in-time-enforcement)
+- [Commands](#commands)
+- [Event selection](#event-selection)
+- [Lifecycle response](#lifecycle-response)
+- [Consumption and source priority](#consumption-and-source-priority)
+- [Safety boundaries](#safety-boundaries)
 - [Synthesis and degradation](#synthesis-and-degradation)
 
-## Purpose And Invariant
+## Commands
 
-Earnings is one lifecycle, not four Skills:
+Latest completed event:
+
+```text
+alva markets earnings --ticker <TICKER>
+```
+
+Next confirmed event:
+
+```text
+alva markets earnings --ticker <TICKER> --event next-confirmed
+```
+
+Explicit fiscal period:
+
+```text
+alva markets earnings --ticker <TICKER> \
+  --fiscal-year <YEAR> --fiscal-quarter <Q1..Q4>
+```
+
+`--event` and explicit fiscal-period flags are mutually exclusive. Fiscal year
+and quarter must be supplied together.
+
+## Event Selection
+
+| Intent | Selector |
+| --- | --- |
+| “What should I watch into earnings?” | `--event next-confirmed` |
+| “What did the company report?” | Default latest completed |
+| “What did management say?” | Default latest completed |
+| “How did the quarter change the thesis?” | Default latest completed |
+| Explicit fiscal year/quarter | Paired fiscal flags |
+| Broad company view | Default latest completed |
+
+The backend resolves the fiscal event. The Skill must not infer a different
+period when the command returns event-not-found.
+
+## Lifecycle Response
+
+One response covers a single event:
 
 ```text
 Pre-Earnings -> Official Release -> Earnings Transcript -> Post-Earnings
 ```
 
-The backend resolves one fiscal event, applies an information cutoff, and
-returns every eligible stage that is valid and available. User intent changes
-emphasis, not event identity. Pre remains the frozen expectation baseline after
-the release; it never becomes a source of reported actuals.
+Observed normalized sections include:
 
-The Skill does not locate records, map symbols, select fiscal events, determine
-publication time, filter full transcripts, or enforce point-in-time rules.
+- `period`: fiscal identity, earnings date/session, completion state, and
+  selection status;
+- `preEarningsAnalysis`: dated expectation baseline and scenario framing;
+- `earningsRelease`: availability, release date, and official document;
+- `earningsTranscript`: availability, publication time, sections, speakers,
+  and entries;
+- `postEarningsSummary`: dated Alva interpretation and evidence state such as
+  initial print or post-call.
 
-## Request And Event Selection
+Missing or not-yet-available stages must not erase valid stages.
 
-```json
-{
-  "symbol": "AMD",
-  "query_as_of": "optional ISO-8601 timestamp",
-  "event": {
-    "fiscal_year": "optional",
-    "fiscal_quarter": "optional",
-    "fiscal_period_end": "optional",
-    "selection": "NEXT_CONFIRMED | LATEST_COMPLETED | PAGE_SELECTED"
-  },
-  "intent": "SETUP | RESULTS | CALL | THESIS_IMPACT | BROAD",
-  "detail": "summary | evidence"
-}
-```
+## Consumption And Source Priority
 
-Backend selection order:
+Use this order when claims conflict:
 
-1. Page-selected event or exact fiscal-period identity.
-2. Explicit fiscal year and quarter.
-3. Explicit release mapped to its fiscal period.
-4. Setup intent selects next confirmed event.
-5. Results, call, and thesis-impact intents select latest completed event.
-6. Broad intent uses the canonical company-event selector.
+1. Official release/filed exhibit for actuals, guidance, KPIs, units, and
+   accounting basis.
+2. Transcript passages for management statements, preserving speaker and
+   section.
+3. Pre for the dated expectation baseline only.
+4. Post for Alva's dated interpretation of what changed.
 
-Stable identity includes canonical symbol, fiscal year, fiscal quarter, and
-fiscal period end. Release date alone is not an event key. If selection is
-ambiguous, return a typed gap instead of merging adjacent events.
+Never treat Pre as reported results. Never use Post alone to quote management
+when transcript evidence is available. Do not calculate beat/miss across
+incompatible periods, currencies, units, accounting bases, or EPS definitions.
 
-## Stage Eligibility
+## Safety Boundaries
 
-Eligibility is determined by what existed at `query_as_of`:
+### Current view only
 
-| State at cutoff | Pre | Release | Transcript | Post |
-| --- | --- | --- | --- | --- |
-| Before official release | Eligible | Not yet | Not yet | Not yet |
-| Release published, call unavailable | Frozen baseline | Eligible | Not yet | Initial print if valid |
-| Transcript available | Frozen baseline | Eligible | Eligible | Post-call if valid |
-| One source fails | Preserve other eligible stages | Preserve | Preserve | Preserve |
+The command does not support `query_as_of`. It can answer current or explicitly
+selected fiscal-event questions, but not “what information was available on a
+past date.” The Skill must disclose that boundary rather than reconstructing a
+historical view from current output.
 
-Every stage returns:
+### Pre integrity
 
-- `content_status`: `AVAILABLE`, `NOT_AVAILABLE_YET`, or `UNAVAILABLE`;
-- `unavailable_reason` when relevant: `SOURCE_MISSING`, `NOT_ENTITLED`,
-  `INVALID_SOURCE`, `UPSTREAM_FAILURE`, or `OUTSIDE_AS_OF`;
-- event identity, source publication/availability time, evidence cutoff, and
-  warnings.
+A Pre record must represent evidence available before the release. If its
+timestamp is after the release or its text contains reported actuals/current
+post-event evidence, exclude it from the expectation baseline and report it as
+invalid. The producer/backend must repair or reject such records.
 
-## Normalized Response
+### Transcript budget
 
-```json
-{
-  "event": {
-    "symbol": "AMD",
-    "fiscal_year": 2026,
-    "fiscal_quarter": 2,
-    "fiscal_period_end": "YYYY-MM-DD",
-    "release_published_at": "ISO-8601",
-    "selection_reason": "LATEST_COMPLETED"
-  },
-  "query_as_of": "ISO-8601",
-  "stages": {
-    "pre": { "content_status": "AVAILABLE", "summary": {} },
-    "release": { "content_status": "AVAILABLE", "summary": {} },
-    "transcript": { "content_status": "NOT_AVAILABLE_YET" },
-    "post": { "content_status": "AVAILABLE", "analysis_state": "INITIAL_PRINT", "summary": {} }
-  },
-  "gaps": [],
-  "warnings": []
-}
-```
-
-`summary` is bounded for default broad answers. `evidence` may include detailed
-KPI comparisons, source-backed variances, and selected transcript passages;
-it must not return an unbounded document.
-
-## Stage Contracts
-
-### Pre-Earnings
-
-The producer must attach:
-
-- exact fiscal-event identity;
-- `generated_at` and `evidence_cutoff_at`;
-- the consensus snapshot and observation times used;
-- the company guidance, KPI expectations, scenario framework, and material
-  evidence gaps.
-
-Every estimate, price, option observation, quote, revision, and event included
-must have been available by `evidence_cutoff_at`. A record generated after the
-release is valid only if all visible evidence is independently bounded to the
-pre-release cutoff. Otherwise the backend returns `INVALID_SOURCE` and the
-record must be repaired or backfilled.
-
-### Official Release
-
-Use the official release or filed results exhibit as authority for actuals,
-guidance, KPIs, accounting basis, units, and release quotations. Structured
-data can reconcile or supplement it but cannot silently override event-time
-official figures.
-
-The backend records `release_published_at` and excludes the stage when it is
-later than `query_as_of`. A locator or filing cover page is not equivalent to
-the underlying results document.
-
-### Earnings Transcript
-
-The backend matches the exact fiscal event and requires a defensible
-availability time. It returns only relevant continuous passages with speaker,
-title, and section metadata.
-
-Selection terms may come from the user question, Pre decision variables,
-Release variances, guidance, and Post claims requiring verification. The API
-must enforce a configurable passage/character budget and support a second
-targeted window when the first omits a material topic. The Skill never loads a
-full transcript merely to search it.
-
-### Post-Earnings
-
-Post has two explicit states:
-
-| State | Minimum evidence | Allowed interpretation |
-| --- | --- | --- |
-| `INITIAL_PRINT` | Official release | Results, guidance, immediate debate change; no call claims. |
-| `POST_CALL` | Release plus transcript | Management framing, prepared remarks, Q&A, and call-informed thesis change. |
-
-Post must carry the same fiscal-event identity, `generated_at`,
-`evidence_cutoff_at`, and evidence-state label. A post-call claim without an
-eligible transcript is invalid.
-
-## Point-In-Time Enforcement
-
-`query_as_of` is a hard server-side boundary. The backend must ensure:
-
-1. Every stage existed by the cutoff.
-2. Every generated analysis has `generated_at` and `evidence_cutoff_at` no
-   later than the cutoff.
-3. Every cited or structured input was observed or published no later than the
-   stage's evidence cutoff.
-4. Later revisions, transcripts, estimates, or analysis are excluded even when
-   they discuss the selected historical event.
-5. Uncertain same-day timing is returned as a warning and cannot be treated as
-   proof that later evidence was available.
-
-These checks must be executable backend rules and contract tests, not prompt
-instructions.
+The current response can contain the full transcript. Broad routing must not
+inject that document into model context. Before enabling the route, provide a
+bounded summary response containing transcript status and only selected
+passages. Detailed call questions may request a targeted evidence mode with a
+hard passage/character limit.
 
 ## Synthesis And Degradation
 
-For broad company questions, return a compact lifecycle delta:
+For a broad company answer, synthesize a compact lifecycle delta:
 
-1. What the pre-event bar was.
+1. The valid pre-event bar, if available.
 2. What the company officially reported and guided.
-3. What management emphasized on the call, if eligible.
-4. How the event changed the investor debate, separating initial print from
-   post-call interpretation.
-5. Which stages or evidence remain unavailable.
+3. The most relevant management explanation, if a bounded passage is available.
+4. How Alva's Post analysis says the investor debate changed.
+5. Missing, invalid, or not-yet-available stages.
 
-For narrow questions, emphasize the requested stage but retain enough adjacent
-context to avoid false interpretation. Release actuals and guidance outrank
-generated analysis; transcript evidence outranks a Post characterization of
-what management said.
+For narrow questions, emphasize the requested stage while retaining enough
+adjacent context to avoid false interpretation.
 
-Missing or unauthorized stages do not suppress valid stages. If no valid stage
-is available, return the typed status and reason without inventing a neutral
-earnings view.
+- No next-confirmed event: say none is currently confirmed; do not substitute
+  the latest completed event.
+- Transcript unavailable: use Release and eligible Post initial-print context;
+  do not imply the call was reviewed.
+- Post unavailable: synthesize valid Pre, Release, and bounded Transcript
+  evidence without generating a replacement Post.
+- Invalid Pre: use Release/Transcript/Post for the completed event and state
+  that a trustworthy stored pre-event baseline is unavailable.

--- a/proposals/markets-context-routing/routing-integration.md
+++ b/proposals/markets-context-routing/routing-integration.md
@@ -1,191 +1,95 @@
 # Proposed Routing Integration
 
-This document describes the minimal changes engineering should make after the
-consumer contracts are approved. It intentionally does not patch the current
-Skill.
+Status: designed, not shipped. This RFC defines the boundary engineering must
+implement before changing the live Skill.
 
-## 1. Target Files
+## 1. Ownership
 
-| Existing file | Proposed change |
+| Layer | Owns |
 | --- | --- |
-| `skills/alva/SKILL.md` | Add direct routing links for Company Narrative and Earnings Context. State that a broad company view attempts both Markets context modules. |
-| `skills/alva/references/ticker-read.md` | Replace the WILF-only consumer assumption with the Company Narrative contract. Add Earnings Context to broad ticker reads. |
-| `skills/alva/references/request-routing.md` | Route all earnings/release/transcript/post-earnings intents through one Earnings Context reference. |
-| `skills/alva/references/company-narrative.md` | Add the approved Narrative consumer contract from this proposal. |
-| `skills/alva/references/earnings.md` | Add the approved Earnings consumer contract from this proposal. |
+| `ticker-read.md` | The only Company Context intent table; decides whether to request Narrative, Earnings, or both. |
+| Narrative/Earnings references | Module inputs, normalized outputs, synthesis, and degradation rules. No intent tables or storage recipes. |
+| Toolkit | One authenticated, channel-independent command that calls the canonical API and returns bounded JSON. |
+| Backend CompanyService | Symbol resolution, version/event selection, point-in-time validation, source priority, typed gaps, and transcript selection. |
+| Producers | Evidence cutoffs, timestamps, event identity, and source integrity. |
 
-Do not create `pre-earnings`, `earnings-release`, `earnings-transcript`, or
-`post-earnings` top-level Skills. Stage selection belongs inside the unified
-Earnings Context workflow.
+Do not add parallel routing paragraphs to `SKILL.md` or
+`request-routing.md`. Those files should only point named-ticker analysis to
+the existing ticker-read chain.
 
-## 2. Router Behavior
+## 2. Ticker-Read Route
 
-### Narrow requests
+The future intent table in `ticker-read.md` should be no larger than this:
 
-| Intent | Required module |
+| User ask | Company Context request |
 | --- | --- |
-| Current debate, investor focus, narrative change, Street view | Company Narrative |
-| Pre-earnings setup, results, guidance, call, transcript, post-earnings | Earnings Context |
-| Live price or one isolated fundamental fact | Neither module unless interpretation is requested |
+| Simple price or isolated fact | None unless interpretation is requested. |
+| Investor focus, debate, narrative, or narrative change | `scope=narrative` |
+| Earnings setup, result, guidance, call, transcript, or thesis impact | `scope=earnings` |
+| Broad view such as “How does Alva view AMD?” | `scope=broad`, summary detail |
+| Historical or page-selected question | Same scope plus explicit selector and `query_as_of` |
 
-### Broad company requests
+Broad responses begin with compact Narrative and Earnings summaries. History,
+full evidence, and transcript passages are fetched only when the question
+requires them.
 
-Examples include "How does Alva view AMD?", "Analyze AAPL", or "What matters
-for NVDA now?"
+## 3. Stable Agent Interface
 
-The ticker router should:
-
-1. Resolve canonical ticker and user information cutoff.
-2. Attempt current Company Narrative.
-3. Resolve one relevant fiscal event and attempt all eligible Earnings stages.
-4. Add anomaly, live price, fundamentals, valuation, or current catalysts only
-   when relevant to the user's question.
-5. Synthesize one answer; do not dump modules as disconnected sections.
-
-The caller must pass page-selected Narrative or earnings versions when the
-request originates from Markets. IM and direct Skill calls use the same router
-without page state.
-
-## 3. Logical Interface
-
-The platform tool names may differ by channel. The behavior should remain
-equivalent to:
+Expose one logical operation across web, IM, and direct Skill calls:
 
 ```text
-read_company_narrative(
-  ticker,
-  query_as_of,
-  selected_version_ms?,
-  environment
-) -> NarrativeResult
-
-read_earnings_context(
-  ticker,
-  query_as_of,
-  event_selector?,
-  user_intent,
-  environment
-) -> EarningsResult
+alva company context \
+  --symbol <canonical-symbol> \
+  --scope narrative|earnings|broad \
+  --detail summary|evidence \
+  [--as-of <timestamp>] \
+  [--fiscal-year <year> --fiscal-quarter <quarter>] \
+  [--narrative-version <generated-at>]
 ```
 
-Both functions are read-only and must return normalized source paths,
-timestamps, gaps, warnings, and selection reasons. They must not generate a
-missing feed or scrape the Markets page.
+The concrete command name may change, but all channels must call the same
+backend contract. The result must include selected identities, source
+timestamps, selection reasons, typed gaps, warnings, and bounded content. It
+must never expose storage addressing as part of the public contract.
 
-## 4. Narrative Route
+## 4. Required Platform Work
 
-The route reads:
+Before the Skill integration:
 
-```text
-/alva/home/{owner}/feeds/wilf-{feed_slug}/v1/data/wilf/card
-```
+1. Repair and backfill any Pre-Earnings record containing evidence published
+   after its declared cutoff.
+2. Add producer fields `generated_at` and `evidence_cutoff_at`; reject evidence
+   observed or published after the cutoff.
+3. Extend CompanyService and its gateway surface with `query_as_of`, exact
+   Narrative selection, fiscal-event selection, release publication time,
+   typed gaps, selection reasons, and bounded transcript retrieval.
+4. Normalize current and legacy Narrative change-log shapes server-side.
+5. Expose the stable Toolkit command and verify authenticated access from every
+   supported channel.
 
-Selection:
+## 5. Delivery Sequence
 
-- current question -> `@last/1`;
-- change question -> bounded `@last/N`;
-- page-selected version -> exact `@range/{dateMs-1}..{dateMs}`;
-- historical question -> newest record whose `date` and `as_of` do not exceed
-  `query_as_of`.
+1. Approve this API-first RFC.
+2. Fix producer integrity and affected historical data.
+3. Ship backend and gateway selection/PIT behavior.
+4. Ship the Toolkit command and contract tests.
+5. Add compact Narrative/Earnings references and the single ticker-read route.
+6. Run gray and cross-channel parity tests before enabling broad routing.
 
-The implementation must parse `news_feed_keywords`, `change_summary`, `gaps`,
-and `narrative_change_log`, and preserve legacy null/missing change logs.
+## 6. Acceptance Criteria
 
-## 5. Earnings Route
-
-The route resolves one fiscal event before reading evidence. It must never
-merge the upcoming Pre record with the previous quarter's Release/Post record
-as if they were one event.
-
-Pre and Post paths:
-
-```text
-/alva/home/{owner}/feeds/pre-earnings-{feed_slug}/v1/data/earnings/pre/
-  @range/{fiscalEndMs-1}..{fiscalEndMs}
-
-/alva/home/{owner}/feeds/post-earnings-{feed_slug}/v1/data/earnings/post/
-  @range/{fiscalEndMs-1}..{fiscalEndMs}
-```
-
-Confirmed current owners:
-
-| Environment | Owner |
-| --- | --- |
-| Production | `eddiid` |
-| Staging | `zal` |
-
-Release and Transcript come from live Data Skills discovery plus the official
-document returned by the locator. The official release/filed exhibit is source
-of truth for actuals and guidance. Transcript passages retain speaker and
-section metadata.
-
-Eligibility is controlled by `query_as_of`:
-
-```text
-before release:          Pre
-after release:           Pre + Release + optional initial-print Post
-after transcript:        Pre + Release + Transcript + optional post-call Post
-```
-
-If an eligible stage is missing or not entitled, preserve the other stages and
-return a typed gap.
-
-## 6. Required Platform Decisions
-
-These are implementation decisions, not reasons to redesign the Skill:
-
-1. Where environment-to-owner configuration lives.
-2. Which shared function owns canonical Markets `feed_slug` resolution.
-3. Which shared function selects the relevant earnings event for broad company
-   questions.
-4. How transcript sections are filtered outside model context.
-5. How page-selected event/version state is passed into the same router used by
-   IM and direct Skill calls.
-
-If these helpers already exist in Markets, reuse them or expose their behavior
-to the agent runtime. Do not duplicate subtly different selectors in each
-channel.
-
-## 7. Acceptance Tests
-
-### Narrative
-
-- A current AAPL question reads the production owner and returns the latest
-  card with `as_of`, `gaps`, and parsed change fields.
-- A page-selected historical version reads the exact `@range`, not `@last/1`.
-- A legacy record with null `narrative_change_log` returns empty history plus a
-  legacy-schema warning.
-- A wrong owner is classified as configuration error before `not_covered`.
-
-### Earnings
-
-- A pre-event question reads only evidence available before release.
-- Immediately after the release, the route returns Pre + Release and continues
-  when Transcript/Post are unavailable.
-- After the call, the route returns all available stages for the same fiscal
-  event.
-- A missing Transcript does not suppress valid Release or Post initial-print
-  context.
-- A transcript entitlement error is distinct from an absent transcript.
-- Production uses `eddiid`; staging uses `zal`.
-- Exact Pre/Post reads use `fiscal_period_end` milliseconds, not release date.
-- Historical requests never include later releases, estimates, transcripts, or
-  generated analyses.
-
-### Cross-channel parity
-
-- The same ticker, event selector, and `query_as_of` produce the same normalized
-  Narrative/Earnings context from web, IM, and direct Skill calls.
-- Channel-specific rendering may differ; event selection, data selection,
-  timestamps, gaps, and source priority may not.
-
-## 8. Merge Sequence
-
-1. Approve the two consumer contracts.
-2. Confirm or implement shared owner, slug, and event-selection helpers.
-3. Add the two references under `skills/alva/references/`.
-4. Add the three minimal router links described in section 1.
-5. Add acceptance scenarios to the existing `evals/alva-skill-docs/` suite.
-6. Validate current simple-price and non-company routes do not load unnecessary
-   context.
-7. Merge only after cross-channel and point-in-time tests pass.
+- The same request returns the same selected Narrative version, fiscal event,
+  stage eligibility, timestamps, and gap reasons in web, IM, and direct calls.
+- A historical cutoff cannot return later Narrative, Release, Transcript,
+  Post, estimates, or producer-generated evidence.
+- Pre, Release, Transcript, and Post always belong to one validated fiscal
+  event; a missing stage does not remove available stages.
+- Current, upcoming, post-call, and explicitly historical scenarios pass.
+- Share classes such as `BRK.B`, ordinary US tickers, and at least one non-US
+  symbol pass without Skill-side symbol-to-source logic.
+- `AVAILABLE`, `NOT_AVAILABLE_YET`, and `UNAVAILABLE` are distinguished; the
+  unavailable reason distinguishes missing source, entitlement, invalid data,
+  upstream failure, and outside-cutoff evidence.
+- Existing price-only and non-company routes do not load Company Context.
+- The final `skills/alva/**` diff contains no source-addressing or deployment
+  configuration details.

--- a/proposals/markets-context-routing/routing-integration.md
+++ b/proposals/markets-context-routing/routing-integration.md
@@ -1,0 +1,191 @@
+# Proposed Routing Integration
+
+This document describes the minimal changes engineering should make after the
+consumer contracts are approved. It intentionally does not patch the current
+Skill.
+
+## 1. Target Files
+
+| Existing file | Proposed change |
+| --- | --- |
+| `skills/alva/SKILL.md` | Add direct routing links for Company Narrative and Earnings Context. State that a broad company view attempts both Markets context modules. |
+| `skills/alva/references/ticker-read.md` | Replace the WILF-only consumer assumption with the Company Narrative contract. Add Earnings Context to broad ticker reads. |
+| `skills/alva/references/request-routing.md` | Route all earnings/release/transcript/post-earnings intents through one Earnings Context reference. |
+| `skills/alva/references/company-narrative.md` | Add the approved Narrative consumer contract from this proposal. |
+| `skills/alva/references/earnings.md` | Add the approved Earnings consumer contract from this proposal. |
+
+Do not create `pre-earnings`, `earnings-release`, `earnings-transcript`, or
+`post-earnings` top-level Skills. Stage selection belongs inside the unified
+Earnings Context workflow.
+
+## 2. Router Behavior
+
+### Narrow requests
+
+| Intent | Required module |
+| --- | --- |
+| Current debate, investor focus, narrative change, Street view | Company Narrative |
+| Pre-earnings setup, results, guidance, call, transcript, post-earnings | Earnings Context |
+| Live price or one isolated fundamental fact | Neither module unless interpretation is requested |
+
+### Broad company requests
+
+Examples include "How does Alva view AMD?", "Analyze AAPL", or "What matters
+for NVDA now?"
+
+The ticker router should:
+
+1. Resolve canonical ticker and user information cutoff.
+2. Attempt current Company Narrative.
+3. Resolve one relevant fiscal event and attempt all eligible Earnings stages.
+4. Add anomaly, live price, fundamentals, valuation, or current catalysts only
+   when relevant to the user's question.
+5. Synthesize one answer; do not dump modules as disconnected sections.
+
+The caller must pass page-selected Narrative or earnings versions when the
+request originates from Markets. IM and direct Skill calls use the same router
+without page state.
+
+## 3. Logical Interface
+
+The platform tool names may differ by channel. The behavior should remain
+equivalent to:
+
+```text
+read_company_narrative(
+  ticker,
+  query_as_of,
+  selected_version_ms?,
+  environment
+) -> NarrativeResult
+
+read_earnings_context(
+  ticker,
+  query_as_of,
+  event_selector?,
+  user_intent,
+  environment
+) -> EarningsResult
+```
+
+Both functions are read-only and must return normalized source paths,
+timestamps, gaps, warnings, and selection reasons. They must not generate a
+missing feed or scrape the Markets page.
+
+## 4. Narrative Route
+
+The route reads:
+
+```text
+/alva/home/{owner}/feeds/wilf-{feed_slug}/v1/data/wilf/card
+```
+
+Selection:
+
+- current question -> `@last/1`;
+- change question -> bounded `@last/N`;
+- page-selected version -> exact `@range/{dateMs-1}..{dateMs}`;
+- historical question -> newest record whose `date` and `as_of` do not exceed
+  `query_as_of`.
+
+The implementation must parse `news_feed_keywords`, `change_summary`, `gaps`,
+and `narrative_change_log`, and preserve legacy null/missing change logs.
+
+## 5. Earnings Route
+
+The route resolves one fiscal event before reading evidence. It must never
+merge the upcoming Pre record with the previous quarter's Release/Post record
+as if they were one event.
+
+Pre and Post paths:
+
+```text
+/alva/home/{owner}/feeds/pre-earnings-{feed_slug}/v1/data/earnings/pre/
+  @range/{fiscalEndMs-1}..{fiscalEndMs}
+
+/alva/home/{owner}/feeds/post-earnings-{feed_slug}/v1/data/earnings/post/
+  @range/{fiscalEndMs-1}..{fiscalEndMs}
+```
+
+Confirmed current owners:
+
+| Environment | Owner |
+| --- | --- |
+| Production | `eddiid` |
+| Staging | `zal` |
+
+Release and Transcript come from live Data Skills discovery plus the official
+document returned by the locator. The official release/filed exhibit is source
+of truth for actuals and guidance. Transcript passages retain speaker and
+section metadata.
+
+Eligibility is controlled by `query_as_of`:
+
+```text
+before release:          Pre
+after release:           Pre + Release + optional initial-print Post
+after transcript:        Pre + Release + Transcript + optional post-call Post
+```
+
+If an eligible stage is missing or not entitled, preserve the other stages and
+return a typed gap.
+
+## 6. Required Platform Decisions
+
+These are implementation decisions, not reasons to redesign the Skill:
+
+1. Where environment-to-owner configuration lives.
+2. Which shared function owns canonical Markets `feed_slug` resolution.
+3. Which shared function selects the relevant earnings event for broad company
+   questions.
+4. How transcript sections are filtered outside model context.
+5. How page-selected event/version state is passed into the same router used by
+   IM and direct Skill calls.
+
+If these helpers already exist in Markets, reuse them or expose their behavior
+to the agent runtime. Do not duplicate subtly different selectors in each
+channel.
+
+## 7. Acceptance Tests
+
+### Narrative
+
+- A current AAPL question reads the production owner and returns the latest
+  card with `as_of`, `gaps`, and parsed change fields.
+- A page-selected historical version reads the exact `@range`, not `@last/1`.
+- A legacy record with null `narrative_change_log` returns empty history plus a
+  legacy-schema warning.
+- A wrong owner is classified as configuration error before `not_covered`.
+
+### Earnings
+
+- A pre-event question reads only evidence available before release.
+- Immediately after the release, the route returns Pre + Release and continues
+  when Transcript/Post are unavailable.
+- After the call, the route returns all available stages for the same fiscal
+  event.
+- A missing Transcript does not suppress valid Release or Post initial-print
+  context.
+- A transcript entitlement error is distinct from an absent transcript.
+- Production uses `eddiid`; staging uses `zal`.
+- Exact Pre/Post reads use `fiscal_period_end` milliseconds, not release date.
+- Historical requests never include later releases, estimates, transcripts, or
+  generated analyses.
+
+### Cross-channel parity
+
+- The same ticker, event selector, and `query_as_of` produce the same normalized
+  Narrative/Earnings context from web, IM, and direct Skill calls.
+- Channel-specific rendering may differ; event selection, data selection,
+  timestamps, gaps, and source priority may not.
+
+## 8. Merge Sequence
+
+1. Approve the two consumer contracts.
+2. Confirm or implement shared owner, slug, and event-selection helpers.
+3. Add the two references under `skills/alva/references/`.
+4. Add the three minimal router links described in section 1.
+5. Add acceptance scenarios to the existing `evals/alva-skill-docs/` suite.
+6. Validate current simple-price and non-company routes do not load unnecessary
+   context.
+7. Merge only after cross-channel and point-in-time tests pass.

--- a/proposals/markets-context-routing/routing-integration.md
+++ b/proposals/markets-context-routing/routing-integration.md
@@ -1,95 +1,94 @@
-# Proposed Routing Integration
+# Routing Integration
 
-Status: designed, not shipped. This RFC defines the boundary engineering must
-implement before changing the live Skill.
+Status: designed, not shipped. The Toolkit command is available in the current
+rollout build; the live Skill has not adopted it.
 
-## 1. Ownership
+## 1. Single Routing Owner
 
-| Layer | Owns |
+Only `skills/alva/references/ticker-read.md` should own the Company Context
+intent table.
+
+- `SKILL.md`: point named-ticker analysis to `ticker-read.md`; add no parallel
+  Markets router.
+- `request-routing.md`: keep the generic Financial Analysis gate; add no
+  Narrative/Earnings intent table.
+- `company-narrative.md` and `earnings.md`: define command use, consumption,
+  synthesis, and degradation only.
+
+## 2. Command Router
+
+| User ask | Command |
 | --- | --- |
-| `ticker-read.md` | The only Company Context intent table; decides whether to request Narrative, Earnings, or both. |
-| Narrative/Earnings references | Module inputs, normalized outputs, synthesis, and degradation rules. No intent tables or storage recipes. |
-| Toolkit | One authenticated, channel-independent command that calls the canonical API and returns bounded JSON. |
-| Backend CompanyService | Symbol resolution, version/event selection, point-in-time validation, source priority, typed gaps, and transcript selection. |
-| Producers | Evidence cutoffs, timestamps, event identity, and source integrity. |
+| Simple price or isolated fact | Do not call Markets unless interpretation is requested. |
+| Investor focus, current debate, narrative change, peers | `alva markets narrative --ticker <TICKER>` |
+| Latest completed earnings, results, call, thesis impact | `alva markets earnings --ticker <TICKER>` |
+| Next confirmed earnings setup | `alva markets earnings --ticker <TICKER> --event next-confirmed` |
+| Explicit fiscal period | Add both `--fiscal-year <YEAR>` and `--fiscal-quarter <Q1..Q4>`. |
+| Broad view such as “How does Alva view AMD?” | Call Narrative plus default Earnings; synthesize compactly. |
 
-Do not add parallel routing paragraphs to `SKILL.md` or
-`request-routing.md`. Those files should only point named-ticker analysis to
-the existing ticker-read chain.
+Command invariants:
 
-## 2. Ticker-Read Route
+- `--event` accepts `latest-completed` or `next-confirmed`; default is
+  `latest-completed`.
+- Do not combine `--event` with fiscal-year/quarter flags.
+- Fiscal year and quarter must be provided together.
+- A typed event-not-found response means no matching confirmed event; do not
+  silently substitute another quarter.
 
-The future intent table in `ticker-read.md` should be no larger than this:
+## 3. Current Boundary
 
-| User ask | Company Context request |
-| --- | --- |
-| Simple price or isolated fact | None unless interpretation is requested. |
-| Investor focus, debate, narrative, or narrative change | `scope=narrative` |
-| Earnings setup, result, guidance, call, transcript, or thesis impact | `scope=earnings` |
-| Broad view such as “How does Alva view AMD?” | `scope=broad`, summary detail |
-| Historical or page-selected question | Same scope plus explicit selector and `query_as_of` |
+The commands return the latest backend view. They do not accept
+`query_as_of`, an exact Narrative version, or a historical evidence cutoff.
 
-Broad responses begin with compact Narrative and Earnings summaries. History,
-full evidence, and transcript passages are fetched only when the question
-requires them.
+Therefore:
 
-## 3. Stable Agent Interface
+- current and explicitly selected fiscal-period questions are supported;
+- Narrative history may explain how the current record changed;
+- “What would I have seen on date X?” is unsupported and must be disclosed;
+- the Skill must not simulate historical point-in-time correctness from current
+  records.
 
-Expose one logical operation across web, IM, and direct Skill calls:
+## 4. Readiness Gaps
 
-```text
-alva company context \
-  --symbol <canonical-symbol> \
-  --scope narrative|earnings|broad \
-  --detail summary|evidence \
-  [--as-of <timestamp>] \
-  [--fiscal-year <year> --fiscal-quarter <quarter>] \
-  [--narrative-version <generated-at>]
-```
+Before enabling automatic broad routing:
 
-The concrete command name may change, but all channels must call the same
-backend contract. The result must include selected identities, source
-timestamps, selection reasons, typed gaps, warnings, and bounded content. It
-must never expose storage addressing as part of the public contract.
+1. Narrative must return a usable current record even when one history row is
+   malformed; invalid history should be isolated or returned as a typed gap.
+2. Pre-Earnings records generated after the release must be repaired or rejected
+   when they contain post-event evidence.
+3. Default Earnings output must be bounded. The current response includes the
+   full transcript; add a summary mode that returns transcript status and
+   selected passages only.
+4. Keep a detailed transcript mode for explicit call questions, with a query or
+   section selector and a hard passage/character budget.
 
-## 4. Required Platform Work
+The first two are backend/data-integrity work. Transcript bounding may be
+implemented in the backend or Toolkit, but the Skill-facing output must be
+bounded before broad auto-routing.
 
-Before the Skill integration:
+Historical `query_as_of` support is a later capability and does not block
+current-view routing once the four readiness gaps above pass.
 
-1. Repair and backfill any Pre-Earnings record containing evidence published
-   after its declared cutoff.
-2. Add producer fields `generated_at` and `evidence_cutoff_at`; reject evidence
-   observed or published after the cutoff.
-3. Extend CompanyService and its gateway surface with `query_as_of`, exact
-   Narrative selection, fiscal-event selection, release publication time,
-   typed gaps, selection reasons, and bounded transcript retrieval.
-4. Normalize current and legacy Narrative change-log shapes server-side.
-5. Expose the stable Toolkit command and verify authenticated access from every
-   supported channel.
+## 5. Rollout Sequence
 
-## 5. Delivery Sequence
-
-1. Approve this API-first RFC.
-2. Fix producer integrity and affected historical data.
-3. Ship backend and gateway selection/PIT behavior.
-4. Ship the Toolkit command and contract tests.
-5. Add compact Narrative/Earnings references and the single ticker-read route.
-6. Run gray and cross-channel parity tests before enabling broad routing.
+1. Fix Narrative invalid-history isolation and contaminated Pre records.
+2. Add bounded default Earnings output and targeted transcript retrieval.
+3. Smoke-test the commands on AAPL, AMD, `BRK.B`, an upcoming event, an explicit
+   quarter, and a ticker with no matching event.
+4. Add the two references and one compact intent table to `ticker-read.md`.
+5. Confirm price-only and non-company routes do not call Markets.
+6. Verify equivalent normalized results from web, IM, and direct Skill calls.
 
 ## 6. Acceptance Criteria
 
-- The same request returns the same selected Narrative version, fiscal event,
-  stage eligibility, timestamps, and gap reasons in web, IM, and direct calls.
-- A historical cutoff cannot return later Narrative, Release, Transcript,
-  Post, estimates, or producer-generated evidence.
-- Pre, Release, Transcript, and Post always belong to one validated fiscal
-  event; a missing stage does not remove available stages.
-- Current, upcoming, post-call, and explicitly historical scenarios pass.
-- Share classes such as `BRK.B`, ordinary US tickers, and at least one non-US
-  symbol pass without Skill-side symbol-to-source logic.
-- `AVAILABLE`, `NOT_AVAILABLE_YET`, and `UNAVAILABLE` are distinguished; the
-  unavailable reason distinguishes missing source, entitlement, invalid data,
-  upstream failure, and outside-cutoff evidence.
-- Existing price-only and non-company routes do not load Company Context.
-- The final `skills/alva/**` diff contains no source-addressing or deployment
-  configuration details.
+- Broad reads return compact Narrative plus latest-completed Earnings context.
+- Next-confirmed and explicit-quarter selectors follow the documented flag
+  constraints.
+- Earnings preserves the validated fiscal event across Pre, Release,
+  Transcript, and Post; a missing stage does not erase available stages.
+- Malformed Narrative history does not destroy a valid current Narrative.
+- Default broad reads never inject an entire transcript into model context.
+- A Pre record containing post-release evidence is excluded or clearly invalid.
+- Historical point-in-time questions receive an explicit unsupported response.
+- The final `skills/alva/**` diff contains no deployment configuration or
+  underlying source-addressing details.


### PR DESCRIPTION
## Goal

Route company questions through the existing `alva markets` Toolkit surface so alva.ai, IM channels, and direct Skill calls can consume the same current Markets context.

## Canonical commands

```text
alva markets narrative --ticker <TICKER>
alva markets earnings --ticker <TICKER>
alva markets earnings --ticker <TICKER> --event next-confirmed
alva markets earnings --ticker <TICKER> --fiscal-year <YEAR> --fiscal-quarter <Q1..Q4>
```

Narrative and Earnings remain internal references inside one installable `alva` Skill. `ticker-read.md` is the sole owner of the Company Context intent table.

## Verified behavior

- Toolkit help confirms `markets narrative` and `markets earnings`.
- Default Earnings selects the latest completed event.
- `--event next-confirmed` and explicit paired fiscal flags follow the documented mutual-exclusion rules.
- Completed AAPL and AMD reads returned Pre, official Release, Transcript, and Post for one fiscal event.
- A missing next-confirmed event returns a typed event-not-found response.
- The current command surface does not support historical `query_as_of`.

## Readiness gaps before broad Skill routing

1. Isolate malformed Narrative history so it does not fail a valid current Narrative.
2. Repair or reject Pre records containing post-release evidence.
3. Add a bounded default Earnings response; current completed-event responses can include the full transcript.
4. Add targeted, hard-bounded transcript evidence for explicit call questions.

Historical point-in-time support is a later enhancement and does not block current-view routing after these readiness gaps pass.

## Safety boundary

This draft changes only `proposals/markets-context-routing/**`. It does not modify `skills/alva/**` and is not loaded by the current Skill. The proposal contains no deployment configuration or underlying source-addressing details.

## Review focus

- Are the command router and flag constraints correct?
- Should transcript bounding live in the Toolkit or backend?
- Are the Narrative-history and Pre-integrity rollout gates sufficient?
- Can the same normalized command output be used from web, IM, and direct Skill calls?