### PR TITLE
docs(alva): require canonical Arrays symbols

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -291,8 +291,11 @@
             "Never invent or assemble an Altra symbol from a ticker",
             "alva run --code",
             "/api/v1/market/trading-pairs?symbol=",
-            "candidates.slice(0, 20)",
-            "Never select the first unfiltered response",
+            "candidatesByPair.set(candidate.tradingPair, candidate)",
+            "candidates.length !== 1",
+            "exact `matchedSymbol`",
+            "exactly one unique `tradingPair`",
+            "opaque canonical identity",
             "pass it to Altra unchanged",
             "bounded smoke window",
             "at least one real OHLCV bar"
@@ -1310,7 +1313,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.21.4",
+        "version: v1.22.0",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -362,7 +362,9 @@
           "alva run --code",
           "NASDAQ:RKLB",
           "US_SPOT_RKLB_USD",
-          "Never select the first unfiltered response",
+          "exact `matchedSymbol`",
+          "exactly one unique `tradingPair`",
+          "opaque canonical identity",
           "pass it to Altra unchanged",
           "bounded smoke window",
           "at least one real OHLCV bar"
@@ -373,7 +375,8 @@
             "heading": "Resolve Trading Pairs Before Backtesting",
             "includes": [
               "/api/v1/market/trading-pairs?symbol=",
-              "candidates.slice(0, 20)",
+              "candidatesByPair.set(candidate.tradingPair, candidate)",
+              "candidates.length !== 1",
               "Exclude options unless the user explicitly asks"
             ]
           }

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -311,7 +311,7 @@ alva run --code '(async () => {
     market: String(args.market || "").toUpperCase(),
     quote: String(args.quote || "").toUpperCase(),
   };
-  const candidates = [];
+  const candidatesByPair = new Map();
   for (const match of body.data || []) {
     for (const group of match.trading_pairs || []) {
       for (const pair of group.pairs || []) {
@@ -328,31 +328,44 @@ alva run --code '(async () => {
         if (wanted.underlyingType && String(candidate.underlyingType).toUpperCase() !== wanted.underlyingType) continue;
         if (wanted.market && String(candidate.market).toUpperCase() !== wanted.market) continue;
         if (wanted.quote && String(candidate.quote).toUpperCase() !== wanted.quote) continue;
-        candidates.push(candidate);
+        if (String(candidate.matchedSymbol).toUpperCase() !== query) continue;
+        candidatesByPair.set(candidate.tradingPair, candidate);
       }
     }
   }
-  return {
-    query,
-    candidates: candidates.slice(0, 20),
-    truncated: candidates.length > 20,
-  };
+  const candidates = Array.from(candidatesByPair.values());
+  if (candidates.length !== 1) {
+    throw new Error(
+      "expected exactly one canonical trading pair for " + query +
+      ", received " + candidates.length,
+    );
+  }
+  return { query, ...candidates[0] };
 })();' --args '{"query":"RKLB","instrument_type":"spot","underlying_type":"stock","market":"US","quote":"USD"}'
 ```
+
+For an ETF such as SPY, use the same lookup with `"underlying_type":"etf"`; its
+canonical pair is still `US_SPOT_SPY_USD`.
 
 Selection rules:
 
 - Treat a prefix such as `NASDAQ:` or `XNAS:` as an intent hint. Search Arrays
   with the base ticker and use the returned `tradingPair`; for example,
   `NASDAQ:RKLB` resolves through `RKLB` to `US_SPOT_RKLB_USD`.
-- For US equities, filter to `spot` + `stock` + `US` + `USD`. For crypto,
-  filter `spot` or `perp` and the requested venue and quote.
+- For US stocks, filter to `spot` + `stock` + `US` + `USD`. For US ETFs, filter
+  to `spot` + `etf` + `US` + `USD`; both resolve to canonical
+  `US_SPOT_<TICKER>_USD` pairs. For crypto, filter `spot` or `perp` and the
+  requested venue and quote.
 - Exclude options unless the user explicitly asks for an option contract.
-- Prefer an exact `matchedSymbol`. Never select the first unfiltered response.
-  If multiple filtered candidates still match the user's intent, ask one
-  blocking question instead of guessing.
+- Require an exact `matchedSymbol` and exactly one unique `tradingPair`. Never
+  select the first response. If zero or multiple filtered candidates match the
+  user's intent, ask one blocking question instead of guessing.
 - Stop when the lookup errors or returns no eligible candidate. Do not silently
   fall back to an invented symbol.
+- Treat the returned `tradingPair` as an opaque canonical identity. Preserve its
+  case and spelling unchanged in OHLCV registration, targets, positions, and
+  orders. Do not convert `US` back to `XNAS`/`XNYS`, use `_ETF_` for ETFs, or
+  replace `PERP` with `FUTURES`.
 
 The lookup proves naming and catalog membership, not OHLCV availability. Before
 the full-range backtest, run Altra with the selected symbol over a bounded smoke
@@ -450,7 +463,7 @@ const altra = new FeedAltra(
 );
 
 dg.registerOhlcv("BINANCE_SPOT_BTC_USDT", "1d");
-dg.registerOhlcv("XNAS_SPOT_AAPL_USD", "1d");
+dg.registerOhlcv("US_SPOT_AAPL_USD", "1d");
 await altra.run(endDate);
 ```
 
