### PR TITLE
docs(alva): teach named Agent Schedules

### DIFF
--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -2,11 +2,11 @@
 
 Source: `origin/main`
 
-SKILL.md lines: 910
+SKILL.md lines: 911
 
-Cases: 82/84
+Cases: 82/86
 
-Checks: 851/857 (99.30%)
+Checks: 855/880 (97.16%)
 
 ## Scoring Diagnosis
 
@@ -15,8 +15,10 @@ Classify the gap before editing: missing capability summary, missing routing poi
 Do not expose eval scores as product copy, and do not patch demos to hide a weak result.
 Instead, fix the canonical skill text or eval case, then rerun baseline and final reports so the regression mechanism proves the gap is closed.
 
-- subscriptions.delivery-destination: inspect for a skill gap before editing. Missing checks: alert destination: references/push-notifications.md#Choose The Delivery Destination includes can contain Alva channel destinations and verified-account email at the same time; alert destination: references/push-notifications.md#Choose The Delivery Destination includes Updating email does not move or clear the current Alva/IM destination; alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery get --id <automation_id>; alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery update --id <automation_id> --email-enabled; alert destination: references/push-notifications.md#Choose The Delivery Destination includes Do not read-modify-write the whole resource
-- scenario.current-topic-channel-alert: inspect for a skill gap before editing. Missing checks: A successful partial update proves that alert delivery is configured
+- target.auto-trade-consent-exemption: inspect for a skill gap before editing. Missing checks: applies only to Agent Schedule occurrences; verified legacy Channel Loop ticks
+- target.auto-trade-consent-references: inspect for a skill gap before editing. Missing checks: consented auto-trading Schedule occurrence; legacy Channel Loop tick
+- target.agent-schedule-lifecycle: inspect for a skill gap before editing. Missing checks: Future Channel Agent Turns; Agent Schedule | Create or resume a named future Channel Agent turn; alva schedule put; exactly one of `--after`, `--at`, `--every`, or `--cron`; omit `--channel-id` for the authenticated user's Agent Channel; put replaces the complete definition; alva schedule pause; alva schedule resume; alva schedule delete
+- target.legacy-loop-compatibility: inspect for a skill gap before editing. Missing checks: Legacy Channel Loop Compatibility; alva schedule list does not list legacy loops; older Toolkit versions may still accept; a Toolkit upgrade is required; alva automation list --status all --json; alva automation inspect --id <automation_id> --json; Channel loop:; ~/loops/_runner/index.js; do not create new legacy loops; alva automation stop --id <automation_id>; alva automation resume --id <automation_id>; alva automation delete --id <automation_id>
 
 ## retained
 
@@ -250,7 +252,7 @@ Interactive orders keep the per-order confirmation rule: the exemption does not 
 
 ## target
 
-15/15 cases, 172/172 checks
+13/17 cases, 170/195 checks
 
 ### PASS target.automation-publish-side-effects
 
@@ -266,7 +268,7 @@ Automation publish documents its owner binding and first-run side effects, inclu
 
 Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count <= 911 (actual 910)
+- [x] line count <= 911 (actual 911)
 
 ### PASS target.playbook-task-offload
 
@@ -432,7 +434,7 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.21.2
+- [x] version: v1.21.4
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
@@ -477,27 +479,60 @@ One-off price-series artifacts route to a pinned Lightweight Charts v5 reference
 - [x] references/lightweight-charts.md includes createPriceLine()
 - [x] SKILL.md includes [lightweight-charts.md](references/lightweight-charts.md)
 
-### PASS target.auto-trade-consent-exemption
+### FAIL target.auto-trade-consent-exemption
 
-A consent-referenced, record-verified channel-loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.
+A consent-referenced, record-verified Agent Schedule occurrence or legacy Channel Loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.
 
 - [x] auto-trade-consent:
 - [x] ~/memory/auto-trade-consent.md
 - [x] one-read verification
 - [x] place live orders without per-order user confirmation
 - [x] missing or unreadable record
-- [x] applies only to loop ticks
+- [ ] applies only to Agent Schedule occurrences
+- [ ] verified legacy Channel Loop ticks
 - [x] verification checks only that the consent record exists
 - [x] timestamp is provenance, not a match key
 - [x] is not a mismatch
 
-### PASS target.auto-trade-consent-references
+### FAIL target.auto-trade-consent-references
 
-The broker and trading references reconcile their per-order confirm lines with the loop-tick consent exemption instead of demanding unqualified confirmation.
+The broker and trading references reconcile their per-order confirm lines with the scheduled-occurrence consent exemption instead of demanding unqualified confirmation.
 
-- [x] consented auto-trading loop tick
+- [ ] consented auto-trading Schedule occurrence
+- [ ] legacy Channel Loop tick
 - [x] recorded consent
 - [x] stands in for this per-order confirmation
+
+### FAIL target.agent-schedule-lifecycle
+
+Future Channel Agent turns use named Schedules with explicit rule, bounds, lifecycle, and target defaults.
+
+- [ ] Future Channel Agent Turns
+- [ ] Agent Schedule | Create or resume a named future Channel Agent turn
+- [ ] alva schedule put
+- [ ] exactly one of `--after`, `--at`, `--every`, or `--cron`
+- [ ] omit `--channel-id` for the authenticated user's Agent Channel
+- [ ] put replaces the complete definition
+- [ ] alva schedule pause
+- [ ] alva schedule resume
+- [ ] alva schedule delete
+
+### FAIL target.legacy-loop-compatibility
+
+Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.
+
+- [ ] Legacy Channel Loop Compatibility
+- [ ] alva schedule list does not list legacy loops
+- [ ] older Toolkit versions may still accept
+- [ ] a Toolkit upgrade is required
+- [ ] alva automation list --status all --json
+- [ ] alva automation inspect --id <automation_id> --json
+- [ ] Channel loop:
+- [ ] ~/loops/_runner/index.js
+- [ ] do not create new legacy loops
+- [ ] alva automation stop --id <automation_id>
+- [ ] alva automation resume --id <automation_id>
+- [ ] alva automation delete --id <automation_id>
 
 ## alerts
 
