### PR TITLE
chore(alva): bump version to v1.21.4

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1288,7 +1288,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.21.2",
+        "version: v1.21.4",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.21.2
+  version: v1.21.4
 ---
 
 # Alva


### PR DESCRIPTION
## Summary
- bump the Alva skill release version to v1.21.4
- align the doc regression version assertion

## Verification
- doc regression eval: 857/857
- mutation smoke: 18/18

Release content includes per-Automation partial email delivery from #609.