### PR TITLE
docs(alva): resolve Arrays symbols before Altra backtests

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -279,6 +279,28 @@
       ]
     },
     {
+      "id": "target.altra-symbol-resolution",
+      "group": "target",
+      "target": "corpus",
+      "description": "Altra resolves Arrays trading pairs through the existing runtime, filters ambiguous matches, and proves OHLCV availability before a full backtest.",
+      "section_includes": [
+        {
+          "file": "references/altra-trading.md",
+          "heading": "Resolve Trading Pairs Before Backtesting",
+          "includes": [
+            "Never invent or assemble an Altra symbol from a ticker",
+            "alva run --code",
+            "/api/v1/market/trading-pairs?symbol=",
+            "candidates.slice(0, 20)",
+            "Never select the first unfiltered response",
+            "pass it to Altra unchanged",
+            "bounded smoke window",
+            "at least one real OHLCV bar"
+          ]
+        }
+      ]
+    },
+    {
       "id": "retained.alpi",
       "group": "retained",
       "target": "corpus",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -30,6 +30,19 @@ const MUTATIONS = [
     ],
   },
   {
+    id: "altra-symbol-resolution",
+    file: "references/altra-trading.md",
+    remove:
+      "Never invent or assemble an Altra symbol from a ticker. Resolve the exact\n" +
+      "`trading_pair` from Arrays before writing the strategy, then pass it to Altra\n" +
+      "unchanged. Use the existing `alva run` surface; no dedicated trading-pair CLI\n" +
+      "command is required.\n",
+    expectFailedCases: [
+      "target.altra-symbol-resolution",
+      "scenario.backtest-symbol-resolution",
+    ],
+  },
+  {
     id: "explicit-advice-request-header",
     file: "references/user-facing-prose.md",
     remove:

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -348,6 +348,39 @@
       }
     },
     {
+      "id": "scenario.backtest-symbol-resolution",
+      "group": "scenarios.strategy",
+      "prompt": "Backtest a weekly momentum strategy for NASDAQ:RKLB.",
+      "description": "A stock backtest resolves an Arrays trading pair without a new CLI command, avoids ambiguous raw ordering, and verifies real OHLCV before the full run.",
+      "expect": {
+        "route": "Strategy / Trading Analysis",
+        "references": [
+          "altra-trading.md"
+        ],
+        "behaviors": [
+          "Never invent or assemble an Altra symbol from a ticker",
+          "alva run --code",
+          "NASDAQ:RKLB",
+          "US_SPOT_RKLB_USD",
+          "Never select the first unfiltered response",
+          "pass it to Altra unchanged",
+          "bounded smoke window",
+          "at least one real OHLCV bar"
+        ],
+        "sections": [
+          {
+            "file": "references/altra-trading.md",
+            "heading": "Resolve Trading Pairs Before Backtesting",
+            "includes": [
+              "/api/v1/market/trading-pairs?symbol=",
+              "candidates.slice(0, 20)",
+              "Exclude options unless the user explicitly asks"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": "scenario.skillhub-method",
       "group": "scenarios.skillhub",
       "prompt": "/use-skill:alva/thesis NVDA AI capex read-through",

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -272,8 +272,92 @@ const ohlcvProvider = createArraysOhlcvProvider({ jwt: ARRAYS_JWT });
 const altra = new FeedAltra(config, ohlcvProvider);
 ```
 
-**Symbol format**: Use the exact format from the system (e.g.
-`"BINANCE_SPOT_BTC_USDT"`, `"XNAS_SPOT_AAPL_USD"`).
+### Resolve Trading Pairs Before Backtesting
+
+Never invent or assemble an Altra symbol from a ticker. Resolve the exact
+`trading_pair` from Arrays before writing the strategy, then pass it to Altra
+unchanged. Use the existing `alva run` surface; no dedicated trading-pair CLI
+command is required.
+
+Run this bounded lookup with the user's intended instrument and venue filters:
+
+```bash
+alva run --code '(async () => {
+  const http = require("net/http");
+  const secret = require("secret-manager");
+  const env = require("env");
+  const args = env.args || {};
+  const rawQuery = String(args.query || "").trim().toUpperCase();
+  const query = rawQuery.includes(":") ? rawQuery.split(":").pop() : rawQuery;
+  if (!query) throw new Error("query is required");
+
+  const response = await http.fetch(
+    "https://data-tools.prd.space.id/api/v1/market/trading-pairs?symbol=" +
+      encodeURIComponent(query),
+    {
+      headers: {
+        Authorization: "Bearer " + secret.loadPlaintext("ARRAYS_JWT"),
+      },
+    },
+  );
+  const body = response.json();
+  if (!response.ok || body.success === false) {
+    throw new Error("trading-pair search failed with HTTP " + response.status);
+  }
+
+  const wanted = {
+    instrumentType: String(args.instrument_type || "").toUpperCase(),
+    underlyingType: String(args.underlying_type || "").toUpperCase(),
+    market: String(args.market || "").toUpperCase(),
+    quote: String(args.quote || "").toUpperCase(),
+  };
+  const candidates = [];
+  for (const match of body.data || []) {
+    for (const group of match.trading_pairs || []) {
+      for (const pair of group.pairs || []) {
+        const candidate = {
+          matchedSymbol: match.symbol,
+          tradingPair: pair.trading_pair,
+          instrumentType: group.instrument_type,
+          underlyingType: pair.underlying_type,
+          market: pair.market,
+          quote: pair.quote,
+        };
+        if (!candidate.tradingPair) continue;
+        if (wanted.instrumentType && String(candidate.instrumentType).toUpperCase() !== wanted.instrumentType) continue;
+        if (wanted.underlyingType && String(candidate.underlyingType).toUpperCase() !== wanted.underlyingType) continue;
+        if (wanted.market && String(candidate.market).toUpperCase() !== wanted.market) continue;
+        if (wanted.quote && String(candidate.quote).toUpperCase() !== wanted.quote) continue;
+        candidates.push(candidate);
+      }
+    }
+  }
+  return {
+    query,
+    candidates: candidates.slice(0, 20),
+    truncated: candidates.length > 20,
+  };
+})();' --args '{"query":"RKLB","instrument_type":"spot","underlying_type":"stock","market":"US","quote":"USD"}'
+```
+
+Selection rules:
+
+- Treat a prefix such as `NASDAQ:` or `XNAS:` as an intent hint. Search Arrays
+  with the base ticker and use the returned `tradingPair`; for example,
+  `NASDAQ:RKLB` resolves through `RKLB` to `US_SPOT_RKLB_USD`.
+- For US equities, filter to `spot` + `stock` + `US` + `USD`. For crypto,
+  filter `spot` or `perp` and the requested venue and quote.
+- Exclude options unless the user explicitly asks for an option contract.
+- Prefer an exact `matchedSymbol`. Never select the first unfiltered response.
+  If multiple filtered candidates still match the user's intent, ask one
+  blocking question instead of guessing.
+- Stop when the lookup errors or returns no eligible candidate. Do not silently
+  fall back to an invented symbol.
+
+The lookup proves naming and catalog membership, not OHLCV availability. Before
+the full-range backtest, run Altra with the selected symbol over a bounded smoke
+window that covers the maximum feature lookback. Require at least one real OHLCV
+bar and no provider error before expanding to the requested range.
 
 **Supported OHLCV intervals**:
 

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -300,7 +300,7 @@ alva run --code '(async () => {
       },
     },
   );
-  const body = response.json();
+  const body = await response.json();
   if (!response.ok || body.success === false) {
     throw new Error("trading-pair search failed with HTTP " + response.status);
   }


### PR DESCRIPTION
## Summary

- resolve ticker inputs through the Arrays trading-pair catalog using the existing `alva run` runtime
- filter candidates by instrument type, underlying type, market, and quote, then pass the returned `tradingPair` to Altra unchanged
- require a bounded OHLCV smoke window before expanding to a full backtest
- add documentation, scenario, and mutation coverage for the symbol-resolution workflow

## Testing

- `node evals/alva-skill-docs/skill-doc-eval.mjs` (`86/86` cases, `878/878` checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs` (`19/19`)
- `uv run --with pyyaml python /Users/grayman/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/alva`
- `git diff --check`
- cold-start agent live check: `NASDAQ:RKLB` resolved uniquely to `US_SPOT_RKLB_USD`; bounded Altra provider smoke returned 24 valid weekly bars