@@ -818,9 +853,9 @@ Push setup is evaluated as a full delivery path instead of a single publisher fl
 
 ## subscriptions
 
-0/1 cases, 23/28 checks
+1/1 cases, 28/28 checks
 
-### FAIL subscriptions.delivery-destination
+### PASS subscriptions.delivery-destination
 
 The skill models concurrent Alva and email destinations, distinguishes the default personal destination from an Alva topic channel, and keeps external-group operations profile-owned.
 
@@ -838,11 +873,11 @@ The skill models concurrent Alva and email destinations, distinguishes the defau
 - [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes `channel_id=0`
 - [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes `active_im_provider`
 - [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes active IM provider
-- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination includes can contain Alva channel destinations and verified-account email at the same time
-- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Updating email does not move or clear the current Alva/IM destination
-- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery get --id <automation_id>
-- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery update --id <automation_id> --email-enabled
-- [ ] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Do not read-modify-write the whole resource
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes can contain Alva channel destinations and verified-account email at the same time
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Updating email does not move or clear the current Alva/IM destination
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery get --id <automation_id>
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes alva automation delivery update --id <automation_id> --email-enabled
+- [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes Do not read-modify-write the whole resource
 - [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes `open_url` action
 - [x] alert destination: references/push-notifications.md#Choose The Delivery Destination includes https://alva.ai/settings?tab=alvaAgent
 - [x] destination verification: references/push-notifications.md#Configure And Verify includes intended destination
@@ -1097,7 +1132,7 @@ Prompt: `<annotation id="hero-title">make this chart title shorter</annotation>`
 
 ## scenarios.push
 
-2/3 cases, 60/61 checks
+3/3 cases, 61/61 checks
 
 ### PASS scenario.alert-push-monitor
 
@@ -1160,7 +1195,7 @@ Prompt: `Create a scheduled market Feed alert with a red Discord card, a View re
 - [x] Portable Actions And Card Presentation: references/feed-sdk.md#Portable Actions And Card Presentation includes sendPromptAction(
 - [x] Portable Actions And Card Presentation: references/feed-sdk.md#Portable Actions And Card Presentation includes cardPresentation({
 
-### FAIL scenario.current-topic-channel-alert
+### PASS scenario.current-topic-channel-alert
 
 A request made in an Alva web topic channel binds the feed to that exact channel id and never invents Telegram delivery.
 
@@ -1174,7 +1209,7 @@ Prompt: `<session-prefill-channel-memory channel-id="44" root="/alva/home/ymchco
 - [x] Do not infer Telegram, Discord, Slack, or another transport
 - [x] current Alva topic channel (channel id <id>)
 - [x] Do not trigger the cronjob or wait for its next scheduled run solely to verify setup
-- [ ] A successful partial update proves that alert delivery is configured
+- [x] A successful partial update proves that alert delivery is configured
 - [x] it does not prove that a message has already been delivered
 - [x] An ALFS record alone is also not delivery proof
 - [x] report it as an Alva web topic channel with its id

--- a/evals/alva-skill-docs/baseline-report.md
+++ b/evals/alva-skill-docs/baseline-report.md
@@ -6,7 +6,7 @@ SKILL.md lines: 911
 
 Cases: 82/86
 
-Checks: 855/880 (97.16%)
+Checks: 855/884 (96.72%)
 
 ## Scoring Diagnosis
 
@@ -17,8 +17,8 @@ Instead, fix the canonical skill text or eval case, then rerun baseline and fina
 
 - target.auto-trade-consent-exemption: inspect for a skill gap before editing. Missing checks: applies only to Agent Schedule occurrences; verified legacy Channel Loop ticks
 - target.auto-trade-consent-references: inspect for a skill gap before editing. Missing checks: consented auto-trading Schedule occurrence; legacy Channel Loop tick
-- target.agent-schedule-lifecycle: inspect for a skill gap before editing. Missing checks: Future Channel Agent Turns; Agent Schedule | Create or resume a named future Channel Agent turn; alva schedule put; exactly one of `--after`, `--at`, `--every`, or `--cron`; omit `--channel-id` for the authenticated user's Agent Channel; put replaces the complete definition; alva schedule pause; alva schedule resume; alva schedule delete
-- target.legacy-loop-compatibility: inspect for a skill gap before editing. Missing checks: Legacy Channel Loop Compatibility; alva schedule list does not list legacy loops; older Toolkit versions may still accept; a Toolkit upgrade is required; alva automation list --status all --json; alva automation inspect --id <automation_id> --json; Channel loop:; ~/loops/_runner/index.js; do not create new legacy loops; alva automation stop --id <automation_id>; alva automation resume --id <automation_id>; alva automation delete --id <automation_id>
+- target.agent-schedule-lifecycle: inspect for a skill gap before editing. Missing checks: Future Channel Agent Turns; Agent Schedule | Create or resume a named future Channel Agent turn; alva schedule put; exactly one of `--after`, `--at`, `--every`, or `--cron`; omit `--channel-id` for the authenticated user's Agent Channel; `put` replaces the complete definition; alva schedule pause; alva schedule resume; alva schedule delete
+- target.legacy-loop-compatibility: inspect for a skill gap before editing. Missing checks: Legacy Channel Loop Compatibility; alva schedule list; does not list legacy loops; older Toolkit versions may still accept; a Toolkit upgrade is required; alva automation list --status all --json; alva automation inspect --id <automation_id> --json; Channel loop:; ~/loops/_runner/index.js; do not create new legacy loops; alva automation stop --id <automation_id>; alva automation resume --id <automation_id>; alva automation delete --id <automation_id>; stop the old Automation and verify it is quiescent before creating; If quiescence cannot be confirmed, do not activate the replacement; never run both
 
 ## retained
 
@@ -252,7 +252,7 @@ Interactive orders keep the per-order confirmation rule: the exemption does not 
 
 ## target
 
-13/17 cases, 170/195 checks
+13/17 cases, 170/199 checks
 
 ### PASS target.automation-publish-side-effects
 
@@ -512,7 +512,7 @@ Future Channel Agent turns use named Schedules with explicit rule, bounds, lifec
 - [ ] alva schedule put
 - [ ] exactly one of `--after`, `--at`, `--every`, or `--cron`
 - [ ] omit `--channel-id` for the authenticated user's Agent Channel
-- [ ] put replaces the complete definition
+- [ ] `put` replaces the complete definition
 - [ ] alva schedule pause
 - [ ] alva schedule resume
 - [ ] alva schedule delete
@@ -522,7 +522,8 @@ Future Channel Agent turns use named Schedules with explicit rule, bounds, lifec
 Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.
 
 - [ ] Legacy Channel Loop Compatibility
-- [ ] alva schedule list does not list legacy loops
+- [ ] alva schedule list
+- [ ] does not list legacy loops
 - [ ] older Toolkit versions may still accept
 - [ ] a Toolkit upgrade is required
 - [ ] alva automation list --status all --json
@@ -533,6 +534,9 @@ Legacy Channel loops remain manageable through their Automation lifecycle withou
 - [ ] alva automation stop --id <automation_id>
 - [ ] alva automation resume --id <automation_id>
 - [ ] alva automation delete --id <automation_id>
+- [ ] stop the old Automation and verify it is quiescent before creating
+- [ ] If quiescence cannot be confirmed, do not activate the replacement
+- [ ] never run both
 
 ## alerts
 

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1404,7 +1404,7 @@
         "alva schedule put",
         "exactly one of `--after`, `--at`, `--every`, or `--cron`",
         "omit `--channel-id` for the authenticated user's Agent Channel",
-        "put replaces the complete definition",
+        "`put` replaces the complete definition",
         "alva schedule pause",
         "alva schedule resume",
         "alva schedule delete"
@@ -1417,7 +1417,8 @@
       "description": "Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.",
       "includes": [
         "Legacy Channel Loop Compatibility",
-        "alva schedule list does not list legacy loops",
+        "alva schedule list",
+        "does not list legacy loops",
         "older Toolkit versions may still accept",
         "a Toolkit upgrade is required",
         "alva automation list --status all --json",
@@ -1427,7 +1428,10 @@
         "do not create new legacy loops",
         "alva automation stop --id <automation_id>",
         "alva automation resume --id <automation_id>",
-        "alva automation delete --id <automation_id>"
+        "alva automation delete --id <automation_id>",
+        "stop the old Automation and verify it is quiescent before creating",
+        "If quiescence cannot be confirmed, do not activate the replacement",
+        "never run both"
       ]
     }
   ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1367,14 +1367,15 @@
       "id": "target.auto-trade-consent-exemption",
       "group": "target",
       "target": "skill",
-      "description": "A consent-referenced, record-verified channel-loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.",
+      "description": "A consent-referenced, record-verified Agent Schedule occurrence or legacy Channel Loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.",
       "includes": [
         "auto-trade-consent:",
         "~/memory/auto-trade-consent.md",
         "one-read verification",
         "place live orders without per-order user confirmation",
         "missing or unreadable record",
-        "applies only to loop ticks",
+        "applies only to Agent Schedule occurrences",
+        "verified legacy Channel Loop ticks",
         "verification checks only that the consent record exists",
         "timestamp is provenance, not a match key",
         "is not a mismatch"
@@ -1384,11 +1385,49 @@
       "id": "target.auto-trade-consent-references",
       "group": "target",
       "target": "corpus",
-      "description": "The broker and trading references reconcile their per-order confirm lines with the loop-tick consent exemption instead of demanding unqualified confirmation.",
+      "description": "The broker and trading references reconcile their per-order confirm lines with the scheduled-occurrence consent exemption instead of demanding unqualified confirmation.",
       "includes": [
-        "consented auto-trading loop tick",
+        "consented auto-trading Schedule occurrence",
+        "legacy Channel Loop tick",
         "recorded consent",
         "stands in for this per-order confirmation"
+      ]
+    },
+    {
+      "id": "target.agent-schedule-lifecycle",
+      "group": "target",
+      "target": "corpus",
+      "description": "Future Channel Agent turns use named Schedules with explicit rule, bounds, lifecycle, and target defaults.",
+      "includes": [
+        "Future Channel Agent Turns",
+        "Agent Schedule | Create or resume a named future Channel Agent turn",
+        "alva schedule put",
+        "exactly one of `--after`, `--at`, `--every`, or `--cron`",
+        "omit `--channel-id` for the authenticated user's Agent Channel",
+        "put replaces the complete definition",
+        "alva schedule pause",
+        "alva schedule resume",
+        "alva schedule delete"
+      ]
+    },
+    {
+      "id": "target.legacy-loop-compatibility",
+      "group": "target",
+      "target": "corpus",
+      "description": "Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.",
+      "includes": [
+        "Legacy Channel Loop Compatibility",
+        "alva schedule list does not list legacy loops",
+        "older Toolkit versions may still accept",
+        "a Toolkit upgrade is required",
+        "alva automation list --status all --json",
+        "alva automation inspect --id <automation_id> --json",
+        "Channel loop:",
+        "~/loops/_runner/index.js",
+        "do not create new legacy loops",
+        "alva automation stop --id <automation_id>",
+        "alva automation resume --id <automation_id>",
+        "alva automation delete --id <automation_id>"
       ]
     }
   ]

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -1,12 +1,12 @@
 # alva-skill-doc-regression
 
-Source: `/Users/yimingchen/alva/mono-meta/.codex-worktrees/notification-delivery-aip/skills/skills/alva`
+Source: `/Users/yimingchen/alva/mono-meta/.codex-worktrees/alva-skills-agent-schedule/skills/alva`
 
 SKILL.md lines: 911
 
-Cases: 84/84
+Cases: 86/86
 
-Checks: 857/857 (100.00%)
+Checks: 880/880 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -249,7 +249,7 @@ Interactive orders keep the per-order confirmation rule: the exemption does not 
 
 ## target
 
-15/15 cases, 172/172 checks
+17/17 cases, 195/195 checks
 
 ### PASS target.automation-publish-side-effects
 
@@ -431,7 +431,7 @@ Operational pitfalls are a mandatory stepwise gate, not an optional debugging ap
 
 Latest mainline Alva skill updates remain integrated after rebasing the refactor.
 
-- [x] version: v1.21.2
+- [x] version: v1.21.4
 - [x] Capability Help
 - [x] Reply 1, 2, or 3 to start
 - [x] feedback
@@ -478,25 +478,58 @@ One-off price-series artifacts route to a pinned Lightweight Charts v5 reference
 
 ### PASS target.auto-trade-consent-exemption
 
-A consent-referenced, record-verified channel-loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.
+A consent-referenced, record-verified Agent Schedule occurrence or legacy Channel Loop tick is exempt from per-order confirmation while staying dry-run/intent-id/risk bound.
 
 - [x] auto-trade-consent:
 - [x] ~/memory/auto-trade-consent.md
 - [x] one-read verification
 - [x] place live orders without per-order user confirmation
 - [x] missing or unreadable record
-- [x] applies only to loop ticks
+- [x] applies only to Agent Schedule occurrences
+- [x] verified legacy Channel Loop ticks
 - [x] verification checks only that the consent record exists
 - [x] timestamp is provenance, not a match key
 - [x] is not a mismatch
 
 ### PASS target.auto-trade-consent-references
 
-The broker and trading references reconcile their per-order confirm lines with the loop-tick consent exemption instead of demanding unqualified confirmation.
+The broker and trading references reconcile their per-order confirm lines with the scheduled-occurrence consent exemption instead of demanding unqualified confirmation.
 
-- [x] consented auto-trading loop tick
+- [x] consented auto-trading Schedule occurrence
+- [x] legacy Channel Loop tick
 - [x] recorded consent
 - [x] stands in for this per-order confirmation
+
+### PASS target.agent-schedule-lifecycle
+
+Future Channel Agent turns use named Schedules with explicit rule, bounds, lifecycle, and target defaults.
+
+- [x] Future Channel Agent Turns
+- [x] Agent Schedule | Create or resume a named future Channel Agent turn
+- [x] alva schedule put
+- [x] exactly one of `--after`, `--at`, `--every`, or `--cron`
+- [x] omit `--channel-id` for the authenticated user's Agent Channel
+- [x] put replaces the complete definition
+- [x] alva schedule pause
+- [x] alva schedule resume
+- [x] alva schedule delete
+
+### PASS target.legacy-loop-compatibility
+
+Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.
+
+- [x] Legacy Channel Loop Compatibility
+- [x] alva schedule list does not list legacy loops
+- [x] older Toolkit versions may still accept
+- [x] a Toolkit upgrade is required
+- [x] alva automation list --status all --json
+- [x] alva automation inspect --id <automation_id> --json
+- [x] Channel loop:
+- [x] ~/loops/_runner/index.js
+- [x] do not create new legacy loops
+- [x] alva automation stop --id <automation_id>
+- [x] alva automation resume --id <automation_id>
+- [x] alva automation delete --id <automation_id>
 
 ## alerts
 

--- a/evals/alva-skill-docs/final-report.md
+++ b/evals/alva-skill-docs/final-report.md
@@ -2,11 +2,11 @@
 
 Source: `/Users/yimingchen/alva/mono-meta/.codex-worktrees/alva-skills-agent-schedule/skills/alva`
 
-SKILL.md lines: 911
+SKILL.md lines: 909
 
 Cases: 86/86
 
-Checks: 880/880 (100.00%)
+Checks: 884/884 (100.00%)
 
 ## Scoring Diagnosis
 
@@ -249,7 +249,7 @@ Interactive orders keep the per-order confirmation rule: the exemption does not 
 
 ## target
 
-17/17 cases, 195/195 checks
+17/17 cases, 199/199 checks
 
 ### PASS target.automation-publish-side-effects
 
@@ -265,7 +265,7 @@ Automation publish documents its owner binding and first-run side effects, inclu
 
 Top-level SKILL.md stays below the current guide ceiling without forcing a minimum size that would block future compression.
 
-- [x] line count <= 911 (actual 911)
+- [x] line count <= 911 (actual 909)
 
 ### PASS target.playbook-task-offload
 
@@ -509,7 +509,7 @@ Future Channel Agent turns use named Schedules with explicit rule, bounds, lifec
 - [x] alva schedule put
 - [x] exactly one of `--after`, `--at`, `--every`, or `--cron`
 - [x] omit `--channel-id` for the authenticated user's Agent Channel
-- [x] put replaces the complete definition
+- [x] `put` replaces the complete definition
 - [x] alva schedule pause
 - [x] alva schedule resume
 - [x] alva schedule delete
@@ -519,7 +519,8 @@ Future Channel Agent turns use named Schedules with explicit rule, bounds, lifec
 Legacy Channel loops remain manageable through their Automation lifecycle without recreating the retired loop command.
 
 - [x] Legacy Channel Loop Compatibility
-- [x] alva schedule list does not list legacy loops
+- [x] alva schedule list
+- [x] does not list legacy loops
 - [x] older Toolkit versions may still accept
 - [x] a Toolkit upgrade is required
 - [x] alva automation list --status all --json
@@ -530,6 +531,9 @@ Legacy Channel loops remain manageable through their Automation lifecycle withou
 - [x] alva automation stop --id <automation_id>
 - [x] alva automation resume --id <automation_id>
 - [x] alva automation delete --id <automation_id>
+- [x] stop the old Automation and verify it is quiescent before creating
+- [x] If quiescence cannot be confirmed, do not activate the replacement
+- [x] never run both
 
 ## alerts
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -246,21 +246,19 @@ orders require the trading surface, a dry run first, explicit user confirmation
 before non-dry-run execution, and [api/trading.md](references/api/trading.md).
 This per-order confirmation rule holds for any order placed in an ordinary
 conversation. *Exemption (scheduled occurrences only):* an Agent Schedule
-`--message` or verified legacy Channel Loop goal carrying `[auto-trade-consent: granted <ISO8601-UTC>
-record=~/memory/auto-trade-consent.md]` AND whose one-read verification finds the
-record MAY place live orders without per-order user confirmation, subject to
-dry-run validation, a fresh idempotent intent-id, and trex risk rules.
-Verification checks only that the consent record exists: the timestamp is provenance, not a match key, and a differing `granted_at` after re-grant is not a mismatch. A
-missing or unreadable record means NO live orders. This applies only to Agent Schedule occurrences and verified legacy Channel Loop ticks, never interactive; recurring schedules also require `--until` or `--max-occurrences`. See [agent-schedules.md](references/agent-schedules.md).
+`--message` or verified legacy Channel Loop goal carrying
+`[auto-trade-consent: granted <ISO8601-UTC>
+record=~/memory/auto-trade-consent.md]` AND whose one-read verification finds
+the record MAY place live orders without per-order user confirmation, subject
+to dry-run validation, a fresh idempotent intent-id, and trex risk rules.
+Verification checks only that the consent record exists: the timestamp is
+provenance, not a match key, and a differing `granted_at` after re-grant is not
+a mismatch. A missing or unreadable record means NO live orders. This applies
+only to Agent Schedule occurrences and verified legacy Channel Loop ticks,
+never interactive; recurring schedules also require `--until` or
+`--max-occurrences`. See [agent-schedules.md](references/agent-schedules.md).
 
 ## Capability Map
-
-The map is organized as one shared layer plus two decision trees. **Shared Data
-And Execution** is the common substrate: Data Skills, search, BYOD, `alva run`,
-jagent runtime, and provenance rules. **Financial Analysis / Ask Question** uses
-that layer for sourced chat answers. **Durable Artifacts / Playbook** uses that
-layer, then persists or publishes work through feeds, automations, signals,
-playbooks, or release flows. Choose the smallest tree that satisfies the verb.
 
 ### Shared Data And Execution Layer
 

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -39,6 +39,7 @@ The main objects are:
 | Data Skills        | 250+ structured Arrays endpoints for US and non-US equities, fundamentals (earnings, filings), options, crypto, macro, on-chain, semiconductor spot/contract prices, news, prediction markets, and indexed Twitter/X. | You need factual financial data.                                                                               |
 | Runtime script     | JavaScript executed inside Alva's V8/jagent runtime through `alva run` or cronjobs.                                                                          | You need computation, HTTP, ALFS, secrets, alpi, ONNX, or Feed SDK.                                            |
 | Feed               | The persistent data pipeline and identity (`feed_id`) that writes outputs to ALFS. `alva automation` is its product-facing lifecycle CLI; `alva deploy` cronjobs produce its data. | Data needs freshness, history, public reads, charts, release, or push.                                         |
+| Agent Schedule     | A named future or recurring instruction that creates durable turns for a Channel Agent.                                                                      | The user wants the Agent itself to return later, continue work, or repeat a judgment.                          |
 | Playbook           | A hosted investing app at `https://alva.ai/u/<username>/playbooks/<name>`.                                                                                   | The user wants a shareable dashboard, screener, thesis, what-if, or strategy surface.                          |
 | Skillhub blueprint | A catalog methodology addressed by `/use-skill:<username>/<name>` or discovered from a user skill/method reference.                                          | The user references a skill/method, or a task matches an official template family.                             |
 | Altra              | The Feed SDK trading engine for event-driven backtesting and signal feeds.                                                                                   | Any strategy, simulation, signal target, portfolio, order, equity curve, or rebalancing logic.                 |
@@ -244,16 +245,13 @@ not require UDFs.
 orders require the trading surface, a dry run first, explicit user confirmation
 before non-dry-run execution, and [api/trading.md](references/api/trading.md).
 This per-order confirmation rule holds for any order placed in an ordinary
-conversation. *Exemption (channel-loop ticks only):* a channel-loop tick whose
-loop `--goal` carries the consent reference line `[auto-trade-consent: granted
-<ISO8601-UTC> record=~/memory/auto-trade-consent.md]` AND whose one-read
-verification finds the consent record MAY place live orders without per-order
-user confirmation, subject to dry-run validation first, a fresh idempotent
-intent-id, and trex risk rules. Verification checks only that the consent record
-exists: the `granted` timestamp is provenance, not a match key; a `granted_at`
-differing after a re-grant is not a mismatch and must not refuse live orders. A
-missing or unreadable record is the only verification failure and means NO live
-orders; applies only to loop ticks, never interactive. Creation-side consent: see "Channel loops".
+conversation. *Exemption (scheduled occurrences only):* an Agent Schedule
+`--message` or verified legacy Channel Loop goal carrying `[auto-trade-consent: granted <ISO8601-UTC>
+record=~/memory/auto-trade-consent.md]` AND whose one-read verification finds the
+record MAY place live orders without per-order user confirmation, subject to
+dry-run validation, a fresh idempotent intent-id, and trex risk rules.
+Verification checks only that the consent record exists: the timestamp is provenance, not a match key, and a differing `granted_at` after re-grant is not a mismatch. A
+missing or unreadable record means NO live orders. This applies only to Agent Schedule occurrences and verified legacy Channel Loop ticks, never interactive; recurring schedules also require `--until` or `--max-occurrences`. See [agent-schedules.md](references/agent-schedules.md).
 
 ## Capability Map
 
@@ -753,6 +751,7 @@ text does not fully cover.
 | `fs`                 | ALFS reads/writes/grants/time-series suffixes and shared modules under `~/library`. Must read [api/filesystem.md](references/api/filesystem.md) for synth suffixes and grant gotchas. |
 | `run`                | Execute jagent JS. See [jagent-runtime.md](references/jagent-runtime.md).                                                                                                             |
 | `deploy`             | Cronjob lifecycle for producer scripts: schedule, args, trigger, run-status, runs, logs. See [deployment.md](references/deployment.md).                                               |
+| `schedule`           | Named future and recurring Channel Agent turns: list, put, pause, resume, delete. See [agent-schedules.md](references/agent-schedules.md).                                            |
 | `automation`         | Product-facing lifecycle and per-Automation delivery CLI (`delivery get/update` supports independent Alva and email destinations). Must read [feed-lifecycle.md](references/feed-lifecycle.md) and [push-notifications.md](references/push-notifications.md). |
 | `release`            | Playbook draft/release; the release reference also covers automation publish metadata extras. Must read [api/release.md](references/api/release.md).                                   |
 | `lint playbook`      | Design-system linter, same gate as release. See [design-contract.yaml](references/design-contract.yaml).                                                                              |
@@ -796,6 +795,7 @@ Use this index to open only the file needed for the current task.
 | [feed-sdk.md](references/feed-sdk.md)                                                 | Feed SDK API, schemas, time series, grouped records, upstreams, examples.                                                                     |
 | [altra-trading.md](references/altra-trading.md)                                       | Altra strategy engine, features, signals, tests, PIT compliance.                                                                              |
 | [alpi.md](references/alpi.md)                                                         | Scheduled LLM reasoning/tool-loop API and examples.                                                                                           |
+| [agent-schedules.md](references/agent-schedules.md)                                   | Named Channel Agent schedules, rule/bound contracts, lifecycle, and legacy Channel Loop compatibility.                                        |
 | [onnx.md](references/onnx.md)                                                         | ONNX artifact, inference, FeedAltra integration, release checks.                                                                              |
 | [deployment.md](references/deployment.md)                                             | Cronjob create/list/pause/resume/trigger/run-status/runs/run-logs.                                                                            |
 | [search.md](references/search.md)                                                     | `unified_search`, finance search, Twitter/X, Reddit, YouTube, web gotchas.                                                                    |

--- a/skills/alva/references/agent-schedules.md
+++ b/skills/alva/references/agent-schedules.md
@@ -1,0 +1,134 @@
+# Agent Schedules
+
+Agent Schedules create durable future turns for a Channel Agent. They do not
+execute an ALFS script. Use `alva deploy` when the occurrence must run a
+deterministic producer script; use `alva schedule` when it must ask the Agent to
+resume reasoning or judgment in a Channel.
+
+Run `alva schedule --help` before use. The active Toolkit contract is
+authoritative if these examples ever drift.
+
+During the cutover, older Toolkit versions may still accept
+`alva loop create` while not recognizing `alva schedule`. That old command
+creates the legacy Automation/Cronjob/runner resources described below; it is
+not an alias for an Agent Schedule. Do not use it for new work. If
+`alva schedule --help` is unavailable, a Toolkit upgrade is required before
+creating a new Schedule. Existing legacy Loops can still be managed with the
+Automation lifecycle commands in this reference.
+
+## Future Channel Agent Turns
+
+`put` creates or replaces a Schedule by its stable name:
+
+```bash
+alva schedule put \
+  --name market-open \
+  --message "Review the market open and report material changes" \
+  --cron "30 9 * * 1-5" \
+  --timezone America/New_York \
+  --until "2026-12-31T21:00:00Z"
+```
+
+Choose exactly one of `--after`, `--at`, `--every`, or `--cron`:
+
+```bash
+# One future turn, relative to the current request.
+alva schedule put --name follow-up --message "Recheck the filing" --after PT30M
+
+# One future turn at an absolute instant.
+alva schedule put --name earnings --message "Review released results" \
+  --at "2026-08-20T20:05:00Z"
+
+# Fixed-interval recurrence.
+alva schedule put --name thesis-check --message "Re-evaluate the thesis" \
+  --every PT6H --max-occurrences 8
+```
+
+Cron rules require an IANA `--timezone`. `--starts-at`, `--until`, and
+`--max-occurrences` are recurrence bounds and therefore apply only to `every`
+and `cron`; `at` and `after` do not accept them. Schedule-semantic timestamps
+and durations use whole seconds. Do not truncate or round a fractional input;
+ask for or construct a whole-second value. `after` is resolved from the time of
+each request, so a retry must send `--after` again rather than reuse a previously
+calculated timestamp.
+
+Omit `--channel-id` for the authenticated user's Agent Channel. Supply it only
+when the user explicitly selected another owned Channel. The engine persists
+and hands off each occurrence as a durable Channel turn; the CLI does not need
+to stay running.
+
+put replaces the complete definition for that name. Read the existing
+Schedule before changing one field, then send the intended complete rule,
+bounds, and message:
+
+```bash
+alva schedule list
+alva schedule pause --name market-open
+alva schedule resume --name market-open
+alva schedule delete --name market-open
+```
+
+Pause and resume affect future occurrences. Delete removes the named Schedule.
+Do not claim an occurrence ran merely because `put` succeeded; use the returned
+status, `nextFireAt`, and subsequent Channel turn as the relevant evidence.
+
+## Auto-Trading Consent
+
+Interactive orders still require explicit per-order confirmation. A scheduled
+auto-trading instruction may use the narrow exception in `SKILL.md` only when:
+
+1. the user explicitly grants it;
+2. the Schedule `--message` carries the canonical consent reference;
+3. each occurrence performs the required one-read record verification;
+4. the recurring Schedule is bounded by `--until` or `--max-occurrences`; and
+5. dry-run, fresh intent-id, and trex risk rules still pass.
+
+Do not copy consent from an old Loop or another Schedule during migration. A
+new Schedule needs the user's explicit consent-bearing message.
+
+## Legacy Channel Loop Compatibility
+
+Toolkit versions before the named Schedule cutover created a legacy Channel
+Loop as three existing resources:
+
+- an Automation whose description begins with `Channel loop:`;
+- a producer Cronjob pointing to `~/loops/_runner/index.js`; and
+- the shared runner file in ALFS.
+
+These rows are not Agent Schedules. `alva schedule list does not list legacy
+loops`, and replacing a legacy Loop with a same-named Schedule does not stop the
+old Cronjob. Do not create new legacy loops and do not recreate the retired
+`alva loop create` command in shell code.
+
+The removed Loop CLI is not required to manage existing rows. Inventory all
+statuses, inspect candidates as JSON, and confirm both the description and
+producer before mutation:
+
+```bash
+alva automation list --status all --json
+alva automation inspect --id <automation_id> --json
+alva deploy get --id <cronjob_id>
+```
+
+Only treat an Automation as a legacy Loop when the inspect result has the
+`Channel loop:` description and its producer path is
+`~/loops/_runner/index.js`. A `loop-` name alone is not proof.
+
+Use the normal Automation lifecycle for the existing Loop:
+
+```bash
+alva automation stop --id <automation_id>
+alva automation resume --id <automation_id>
+alva automation delete --id <automation_id>
+```
+
+Deletion removes the producer Cronjob best-effort. If cleanup matters, verify
+the returned result and confirm the former Cronjob no longer exists; do not
+delete the shared runner while any legacy Loop still references it.
+
+When the user explicitly requests migration, inspect and record the legacy
+goal, cadence, remaining bounds, target Channel, and consent state first. Create
+and verify the named Schedule, then stop the old Automation before its next
+tick so both systems cannot deliver the same occurrence. Delete the old
+Automation only after the user accepts the cutover. There is no automatic
+history, run-count, or in-flight-occurrence migration.

--- a/skills/alva/references/agent-schedules.md
+++ b/skills/alva/references/agent-schedules.md
@@ -45,19 +45,19 @@ alva schedule put --name thesis-check --message "Re-evaluate the thesis" \
 ```
 
 Cron rules require an IANA `--timezone`. `--starts-at`, `--until`, and
-`--max-occurrences` are recurrence bounds and therefore apply only to `every`
-and `cron`; `at` and `after` do not accept them. Schedule-semantic timestamps
-and durations use whole seconds. Do not truncate or round a fractional input;
-ask for or construct a whole-second value. `after` is resolved from the time of
-each request, so a retry must send `--after` again rather than reuse a previously
-calculated timestamp.
+`--max-occurrences` are recurrence bounds and therefore apply only to `--every`
+and `--cron`; `--at` and `--after` do not accept them. Schedule-semantic
+timestamps and durations use whole seconds. Do not truncate or round a
+fractional input; ask for or construct a whole-second value. `after` is resolved
+from the time of each request, so a retry must send `--after` again rather than
+reuse a previously calculated timestamp.
 
 Omit `--channel-id` for the authenticated user's Agent Channel. Supply it only
 when the user explicitly selected another owned Channel. The engine persists
 and hands off each occurrence as a durable Channel turn; the CLI does not need
 to stay running.
 
-put replaces the complete definition for that name. Read the existing
+`put` replaces the complete definition for that name. Read the existing
 Schedule before changing one field, then send the intended complete rule,
 bounds, and message:
 
@@ -95,8 +95,8 @@ Loop as three existing resources:
 - a producer Cronjob pointing to `~/loops/_runner/index.js`; and
 - the shared runner file in ALFS.
 
-These rows are not Agent Schedules. `alva schedule list does not list legacy
-loops`, and replacing a legacy Loop with a same-named Schedule does not stop the
+These rows are not Agent Schedules. `alva schedule list` does not list legacy
+loops, and replacing a legacy Loop with a same-named Schedule does not stop the
 old Cronjob. Do not create new legacy loops and do not recreate the retired
 `alva loop create` command in shell code.
 
@@ -122,13 +122,18 @@ alva automation resume --id <automation_id>
 alva automation delete --id <automation_id>
 ```
 
-Deletion removes the producer Cronjob best-effort. If cleanup matters, verify
-the returned result and confirm the former Cronjob no longer exists; do not
-delete the shared runner while any legacy Loop still references it.
+Deletion removes the producer Cronjob on a best-effort basis. If cleanup
+matters, verify the returned result and confirm the former Cronjob no longer
+exists; do not delete the shared runner while any legacy Loop still references
+it.
 
 When the user explicitly requests migration, inspect and record the legacy
-goal, cadence, remaining bounds, target Channel, and consent state first. Create
-and verify the named Schedule, then stop the old Automation before its next
-tick so both systems cannot deliver the same occurrence. Delete the old
-Automation only after the user accepts the cutover. There is no automatic
-history, run-count, or in-flight-occurrence migration.
+goal, cadence, remaining bounds, target Channel, producer id, and consent state.
+Then stop the old Automation and verify it is quiescent before creating the
+named Schedule: no future tick is admitted, and any already-admitted run has
+finished or failed. If quiescence cannot be confirmed, do not activate the
+replacement. After the new Schedule is created and verified, keep the old
+Automation stopped until the user accepts deletion. If Schedule creation is
+uncertain, list Schedules before deciding whether to resume the old Automation;
+never run both. There is no automatic history, run-count, or
+in-flight-occurrence migration.

--- a/skills/alva/references/api/broker.md
+++ b/skills/alva/references/api/broker.md
@@ -40,9 +40,9 @@ an `error`.
 `order place ... --dry-run` runs the full admission gate (ownership, price
 collar ~12%, daily budget/velocity/open-order limits) and returns
 `admitted:true` + the deterministic `clientOrderId` **without placing**.
-Confirm, then re-run without `--dry-run`. (For a consented auto-trading loop
-tick, the recorded consent per the SKILL.md trading rule stands in for this
-per-order confirmation.)
+Confirm, then re-run without `--dry-run`. (For a consented auto-trading
+Schedule occurrence or legacy Channel Loop tick, recorded consent per the
+SKILL.md rule stands in for this per-order confirmation.)
 
 ## Capabilities are per-venue — read them from describe
 

--- a/skills/alva/references/api/trading.md
+++ b/skills/alva/references/api/trading.md
@@ -39,9 +39,9 @@ alva trading execute \
 ## Operational rules
 
 - **Always dry-run first.** Show simulated orders and confirm before
-  re-running without `--dry-run`. For a consented auto-trading loop tick, the
-  recorded consent per the SKILL.md trading rule stands in for this per-order
-  confirmation.
+  re-running without `--dry-run`. For a consented auto-trading Schedule
+  occurrence or legacy Channel Loop tick, recorded consent per the SKILL.md
+  rule stands in for this per-order confirmation.
 - **One active subscription per account.** `alva trading subscribe`
   fails until you `unsubscribe` the existing one.
 - `--execute-latest` on subscribe fires the playbook's last signal

--- a/skills/alva/references/request-routing.md
+++ b/skills/alva/references/request-routing.md
@@ -14,8 +14,9 @@ Decision order:
 1. If the user wants an explanation, comparison, valuation, rank, or current
    market fact in chat, route to Financial Analysis / Ask Question.
 2. If the user wants persistence, cadence, alerting, trading signals, or a
-   reusable dataset, route to the durable artifact that fits, not automatically
-   to a playbook.
+   reusable dataset, route to the durable artifact that fits: Agent Schedule
+   for a future Agent turn, Automation for a feed/script pipeline, not
+   automatically to a playbook.
 3. If the user wants a hosted app, share URL, remix, annotation edit, release,
    or playbook version update, enter the Playbook Creation tree.
 
@@ -26,6 +27,7 @@ Decision order:
 | Financial Analysis / Ask Question | Answer market, asset, portfolio, valuation, comparison, single-ticker, and "why" questions with fresh data/search/`alva run` evidence. A named-ticker question — including company narrative, earnings, or earnings call questions — first opens [ticker-read.md](ticker-read.md). Comparison baselines are figures too: fetch or qualify them. Every answer must read [user-facing-prose.md](user-facing-prose.md), apply its required Investment Disclaimer, then pass the ask evidence gate. |
 | Playbook Creation | Build, remix, edit, release, or update a hosted/shareable playbook. Read [playbook-creation.md](playbook-creation.md) for the subroute tree and gates. |
 | Strategy / Trading Analysis | Use Altra for backtests, signals, portfolio simulation, rebalancing, or trading analysis; deliver an answer, feed, signal, or playbook as requested. Strategy answers apply the required [Investment Disclaimer](user-facing-prose.md#investment-disclaimer). |
+| Agent Schedule | Create or resume a named future Channel Agent turn. Read [agent-schedules.md](agent-schedules.md); use `schedule` for Agent instructions and `deploy` for scripts. |
 | Automation / Push | Read [alva-knowledge.md](alva-knowledge.md) before design, build or modify a feed that declares actionable outputs with `alertOutput(typeDoc)`, then verify publisher, subscription, and delivery paths. |
 | Debug / Edit | Inspect existing code, logs, playbook source, feed output, or annotations, then change the generator rather than rendered values. |
 | Capability Verification | Verify Data Skills, Skillhub, runtime, trading, or search coverage before saying Alva lacks a capability. |


### PR DESCRIPTION
## Summary
- route future Channel Agent turns to the named `alva schedule` lifecycle and distinguish them from script-producing Cronjobs
- document rule, bound, whole-second, target, replacement, and delivery-evidence contracts
- preserve short-term management of legacy Channel Loops through their existing Automation and producer Cronjob resources
- migrate the scheduled auto-trading consent wording without dropping already-running verified legacy Loop ticks
- add deterministic doc eval coverage for Schedule lifecycle and legacy compatibility

## Breaking Changes
The skill no longer recommends `alva loop create` for new work. Toolkit versions that still expose it create legacy Automation/Cronjob/runner resources, not Agent Schedules. Existing legacy Loops remain manageable through `alva automation` and `alva deploy`.

## Database Migrations
None.

## Merge Order
Toolkit PR alva-ai/toolkit-ts#155 is merged. A Toolkit release containing it must be available before this skill update is promoted to users; the reference fails closed with an upgrade instruction when `alva schedule --help` is unavailable.

## Related PRs
- alva-ai/toolkit-ts#155

## Verification
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` — 86/86 cases, 878/878 checks
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` — 18/18 mutations failed as expected
- `bash skills/alva/scripts/version_check.sh`
- `git diff --check`
- lint skipped: repository has no `Makefile` / `make lint-fix` target
