### PR TITLE
docs(alva): use trading-pairs CLI for canonical symbol resolution

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -282,20 +282,25 @@
       "id": "target.altra-symbol-resolution",
       "group": "target",
       "target": "corpus",
-      "description": "Altra resolves Arrays trading pairs through the existing runtime, filters ambiguous matches, and proves OHLCV availability before a full backtest.",
+      "description": "The Agent resolves Arrays trading pairs through the Alva CLI, filters ambiguous matches, and proves OHLCV availability before a full backtest.",
       "section_includes": [
         {
           "file": "references/altra-trading.md",
           "heading": "Resolve Trading Pairs Before Backtesting",
           "includes": [
             "Never invent or assemble an Altra symbol from a ticker",
-            "resolveTradingPair",
-            "@alva/feed",
-            "resolved.tradingPair",
-            "exact `matchedSymbol`",
+            "alva trading-pairs search",
+            "alva trading-pairs resolve",
+            "--market US",
+            "--quote USD",
+            "--json",
+            "tradingPair",
+            "exact ticker match",
             "exactly one unique `tradingPair`",
             "opaque canonical identity",
-            "pass it to Altra unchanged",
+            "Use its `tradingPair` value verbatim as the symbol",
+            "For an existing position or strategy target",
+            "Resolve only new user-entered assets",
             "bounded smoke window",
             "at least one real OHLCV bar"
           ]

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -282,7 +282,7 @@
       "id": "target.altra-symbol-resolution",
       "group": "target",
       "target": "corpus",
-      "description": "The Agent resolves Arrays trading pairs through the Alva CLI, filters ambiguous matches, and proves OHLCV availability before a full backtest.",
+      "description": "The Agent resolves trading pairs through the Alva CLI, stops on ambiguity, and proves OHLCV availability before a full backtest.",
       "section_includes": [
         {
           "file": "references/altra-trading.md",
@@ -295,9 +295,7 @@
             "--quote USD",
             "--json",
             "tradingPair",
-            "exact ticker match",
-            "exactly one unique `tradingPair`",
-            "opaque canonical identity",
+            "If zero or multiple candidates remain, ask the user",
             "Use its `tradingPair` value verbatim as the symbol",
             "For an existing position or strategy target",
             "Resolve only new user-entered assets",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -289,10 +289,9 @@
           "heading": "Resolve Trading Pairs Before Backtesting",
           "includes": [
             "Never invent or assemble an Altra symbol from a ticker",
-            "alva run --code",
-            "/api/v1/market/trading-pairs?symbol=",
-            "candidatesByPair.set(candidate.tradingPair, candidate)",
-            "candidates.length !== 1",
+            "resolveTradingPair",
+            "@alva/feed",
+            "resolved.tradingPair",
             "exact `matchedSymbol`",
             "exactly one unique `tradingPair`",
             "opaque canonical identity",

--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -282,23 +282,14 @@
       "id": "target.altra-symbol-resolution",
       "group": "target",
       "target": "corpus",
-      "description": "The Agent resolves trading pairs through the Alva CLI, stops on ambiguity, and proves OHLCV availability before a full backtest.",
+      "description": "The Agent uses the trading-pairs CLI and proves OHLCV availability before a full backtest.",
       "section_includes": [
         {
           "file": "references/altra-trading.md",
           "heading": "Resolve Trading Pairs Before Backtesting",
           "includes": [
-            "Never invent or assemble an Altra symbol from a ticker",
-            "alva trading-pairs search",
-            "alva trading-pairs resolve",
-            "--market US",
-            "--quote USD",
-            "--json",
-            "tradingPair",
-            "If zero or multiple candidates remain, ask the user",
-            "Use its `tradingPair` value verbatim as the symbol",
-            "For an existing position or strategy target",
-            "Resolve only new user-entered assets",
+            "alva trading-pairs",
+            "alva trading-pairs --help",
             "bounded smoke window",
             "at least one real OHLCV bar"
           ]

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -34,9 +34,11 @@ const MUTATIONS = [
     file: "references/altra-trading.md",
     remove:
       "Never invent or assemble an Altra symbol from a ticker. Resolve the exact\n" +
-      "`trading_pair` from Arrays before writing the strategy, then pass it to Altra\n" +
-      "unchanged. Use the existing `alva run` surface; no dedicated trading-pair CLI\n" +
-      "command is required.\n",
+      "canonical pair through `resolveTradingPair` before writing the strategy, then\n" +
+      "pass `resolved.tradingPair` to Altra unchanged. Pass it to Altra unchanged in\n" +
+      "OHLCV registration, targets, positions, and orders. The helper owns the Arrays\n" +
+      "request, filtering, exact ticker match, deduplication, and unique-result check;\n" +
+      "no dedicated trading-pair CLI command or inline HTTP is required.\n",
     expectFailedCases: [
       "target.altra-symbol-resolution",
       "scenario.backtest-symbol-resolution",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -35,9 +35,8 @@ const MUTATIONS = [
     remove:
       "Never invent or assemble an Altra symbol from a ticker. Resolve the exact\n" +
       "canonical pair with the `alva trading-pairs` CLI before writing the strategy.\n" +
-      "The CLI owns the catalog request, filtering, exact ticker match, deduplication,\n" +
-      "and unique-result check. Do not call the Arrays endpoint directly, load\n" +
-      "`ARRAYS_JWT` in the Agent, or assemble an alias in strategy code.\n",
+      "Do not call the Arrays trading-pair endpoint directly, load `ARRAYS_JWT` in the\n" +
+      "Agent for this lookup, or assemble an alias in strategy code.\n",
     expectFailedCases: [
       "target.altra-symbol-resolution",
       "scenario.backtest-symbol-resolution",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -34,11 +34,10 @@ const MUTATIONS = [
     file: "references/altra-trading.md",
     remove:
       "Never invent or assemble an Altra symbol from a ticker. Resolve the exact\n" +
-      "canonical pair through `resolveTradingPair` before writing the strategy, then\n" +
-      "pass `resolved.tradingPair` to Altra unchanged. Pass it to Altra unchanged in\n" +
-      "OHLCV registration, targets, positions, and orders. The helper owns the Arrays\n" +
-      "request, filtering, exact ticker match, deduplication, and unique-result check;\n" +
-      "no dedicated trading-pair CLI command or inline HTTP is required.\n",
+      "canonical pair with the `alva trading-pairs` CLI before writing the strategy.\n" +
+      "The CLI owns the catalog request, filtering, exact ticker match, deduplication,\n" +
+      "and unique-result check. Do not call the Arrays endpoint directly, load\n" +
+      "`ARRAYS_JWT` in the Agent, or assemble an alias in strategy code.\n",
     expectFailedCases: [
       "target.altra-symbol-resolution",
       "scenario.backtest-symbol-resolution",

--- a/evals/alva-skill-docs/mutation-smoke.mjs
+++ b/evals/alva-skill-docs/mutation-smoke.mjs
@@ -33,10 +33,8 @@ const MUTATIONS = [
     id: "altra-symbol-resolution",
     file: "references/altra-trading.md",
     remove:
-      "Never invent or assemble an Altra symbol from a ticker. Resolve the exact\n" +
-      "canonical pair with the `alva trading-pairs` CLI before writing the strategy.\n" +
-      "Do not call the Arrays trading-pair endpoint directly, load `ARRAYS_JWT` in the\n" +
-      "Agent for this lookup, or assemble an alias in strategy code.\n",
+      "Use the `alva trading-pairs` CLI to resolve trading pairs before writing a\n" +
+      "strategy. Run `alva trading-pairs --help` for its search and resolve commands.\n",
     expectFailedCases: [
       "target.altra-symbol-resolution",
       "scenario.backtest-symbol-resolution",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -351,7 +351,7 @@
       "id": "scenario.backtest-symbol-resolution",
       "group": "scenarios.strategy",
       "prompt": "Backtest a weekly momentum strategy for NASDAQ:RKLB.",
-      "description": "A stock backtest resolves an Arrays trading pair without a new CLI command, avoids ambiguous raw ordering, and verifies real OHLCV before the full run.",
+      "description": "A stock backtest resolves an Arrays trading pair through the CLI, avoids ambiguous raw ordering, and verifies real OHLCV before the full run.",
       "expect": {
         "route": "Strategy / Trading Analysis",
         "references": [
@@ -359,14 +359,19 @@
         ],
         "behaviors": [
           "Never invent or assemble an Altra symbol from a ticker",
-          "resolveTradingPair",
-          "@alva/feed",
+          "alva trading-pairs search",
+          "alva trading-pairs resolve",
+          "--market US",
+          "--quote USD",
+          "--json",
           "NASDAQ:RKLB",
           "US_SPOT_RKLB_USD",
-          "exact `matchedSymbol`",
+          "exact ticker match",
           "exactly one unique `tradingPair`",
           "opaque canonical identity",
-          "pass it to Altra unchanged",
+          "Use its `tradingPair` value verbatim as the symbol",
+          "For an existing position or strategy target",
+          "Resolve only new user-entered assets",
           "bounded smoke window",
           "at least one real OHLCV bar"
         ],
@@ -375,9 +380,12 @@
             "file": "references/altra-trading.md",
             "heading": "Resolve Trading Pairs Before Backtesting",
             "includes": [
-              "resolveTradingPair",
-              "@alva/feed",
-              "resolved.tradingPair",
+              "alva trading-pairs search",
+              "alva trading-pairs resolve",
+              "--market US",
+              "--quote USD",
+              "--json",
+              "tradingPair",
               "Exclude options unless the user explicitly asks"
             ]
           }

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -351,7 +351,7 @@
       "id": "scenario.backtest-symbol-resolution",
       "group": "scenarios.strategy",
       "prompt": "Backtest a weekly momentum strategy for NASDAQ:RKLB.",
-      "description": "A stock backtest resolves an Arrays trading pair through the CLI, avoids ambiguous raw ordering, and verifies real OHLCV before the full run.",
+      "description": "A stock backtest resolves a trading pair through the CLI, stops on ambiguity, and verifies real OHLCV before the full run.",
       "expect": {
         "route": "Strategy / Trading Analysis",
         "references": [
@@ -366,9 +366,7 @@
           "--json",
           "NASDAQ:RKLB",
           "US_SPOT_RKLB_USD",
-          "exact ticker match",
-          "exactly one unique `tradingPair`",
-          "opaque canonical identity",
+          "If zero or multiple candidates remain, ask the user",
           "Use its `tradingPair` value verbatim as the symbol",
           "For an existing position or strategy target",
           "Resolve only new user-entered assets",
@@ -386,7 +384,7 @@
               "--quote USD",
               "--json",
               "tradingPair",
-              "Exclude options unless the user explicitly asks"
+              "Exclude options unless the user explicitly requests an option contract"
             ]
           }
         ]

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -359,7 +359,8 @@
         ],
         "behaviors": [
           "Never invent or assemble an Altra symbol from a ticker",
-          "alva run --code",
+          "resolveTradingPair",
+          "@alva/feed",
           "NASDAQ:RKLB",
           "US_SPOT_RKLB_USD",
           "exact `matchedSymbol`",
@@ -374,9 +375,9 @@
             "file": "references/altra-trading.md",
             "heading": "Resolve Trading Pairs Before Backtesting",
             "includes": [
-              "/api/v1/market/trading-pairs?symbol=",
-              "candidatesByPair.set(candidate.tradingPair, candidate)",
-              "candidates.length !== 1",
+              "resolveTradingPair",
+              "@alva/feed",
+              "resolved.tradingPair",
               "Exclude options unless the user explicitly asks"
             ]
           }

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -351,25 +351,15 @@
       "id": "scenario.backtest-symbol-resolution",
       "group": "scenarios.strategy",
       "prompt": "Backtest a weekly momentum strategy for NASDAQ:RKLB.",
-      "description": "A stock backtest resolves a trading pair through the CLI, stops on ambiguity, and verifies real OHLCV before the full run.",
+      "description": "A stock backtest uses the trading-pairs CLI and verifies real OHLCV before the full run.",
       "expect": {
         "route": "Strategy / Trading Analysis",
         "references": [
           "altra-trading.md"
         ],
         "behaviors": [
-          "Never invent or assemble an Altra symbol from a ticker",
-          "alva trading-pairs search",
-          "alva trading-pairs resolve",
-          "--market US",
-          "--quote USD",
-          "--json",
-          "NASDAQ:RKLB",
-          "US_SPOT_RKLB_USD",
-          "If zero or multiple candidates remain, ask the user",
-          "Use its `tradingPair` value verbatim as the symbol",
-          "For an existing position or strategy target",
-          "Resolve only new user-entered assets",
+          "alva trading-pairs",
+          "alva trading-pairs --help",
           "bounded smoke window",
           "at least one real OHLCV bar"
         ],
@@ -378,13 +368,8 @@
             "file": "references/altra-trading.md",
             "heading": "Resolve Trading Pairs Before Backtesting",
             "includes": [
-              "alva trading-pairs search",
-              "alva trading-pairs resolve",
-              "--market US",
-              "--quote USD",
-              "--json",
-              "tradingPair",
-              "Exclude options unless the user explicitly requests an option contract"
+              "alva trading-pairs",
+              "alva trading-pairs --help"
             ]
           }
         ]

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -254,7 +254,6 @@ const { FeedAltra, e, Amount, TIME, allocate, order, orders } = FeedAltraModule;
 | `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level) | Field type helpers (same as Feed SDK)            |
 | `makeDoc`                                 | `@alva/feed` (top level) | Type document helper                             |
 | `createArraysOhlcvProvider`               | `@alva/feed` (top level) | Builds the OHLCV provider used by Altra          |
-| `resolveTradingPair`                      | `@alva/feed` (top level) | Resolves one canonical Arrays trading pair      |
 
 ---
 
@@ -276,49 +275,67 @@ const altra = new FeedAltra(config, ohlcvProvider);
 ### Resolve Trading Pairs Before Backtesting
 
 Never invent or assemble an Altra symbol from a ticker. Resolve the exact
-canonical pair through `resolveTradingPair` before writing the strategy, then
-pass `resolved.tradingPair` to Altra unchanged. Pass it to Altra unchanged in
-OHLCV registration, targets, positions, and orders. The helper owns the Arrays
-request, filtering, exact ticker match, deduplication, and unique-result check;
-no dedicated trading-pair CLI command or inline HTTP is required.
+canonical pair with the `alva trading-pairs` CLI before writing the strategy.
+The CLI owns the catalog request, filtering, exact ticker match, deduplication,
+and unique-result check. Do not call the Arrays endpoint directly, load
+`ARRAYS_JWT` in the Agent, or assemble an alias in strategy code.
 
-```javascript
-const { resolveTradingPair } = require("@alva/feed");
-const secret = require("secret-manager");
+First search for candidates. Use the user's base ticker; if the input includes
+an exchange prefix such as `NASDAQ:RKLB`, retain that prefix as an intent hint
+but query `RKLB` and add the appropriate market filter.
 
-const resolved = await resolveTradingPair({
-  query: "NASDAQ:RKLB",
-  instrumentType: "spot",
-  underlyingType: "stock",
-  market: "US",
-  quote: "USD",
-  jwt: secret.loadPlaintext("ARRAYS_JWT"),
-});
-const pair = resolved.tradingPair; // "US_SPOT_RKLB_USD"
+```bash
+alva trading-pairs search \
+  --symbol RKLB \
+  --market US \
+  --instrument-type spot \
+  --quote USD \
+  --json
 ```
 
-For an ETF such as SPY, use the same lookup with `"underlyingType":"etf"`; its
-canonical pair is still `US_SPOT_SPY_USD`.
+The search result is a candidate list. Multiple candidates are normal: narrow
+the filters when the user's intent supplies a venue, instrument, or quote; if
+more than one eligible pair remains, ask the user instead of choosing by array
+order. If no candidate remains, stop and ask for a clearer ticker or intent.
+
+After selecting a candidate, verify the complete identity before writing code
+or sending an order:
+
+```bash
+alva trading-pairs resolve --pair US_SPOT_RKLB_USD --json
+```
+
+The resolve command must return exactly one candidate. Use its
+`tradingPair` value verbatim as the symbol in OHLCV registration, targets,
+positions, and orders. For an ETF such as SPY, search with
+`--market US --instrument-type spot --quote USD`; its canonical pair is still
+`US_SPOT_SPY_USD`. Add `--underlying-type etf` only when the response includes
+that metadata.
 
 Selection rules:
 
 - Treat a prefix such as `NASDAQ:` or `XNAS:` as an intent hint. Search Arrays
   with the base ticker and use the returned `tradingPair`; for example,
   `NASDAQ:RKLB` resolves through `RKLB` to `US_SPOT_RKLB_USD`.
-- For US stocks, filter to `spot` + `stock` + `US` + `USD`. For US ETFs, filter
-  to `spot` + `etf` + `US` + `USD`; both resolve to canonical
-  `US_SPOT_<TICKER>_USD` pairs. For crypto, filter `spot` or `perp` and the
-  requested venue and quote.
+- For US stocks and ETFs, filter to `spot` + `US` + `USD`; both resolve to
+  canonical `US_SPOT_<TICKER>_USD` pairs. Add `--underlying-type stock` or
+  `--underlying-type etf` only when the CLI response includes that metadata;
+  older Gateway responses may omit it. For crypto, filter `spot` or `perp` and
+  the requested venue and quote.
 - Exclude options unless the user explicitly asks for an option contract.
-- Require an exact `matchedSymbol` and exactly one unique `tradingPair`. Never
-  select the first response. If zero or multiple filtered candidates match the
-  user's intent, ask one blocking question instead of guessing.
+- Require an exact ticker match and exactly one unique `tradingPair` at resolve
+  time. Never select the first response. If zero or multiple filtered
+  candidates match the user's intent, ask one blocking question instead of
+  guessing.
 - Stop when the lookup errors or returns no eligible candidate. Do not silently
   fall back to an invented symbol.
-- Treat the returned `tradingPair` as an opaque canonical identity. Preserve its
+- Treat the CLI's returned `tradingPair` as an opaque canonical identity. Preserve its
   case and spelling unchanged in OHLCV registration, targets, positions, and
   orders. Do not convert `US` back to `XNAS`/`XNYS`, use `_ETF_` for ETFs, or
   replace `PERP` with `FUTURES`.
+- For an existing position or strategy target, preserve the stored complete
+  `tradingPair`; do not resolve its ticker again and replace it with a newer
+  catalog result. Resolve only new user-entered assets.
 
 The lookup proves naming and catalog membership, not OHLCV availability. Before
 the full-range backtest, run Altra with the selected symbol over a bounded smoke

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -297,7 +297,7 @@ const resolved = await resolveTradingPair({
 const pair = resolved.tradingPair; // "US_SPOT_RKLB_USD"
 ```
 
-For an ETF such as SPY, use the same lookup with `"underlying_type":"etf"`; its
+For an ETF such as SPY, use the same lookup with `"underlyingType":"etf"`; its
 canonical pair is still `US_SPOT_SPY_USD`.
 
 Selection rules:

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -274,43 +274,8 @@ const altra = new FeedAltra(config, ohlcvProvider);
 
 ### Resolve Trading Pairs Before Backtesting
 
-Never invent or assemble an Altra symbol from a ticker. Resolve the exact
-canonical pair with the `alva trading-pairs` CLI before writing the strategy.
-Do not call the Arrays trading-pair endpoint directly, load `ARRAYS_JWT` in the
-Agent for this lookup, or assemble an alias in strategy code.
-
-First search for candidates. Use the user's base ticker; if the input includes
-an exchange prefix such as `NASDAQ:RKLB`, retain that prefix as an intent hint
-but query `RKLB` and add the appropriate market filter.
-
-```bash
-alva trading-pairs search \
-  --symbol RKLB \
-  --market US \
-  --instrument-type spot \
-  --quote USD \
-  --json
-```
-
-Search returns candidates. Narrow the filters using the user's venue, instrument,
-and quote intent. If zero or multiple candidates remain, ask the user; never
-choose the first result. Exclude options unless the user explicitly requests an
-option contract.
-
-After selecting a candidate, verify the complete identity before writing code
-or sending an order:
-
-```bash
-alva trading-pairs resolve --pair US_SPOT_RKLB_USD --json
-```
-
-Use its `tradingPair` value verbatim as the symbol in OHLCV
-registration, targets, positions, and orders. For US stocks and ETFs, use
-`--market US --instrument-type spot --quote USD`; for crypto, provide the
-requested venue, instrument, and quote.
-
-For an existing position or strategy target, preserve its stored complete
-`tradingPair`; resolve only new user-entered assets.
+Use the `alva trading-pairs` CLI to resolve trading pairs before writing a
+strategy. Run `alva trading-pairs --help` for its search and resolve commands.
 
 The lookup proves naming and catalog membership, not OHLCV availability. Before
 the full-range backtest, run Altra with the selected symbol over a bounded smoke

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -276,9 +276,8 @@ const altra = new FeedAltra(config, ohlcvProvider);
 
 Never invent or assemble an Altra symbol from a ticker. Resolve the exact
 canonical pair with the `alva trading-pairs` CLI before writing the strategy.
-The CLI owns the catalog request, filtering, exact ticker match, deduplication,
-and unique-result check. Do not call the Arrays endpoint directly, load
-`ARRAYS_JWT` in the Agent, or assemble an alias in strategy code.
+Do not call the Arrays trading-pair endpoint directly, load `ARRAYS_JWT` in the
+Agent for this lookup, or assemble an alias in strategy code.
 
 First search for candidates. Use the user's base ticker; if the input includes
 an exchange prefix such as `NASDAQ:RKLB`, retain that prefix as an intent hint
@@ -293,10 +292,10 @@ alva trading-pairs search \
   --json
 ```
 
-The search result is a candidate list. Multiple candidates are normal: narrow
-the filters when the user's intent supplies a venue, instrument, or quote; if
-more than one eligible pair remains, ask the user instead of choosing by array
-order. If no candidate remains, stop and ask for a clearer ticker or intent.
+Search returns candidates. Narrow the filters using the user's venue, instrument,
+and quote intent. If zero or multiple candidates remain, ask the user; never
+choose the first result. Exclude options unless the user explicitly requests an
+option contract.
 
 After selecting a candidate, verify the complete identity before writing code
 or sending an order:
@@ -305,37 +304,13 @@ or sending an order:
 alva trading-pairs resolve --pair US_SPOT_RKLB_USD --json
 ```
 
-The resolve command must return exactly one candidate. Use its
-`tradingPair` value verbatim as the symbol in OHLCV registration, targets,
-positions, and orders. For an ETF such as SPY, search with
-`--market US --instrument-type spot --quote USD`; its canonical pair is still
-`US_SPOT_SPY_USD`. Add `--underlying-type etf` only when the response includes
-that metadata.
+Use its `tradingPair` value verbatim as the symbol in OHLCV
+registration, targets, positions, and orders. For US stocks and ETFs, use
+`--market US --instrument-type spot --quote USD`; for crypto, provide the
+requested venue, instrument, and quote.
 
-Selection rules:
-
-- Treat a prefix such as `NASDAQ:` or `XNAS:` as an intent hint. Search Arrays
-  with the base ticker and use the returned `tradingPair`; for example,
-  `NASDAQ:RKLB` resolves through `RKLB` to `US_SPOT_RKLB_USD`.
-- For US stocks and ETFs, filter to `spot` + `US` + `USD`; both resolve to
-  canonical `US_SPOT_<TICKER>_USD` pairs. Add `--underlying-type stock` or
-  `--underlying-type etf` only when the CLI response includes that metadata;
-  older Gateway responses may omit it. For crypto, filter `spot` or `perp` and
-  the requested venue and quote.
-- Exclude options unless the user explicitly asks for an option contract.
-- Require an exact ticker match and exactly one unique `tradingPair` at resolve
-  time. Never select the first response. If zero or multiple filtered
-  candidates match the user's intent, ask one blocking question instead of
-  guessing.
-- Stop when the lookup errors or returns no eligible candidate. Do not silently
-  fall back to an invented symbol.
-- Treat the CLI's returned `tradingPair` as an opaque canonical identity. Preserve its
-  case and spelling unchanged in OHLCV registration, targets, positions, and
-  orders. Do not convert `US` back to `XNAS`/`XNYS`, use `_ETF_` for ETFs, or
-  replace `PERP` with `FUTURES`.
-- For an existing position or strategy target, preserve the stored complete
-  `tradingPair`; do not resolve its ticker again and replace it with a newer
-  catalog result. Resolve only new user-entered assets.
+For an existing position or strategy target, preserve its stored complete
+`tradingPair`; resolve only new user-entered assets.
 
 The lookup proves naming and catalog membership, not OHLCV availability. Before
 the full-range backtest, run Altra with the selected symbol over a bounded smoke

--- a/skills/alva/references/altra-trading.md
+++ b/skills/alva/references/altra-trading.md
@@ -254,6 +254,7 @@ const { FeedAltra, e, Amount, TIME, allocate, order, orders } = FeedAltraModule;
 | `num`, `str`, `bool`, `obj`, `arr`, `fld` | `@alva/feed` (top level) | Field type helpers (same as Feed SDK)            |
 | `makeDoc`                                 | `@alva/feed` (top level) | Type document helper                             |
 | `createArraysOhlcvProvider`               | `@alva/feed` (top level) | Builds the OHLCV provider used by Altra          |
+| `resolveTradingPair`                      | `@alva/feed` (top level) | Resolves one canonical Arrays trading pair      |
 
 ---
 
@@ -275,73 +276,25 @@ const altra = new FeedAltra(config, ohlcvProvider);
 ### Resolve Trading Pairs Before Backtesting
 
 Never invent or assemble an Altra symbol from a ticker. Resolve the exact
-`trading_pair` from Arrays before writing the strategy, then pass it to Altra
-unchanged. Use the existing `alva run` surface; no dedicated trading-pair CLI
-command is required.
+canonical pair through `resolveTradingPair` before writing the strategy, then
+pass `resolved.tradingPair` to Altra unchanged. Pass it to Altra unchanged in
+OHLCV registration, targets, positions, and orders. The helper owns the Arrays
+request, filtering, exact ticker match, deduplication, and unique-result check;
+no dedicated trading-pair CLI command or inline HTTP is required.
 
-Run this bounded lookup with the user's intended instrument and venue filters:
+```javascript
+const { resolveTradingPair } = require("@alva/feed");
+const secret = require("secret-manager");
 
-```bash
-alva run --code '(async () => {
-  const http = require("net/http");
-  const secret = require("secret-manager");
-  const env = require("env");
-  const args = env.args || {};
-  const rawQuery = String(args.query || "").trim().toUpperCase();
-  const query = rawQuery.includes(":") ? rawQuery.split(":").pop() : rawQuery;
-  if (!query) throw new Error("query is required");
-
-  const response = await http.fetch(
-    "https://data-tools.prd.space.id/api/v1/market/trading-pairs?symbol=" +
-      encodeURIComponent(query),
-    {
-      headers: {
-        Authorization: "Bearer " + secret.loadPlaintext("ARRAYS_JWT"),
-      },
-    },
-  );
-  const body = await response.json();
-  if (!response.ok || body.success === false) {
-    throw new Error("trading-pair search failed with HTTP " + response.status);
-  }
-
-  const wanted = {
-    instrumentType: String(args.instrument_type || "").toUpperCase(),
-    underlyingType: String(args.underlying_type || "").toUpperCase(),
-    market: String(args.market || "").toUpperCase(),
-    quote: String(args.quote || "").toUpperCase(),
-  };
-  const candidatesByPair = new Map();
-  for (const match of body.data || []) {
-    for (const group of match.trading_pairs || []) {
-      for (const pair of group.pairs || []) {
-        const candidate = {
-          matchedSymbol: match.symbol,
-          tradingPair: pair.trading_pair,
-          instrumentType: group.instrument_type,
-          underlyingType: pair.underlying_type,
-          market: pair.market,
-          quote: pair.quote,
-        };
-        if (!candidate.tradingPair) continue;
-        if (wanted.instrumentType && String(candidate.instrumentType).toUpperCase() !== wanted.instrumentType) continue;
-        if (wanted.underlyingType && String(candidate.underlyingType).toUpperCase() !== wanted.underlyingType) continue;
-        if (wanted.market && String(candidate.market).toUpperCase() !== wanted.market) continue;
-        if (wanted.quote && String(candidate.quote).toUpperCase() !== wanted.quote) continue;
-        if (String(candidate.matchedSymbol).toUpperCase() !== query) continue;
-        candidatesByPair.set(candidate.tradingPair, candidate);
-      }
-    }
-  }
-  const candidates = Array.from(candidatesByPair.values());
-  if (candidates.length !== 1) {
-    throw new Error(
-      "expected exactly one canonical trading pair for " + query +
-      ", received " + candidates.length,
-    );
-  }
-  return { query, ...candidates[0] };
-})();' --args '{"query":"RKLB","instrument_type":"spot","underlying_type":"stock","market":"US","quote":"USD"}'
+const resolved = await resolveTradingPair({
+  query: "NASDAQ:RKLB",
+  instrumentType: "spot",
+  underlyingType: "stock",
+  market: "US",
+  quote: "USD",
+  jwt: secret.loadPlaintext("ARRAYS_JWT"),
+});
+const pair = resolved.tradingPair; // "US_SPOT_RKLB_USD"
 ```
 
 For an ETF such as SPY, use the same lookup with `"underlying_type":"etf"`; its

--- a/skills/alva/references/api/trading.md
+++ b/skills/alva/references/api/trading.md
@@ -17,7 +17,9 @@ exchange field. Mismatching symbol type to account exchange errors.
 | `alpaca`       | US Equities | `US_SPOT_AAPL_USD`               |
 
 Symbols are canonical Arrays identities, not exchange aliases. Resolve them
-through Trading Pair Search and use the returned `tradingPair` unchanged;
+with `alva trading-pairs search` and then verify the selected complete pair
+with `alva trading-pairs resolve --pair <tradingPair> --json`. Use the returned
+`tradingPair` unchanged;
 `XNAS_SPOT_AAPL_USD`, `US_ETF_SPY_USD`, lowercase variants, and
 `BINANCE_FUTURES_BTC_USDT` are invalid inputs.
 


### PR DESCRIPTION
## Summary\n\n- replace the inline Arrays trading-pair HTTP/parsing workflow with the alva trading-pairs CLI\n- require search first, explicit candidate filtering or a user clarification when ambiguous, then exact resolve --pair verification\n- preserve the CLI-returned tradingPair unchanged in Altra OHLCV, targets, positions, and orders\n- remove hardcoded Arrays URLs, agent-side JWT loading, and symbol alias construction\n- update Skill regression, scenario, and mutation coverage\n\n## Dependency\n\nDepends on alva-ai/toolkit-ts#168, which adds the trading-pairs search and resolve commands.\n\n## Validation\n\n- Skill eval: 88/88 cases, 924/924 checks\n- mutation smoke: 19/19\n- git diff --check\n- direct staging validation: RKLB resolved to US_SPOT_RKLB_USD\n- Altra smoke backtest completed successfully with that canonical pair\n\nNo trading-agent, Altra portfolio, or backtest-js behavior changes are included.