### PR TITLE
docs(alva): remove price chart SDK doc gate

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1407,7 +1407,6 @@
           "includes": [
             "only when a deployed Automation/Feed producer is explicitly designed",
             "Do not add charts to Automations by default",
-            "alva sdk doc --name @alva/price-chart-sdk",
             "does not fetch market data",
             "publishPriceChart()",
             "PRICE_CHART_SCHEMA_VERSION",

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -10,17 +10,6 @@ needed. The Automation resolves legitimate price data first, calls the SDK, and
 decides how to store or deliver the returned URLs. Do not call
 `@alva/automation-chart` directly or hand-write chart HTML for this route.
 
-## Before Coding
-
-Run `alva sdk --help`, then load the current public surface:
-
-```bash
-alva sdk doc --name @alva/price-chart-sdk
-```
-
-If the module is unavailable in the active environment, report the coverage gap;
-do not silently fall back to the one-off chart publisher.
-
 ## Business Input
 
 Pass one already-resolved immutable snapshot:


### PR DESCRIPTION
## Summary
- remove the mandatory `alva sdk doc` preflight from the Automation price-chart reference
- keep the package documented as a platform-owned Registry SDK through the canonical Skill reference
- update the documentation regression case accordingly

## Why
`@alva/price-chart-sdk` resolves successfully at runtime from Artifact Registry, while its documentation is not currently indexed by `alva sdk doc`. Documentation discovery should not block Automation creation when the maintained Skill reference already defines the public contract.

## Validation
- `node evals/alva-skill-docs/skill-doc-eval.mjs --skill-dir skills/alva` (90/90 cases, 932/932 checks)
- `node evals/alva-skill-docs/mutation-smoke.mjs --skill-dir skills/alva` (19/19)
- `git diff --check`