### PR TITLE
docs(alva): route Automation price charts through SDK

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1389,6 +1389,37 @@
       ]
     },
     {
+      "id": "target.automation-price-chart-sdk",
+      "group": "target",
+      "target": "corpus",
+      "description": "Scheduled Automation price charts route to the dedicated runtime SDK while one-off Ask/chat and Playbook chart paths stay separate.",
+      "file_includes": [
+        {
+          "file": "SKILL.md",
+          "includes": [
+            "@alva/price-chart-sdk",
+            "[price-chart-sdk.md](references/price-chart-sdk.md)",
+            "Do not add charts by default or apply this route to one-off chat or Playbook charts"
+          ]
+        },
+        {
+          "file": "references/price-chart-sdk.md",
+          "includes": [
+            "only when a deployed Automation/Feed producer is explicitly designed",
+            "Do not add charts to Automations by default",
+            "alva sdk doc --name @alva/price-chart-sdk",
+            "does not fetch market data",
+            "publishPriceChart()",
+            "PRICE_CHART_SCHEMA_VERSION",
+            "previewUrl?: string",
+            "publishedUrl: string",
+            "already includes `interactive=1`",
+            "Do not call `@alva/automation-chart` directly"
+          ]
+        }
+      ]
+    },
+    {
       "id": "target.auto-trade-consent-exemption",
       "group": "target",
       "target": "skill",

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -748,6 +748,27 @@
       }
     },
     {
+      "id": "scenario.automation-price-chart",
+      "group": "scenarios.automation",
+      "prompt": "Create an hourly NVDA Automation that returns a static chart preview and opens an interactive Area/Candles chart.",
+      "description": "A chart produced on every scheduled run uses the Automation-only price chart SDK, not the one-off chat publisher or Playbook renderer.",
+      "expect": {
+        "route": "Automation / Push",
+        "top_level_route": "Data Product Layer: Feed Lifecycle And Automation",
+        "references": [
+          "price-chart-sdk.md",
+          "feed-sdk.md"
+        ],
+        "behaviors": [
+          "@alva/price-chart-sdk",
+          "does not fetch market data",
+          "previewUrl",
+          "publishedUrl",
+          "Do not add charts by default or apply this route to one-off chat or Playbook charts"
+        ]
+      }
+    },
+    {
       "id": "scenario.udf-strict-opt-in",
       "group": "scenarios.udf",
       "prompt": "Add a button so viewers can run my custom analysis function.",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -349,6 +349,7 @@ code. Common modules:
 | HTTP                          | `require("net/http")`                                                                                         |
 | statistics / indicators       | `@alva/algorithm` or runtime `alva sdk` modules                                                               |
 | persistent feed output        | `@alva/feed`; [feed-sdk.md](references/feed-sdk.md)                                                           |
+| Automation price chart        | `@alva/price-chart-sdk`; [price-chart-sdk.md](references/price-chart-sdk.md)                                  |
 | Platform Data digest module   | `@alva/fintwit-digest`; see Platform Data above and [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md) |
 | trading engine                | `FeedAltra`; [altra-trading.md](references/altra-trading.md)                                                  |
 | scheduled LLM reasoning       | `@alva/pi`; [alpi.md](references/alpi.md)                                                                     |
@@ -448,7 +449,7 @@ reusable dataset, or future answer.
 
 Read [alva-knowledge.md](references/alva-knowledge.md) before designing an
 automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
-[feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
+[feed-sdk.md](references/feed-sdk.md) when creating or changing a feed; only if an Automation explicitly needs a price chart on each run, read [price-chart-sdk.md](references/price-chart-sdk.md). Do not add charts by default or apply this route to one-off chat or Playbook charts. The
 short creation lifecycle is: write schema and logic to ALFS, `alva run`,
 deploy, publish once with `alva automation publish`, then use its returned
 `feed_id` with `alva feed set-visibility` when public access is required.
@@ -791,6 +792,7 @@ Use this index to open only the file needed for the current task.
 | [operational-pitfalls.md](references/operational-pitfalls.md)                         | Runtime, ALFS, chart, watermark, and resource pitfalls.                                                                                       |
 | [jagent-runtime.md](references/jagent-runtime.md)                                     | V8 runtime, modules, async model, constraints, built-ins.                                                                                     |
 | [feed-sdk.md](references/feed-sdk.md)                                                 | Feed SDK API, schemas, time series, grouped records, upstreams, examples.                                                                     |
+| [price-chart-sdk.md](references/price-chart-sdk.md)                                   | Automation-only price chart rendering, publication inputs, and preview/interactive URL contract.                                              |
 | [altra-trading.md](references/altra-trading.md)                                       | Altra strategy engine, features, signals, tests, PIT compliance.                                                                              |
 | [alpi.md](references/alpi.md)                                                         | Scheduled LLM reasoning/tool-loop API and examples.                                                                                           |
 | [agent-schedules.md](references/agent-schedules.md)                                   | Named Channel Agent schedules, rule/bound contracts, lifecycle, and legacy Channel Loop compatibility.                                        |

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -4,13 +4,6 @@ Use `@alva/price-chart-sdk` only when a deployed Automation/Feed producer is
 explicitly designed to publish a standard time-based price chart on each run.
 Do not add charts to Automations by default.
 
-Keep the other chart routes unchanged:
-
-- One-off Ask/chat chart: use [lightweight-charts.md](lightweight-charts.md) and
-  the existing `PublishChartHTML` flow.
-- Playbook chart: use [design-widgets.md](design-widgets.md).
-- Explicitly requested Automation chart published on every run: use this SDK.
-
 The SDK is deterministic infrastructure, not an Agent. It does not fetch market
 data, write Feed rows, run screenshot review loops, or decide whether a chart is
 needed. The Automation resolves legitimate price data first, calls the SDK, and
@@ -39,8 +32,8 @@ Pass one already-resolved immutable snapshot:
   ticker: string,
   dataAsOfMs: number,
   series:
-    | { type: "area" | "line"; data: { time, value }[] }
-    | { type: "candlestick"; data: { time, open, high, low, close }[] },
+    | { type: "area" | "line"; data: { time: number | string, value: number }[] }
+    | { type: "candlestick"; data: { time: number | string, open: number, high: number, low: number, close: number }[] },
   levels?: { label: string, price: number, color?: string }[],
   viewToggle?: { enabled: boolean, initialView?: "area" | "candlestick" }
 }

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -1,0 +1,164 @@
+# Automation Price Chart SDK
+
+Use `@alva/price-chart-sdk` only when a deployed Automation/Feed producer is
+explicitly designed to publish a standard time-based price chart on each run.
+Do not add charts to Automations by default.
+
+Keep the other chart routes unchanged:
+
+- One-off Ask/chat chart: use [lightweight-charts.md](lightweight-charts.md) and
+  the existing `PublishChartHTML` flow.
+- Playbook chart: use [design-widgets.md](design-widgets.md).
+- Explicitly requested Automation chart published on every run: use this SDK.
+
+The SDK is deterministic infrastructure, not an Agent. It does not fetch market
+data, write Feed rows, run screenshot review loops, or decide whether a chart is
+needed. The Automation resolves legitimate price data first, calls the SDK, and
+decides how to store or deliver the returned URLs. Do not call
+`@alva/automation-chart` directly or hand-write chart HTML for this route.
+
+## Before Coding
+
+Run `alva sdk --help`, then load the current public surface:
+
+```bash
+alva sdk doc --name @alva/price-chart-sdk
+```
+
+If the module is unavailable in the active environment, report the coverage gap;
+do not silently fall back to the one-off chart publisher.
+
+## Business Input
+
+Pass one already-resolved immutable snapshot:
+
+```typescript
+{
+  schemaVersion: PRICE_CHART_SCHEMA_VERSION,
+  title: string,
+  ticker: string,
+  dataAsOfMs: number,
+  series:
+    | { type: "area" | "line"; data: { time, value }[] }
+    | { type: "candlestick"; data: { time, open, high, low, close }[] },
+  levels?: { label: string, price: number, color?: string }[],
+  viewToggle?: { enabled: boolean, initialView?: "area" | "candlestick" }
+}
+```
+
+- `dataAsOfMs` is epoch milliseconds.
+- Intraday `time` is Unix seconds; daily `time` is `YYYY-MM-DD`. Use one
+  representation per series and never include a point after `dataAsOfMs`.
+- `viewToggle` requires candlestick OHLC input. The Area view derives close
+  values; `initialView` is the preview image view.
+- Financial values must come from Data Skills, a Feed, or validated BYOD data.
+  The generated HTML template is fixed; the Agent must not write financial
+  values or chart HTML from memory.
+
+## Publication Input
+
+`publishPriceChart()` also needs platform-owned publication context:
+
+| Field            | Source / rule                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`       | Current environment's chart publication endpoint. Use explicit runtime/platform configuration; do not guess an environment.                                                     |
+| `http`           | A `postJson(url, body, headers)` adapter over `require("net/http")`.                                                                                                            |
+| `headers`        | Platform authentication such as `X-Alva-Api-Key`; load it from runtime configuration/Secret Manager, never inline or log it.                                                    |
+| `origin`         | `{ kind: "automation", ownerUserId, channelId, feedId?, cronjobRunId?, outputRowId? }`. Owner and channel are required and must come from the authenticated Automation context. |
+| `idempotencyKey` | Stable per logical chart output. A retry of the same output reuses the same key; multiple charts use distinct keys.                                                             |
+| `render`         | Optional capture dimensions. Omit for the deterministic 720 x 336 default unless the product contract requires another size.                                                    |
+
+Minimal jagent adapter shape:
+
+```javascript
+const {
+  PRICE_CHART_SCHEMA_VERSION,
+  publishPriceChart,
+} = require("@alva/price-chart-sdk");
+const env = require("env");
+const netHttp = require("net/http");
+const secrets = require("secret-manager");
+
+function jsonClient(http) {
+  return {
+    async postJson(url, body, headers) {
+      const response = await http.fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Chart publication failed: HTTP ${response.status}`);
+      }
+      return JSON.parse(text);
+    },
+  };
+}
+
+(async () => {
+  const args = env.args || {};
+  const ticker = resolvedTicker;
+  const dataAsOfMs = resolvedDataAsOfMs;
+  const channelId = String(args.channelId || "");
+  const endpoint = String(args.chartEndpoint || "");
+  const apiKey = await secrets.loadPlaintext(
+    args.chartApiKeySecretName || "ALVA_API_KEY",
+  );
+  if (!channelId || !endpoint || !apiKey) {
+    throw new Error("Missing chart publication context");
+  }
+
+  const outputRowId = [
+    "price-chart",
+    args.feedId || channelId,
+    args.chartSlot || ticker,
+    String(dataAsOfMs),
+  ].join(":");
+
+  return publishPriceChart({
+    endpoint,
+    http: jsonClient(netHttp),
+    headers: { "X-Alva-Api-Key": apiKey },
+    idempotencyKey: outputRowId,
+    origin: {
+      kind: "automation",
+      ownerUserId: String(env.userId),
+      channelId,
+      ...(args.feedId ? { feedId: String(args.feedId) } : {}),
+      ...(args.cronjobRunId ? { cronjobRunId: String(args.cronjobRunId) } : {}),
+      outputRowId,
+    },
+    spec: {
+      schemaVersion: PRICE_CHART_SCHEMA_VERSION,
+      title: ticker,
+      ticker,
+      dataAsOfMs,
+      series: { type: "candlestick", data: resolvedOhlc },
+      viewToggle: { enabled: true, initialView: "area" },
+    },
+  });
+})();
+```
+
+`resolvedTicker`, `resolvedDataAsOfMs`, and `resolvedOhlc` stand for data
+already fetched and validated by the Automation; they are not literals to copy.
+
+## Result Contract
+
+```typescript
+{
+  artifactId: string,
+  previewUrl?: string,
+  publishedUrl: string
+}
+```
+
+- `previewUrl` is a static image without the Area/Candles toggle. It is optional
+  because HTML publication may succeed when screenshot capture fails.
+- `publishedUrl` already includes `interactive=1`; pass it directly to an iframe
+  or Native WebView. Do not rewrite it in the client.
+- The interactive artifact fills its iframe/WebView and shows the toggle when
+  enabled. The SDK does not implement Feed cards, click handlers, or modals.
+- Do not fabricate either URL or fall back to embedding generated HTML in a Feed
+  output when publication fails.


### PR DESCRIPTION
## Summary
- add an Automation-only reference for `@alva/price-chart-sdk`
- route only explicitly requested per-run price charts through the SDK
- keep one-off Ask/chat Lightweight Charts and Playbook chart paths unchanged
- document deterministic inputs, publication context, and preview/published URL outputs
- add an Automation routing regression case

## Validation
- `node evals/alva-skill-docs/skill-doc-eval.mjs`
- `node evals/alva-skill-docs/mutation-smoke.mjs`
- `quick_validate.py skills/alva`
- `git diff --check`

## Dependency
- `alva-ai/sdk-monorepo#82` (merged)