@@ -647,7 +660,7 @@ e.raw("sentiment_score"); // Raw data update
 e.feature("rsi"); // Feature computed
 
 e.all(
-  e.ohlcv("XNAS_SPOT_AAPL_USD", "1d"),
+  e.ohlcv("US_SPOT_AAPL_USD", "1d"),
   e.ohlcv("BINANCE_SPOT_BTC_USDT", "1d"),
 ); // AND
 e.any(e.ohlcv("BINANCE_SPOT_BTC_USDT", "1h"), e.raw("funding")); // OR

--- a/skills/alva/references/api/trading.md
+++ b/skills/alva/references/api/trading.md
@@ -14,7 +14,12 @@ exchange field. Mismatching symbol type to account exchange errors.
 | `binance_spot` | Spot        | `BINANCE_SPOT_BTC_USDT`          |
 | `okx`          | Unified     | `OKX_PERP_*` / `OKX_SPOT_*`      |
 | `hyperliquid`  | Unified     | `HYPERLIQUID_PERP_*` / `_SPOT_*` |
-| `alpaca`       | US Equities | `XNAS_SPOT_AAPL_USD`             |
+| `alpaca`       | US Equities | `US_SPOT_AAPL_USD`               |
+
+Symbols are canonical Arrays identities, not exchange aliases. Resolve them
+through Trading Pair Search and use the returned `tradingPair` unchanged;
+`XNAS_SPOT_AAPL_USD`, `US_ETF_SPY_USD`, lowercase variants, and
+`BINANCE_FUTURES_BTC_USDT` are invalid inputs.
 
 ## `--signal` JSON schema for `alva trading execute`
 


### PR DESCRIPTION
## Summary

- require agents to resolve ticker intent through Arrays Trading Pair Search before backtesting
- filter by instrument, underlying type, market, and quote, then require an exact `matchedSymbol`
- deduplicate by `tradingPair` and require exactly one unique result
- pass the returned `tradingPair` unchanged through OHLCV registration, targets, positions, and orders
- document canonical ETF naming and replace active XNAS examples with US symbols

## Companion change

Depends on alva-ai/backtest-js#412 for Altra-side strict validation. Roll out the Altra change first so any remaining alias input fails closed.

## Validation

Real Arrays calls through the documented `alva run` flow returned:

- RKLB stock/spot/US/USD -> `US_SPOT_RKLB_USD`
- SPY ETF/spot/US/USD -> `US_SPOT_SPY_USD`

Both searches produced exactly one unique canonical pair.

- `git diff --check`