### PR TITLE
Clarify Alva follow-up CTA guidance

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -900,7 +900,9 @@
             "`channel_id=0`",
             "`active_im_provider`",
             "active IM provider",
-            "moves the personal alert"
+            "moves the personal alert",
+            "`open_url` action",
+            "https://alva.ai/settings?tab=alvaAgent"
           ]
         },
         {
@@ -911,7 +913,10 @@
             "intended destination",
             "global \"subscribed\" state is not sufficient",
             "report it as an Alva web topic channel with its id",
-            "never as Telegram or another external DM"
+            "never as Telegram or another external DM",
+            "fix it when alert delivery was requested",
+            "when optional, explain the benefit",
+            "`send_prompt` action to enable the named Automation's alert"
           ]
         }
       ]
@@ -1023,6 +1028,20 @@
         "cap confidence when required evidence",
         "KPI coverage",
         "computation is missing"
+      ]
+    },
+    {
+      "id": "target.useful-next-step-actions",
+      "group": "target",
+      "target": "skill",
+      "description": "Useful post-answer suggestions pair explanatory prose with the correct compact action when the tool is available.",
+      "includes": [
+        "If `PresentActions` is available",
+        "`send_prompt` when the Agent should continue",
+        "`open_url`",
+        "short imperative",
+        "button condenses the action",
+        "Required questions use `AskUserQuestion`"
       ]
     },
     {

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -425,12 +425,12 @@ both pass, prefer Automation when recurring value justifies the setup; choose
 one-off only when it is clearly more useful now. Never recommend Automation
 merely because work is schedulable.
 
-When suggesting, use one short, low-pressure sentence in the user's language.
-Lead with the specific outcome and let the invitation follow the answer's natural
-cadence: a direct offer, compact question, or contextual bridge can all work.
-Use tone to make the suggestion easy to decline, and let recurring suggestions
-vary naturally within a thread. Keep the focus on outcome and value; save
-implementation details for an accepted next step.
+When suggesting, use one short, low-pressure sentence in the user's language to
+explain the outcome. If `PresentActions` is available, follow it with one matching action:
+`send_prompt` when the Agent should continue, change state, or verify here; `open_url`
+when the user should go directly to an HTTPS product surface. Use a short imperative
+label (normally verb + object) and a self-contained, context-grounded prompt; the sentence
+explains value while the button condenses the action. Required questions use `AskUserQuestion`.
 For named single-instrument ticker reads, apply the Trade Setup follow-up rules in [ticker-read.md](references/ticker-read.md#trade-setup-follow-up).
 If Automation clears this bar or is already requested, apply [Preferred Automation Setup Skills](references/request-routing.md#preferred-automation-setup-skills) before suggesting or building it.
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -429,8 +429,8 @@ When suggesting, use one short, low-pressure sentence in the user's language to
 explain the outcome. If `PresentActions` is available, follow it with one matching action:
 `send_prompt` when the Agent should continue, change state, or verify here; `open_url`
 when the user should go directly to an HTTPS product surface. Use a short imperative
-label (normally verb + object) and a self-contained, context-grounded prompt; the sentence
-explains value while the button condenses the action. Required questions use `AskUserQuestion`.
+label (normally verb + object); for `send_prompt`, use a self-contained, context-grounded
+prompt. The sentence explains value while the button condenses the action. Required questions use `AskUserQuestion`.
 For named single-instrument ticker reads, apply the Trade Setup follow-up rules in [ticker-read.md](references/ticker-read.md#trade-setup-follow-up).
 If Automation clears this bar or is already requested, apply [Preferred Automation Setup Skills](references/request-routing.md#preferred-automation-setup-skills) before suggesting or building it.
 

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -49,8 +49,9 @@ explicitly identifies it; otherwise describe a topic destination as the
 `current Alva topic channel (channel id <id>)`.
 
 If no active IM provider exists for the default personal destination, say web
-notifications will work immediately and the user can connect Telegram,
-Discord, or Slack at <https://alva.ai/settings>.
+notifications already work and, when `PresentActions` is available, offer one
+`open_url` action to <https://alva.ai/settings?tab=alvaAgent> with a short
+imperative label; otherwise include that link in the sentence.
 
 ## Configure And Verify
 
@@ -78,13 +79,13 @@ A push is set up only after all of these succeed:
    and confirm it does not append a new record.
 4. Enable publisher push on the cronjob:
    `alva deploy update --id <ID> --push-notify`.
-5. Inspect the owner FEED alert created by publish and confirm its destination.
-   If it is already correct, do not re-enable it. To move it to the default
-   personal destination, use `alva alert enable --automation <owner>/<feed>` or
-   `alva alert enable --automation-ids <id,id>`. For the current Alva topic
-   channel, use `alva alert enable --automation-ids <id,id> --channel-id
-   <current_channel_id>`; never replace this with the name-addressed
-   default-personal command.
+5. Inspect the owner FEED alert created by publish and confirm its destination. If missing
+   or wrong, fix it when alert delivery was requested; when optional, explain the benefit
+   and offer one `send_prompt` action to enable the named Automation's alert. If already
+   correct, do not re-enable it. To move it to the default personal destination, use
+   `alva alert enable --automation <owner>/<feed>` or `alva alert enable --automation-ids
+   <id,id>`. For the current Alva topic channel, use `alva alert enable --automation-ids
+   <id,id> --channel-id <current_channel_id>`; never replace this with the name-addressed default-personal command.
 
 Do not trigger the cronjob or wait for its next scheduled run solely to verify
 setup. A default publish already admitted the first producer run; triggering it

--- a/skills/alva/references/push-notifications.md
+++ b/skills/alva/references/push-notifications.md
@@ -85,7 +85,8 @@ A push is set up only after all of these succeed:
    correct, do not re-enable it. To move it to the default personal destination, use
    `alva alert enable --automation <owner>/<feed>` or `alva alert enable --automation-ids
    <id,id>`. For the current Alva topic channel, use `alva alert enable --automation-ids
-   <id,id> --channel-id <current_channel_id>`; never replace this with the name-addressed default-personal command.
+   <id,id> --channel-id <current_channel_id>`; never replace this with the
+   name-addressed default-personal command.
 
 Do not trigger the cronjob or wait for its next scheduled run solely to verify
 setup. A default publish already admitted the first producer run; triggering it


### PR DESCRIPTION
## Summary

- Pair a useful post-answer explanation with one matching PresentActions CTA when available.
- Use send_prompt for work the Agent should continue and open_url for direct product navigation.
- Guide requested versus optional Automation alert binding separately.
- Route IM connection to https://alva.ai/settings?tab=alvaAgent.
- Preserve the existing Trade Setup follow-up rules unchanged.
- Add regression coverage for the new guidance.

## Why

The existing Skill selected meaningful next steps but did not connect that policy clearly to the conversational action tool. Push guidance also used a generic settings URL and did not distinguish required alert delivery from an optional binding suggestion.

## Impact

Users keep the explanatory sentence and receive one concise, actionable button. Missing requested alert bindings are completed as part of setup; optional binding and IM connection remain low-pressure next steps.

## Validation

- Alva Skill quick validation passed.
- Skill documentation regression: 84/84 cases and 853/853 checks.
- Top-level SKILL.md remains 910 lines.
- git diff --check passed.

## Companion change

- alva-ai/sandbox-agent-ts#340 refines the PresentActions tool description.