### PR TITLE
docs(alva): hide price chart render sizing

### DIFF
--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -48,7 +48,9 @@ Pass one already-resolved immutable snapshot:
 | `headers`        | Platform authentication such as `X-Alva-Api-Key`; load it from runtime configuration/Secret Manager, never inline or log it.                                                    |
 | `origin`         | `{ kind: "automation", ownerUserId, channelId, feedId?, cronjobRunId?, outputRowId? }`. Owner and channel are required and must come from the authenticated Automation context. |
 | `idempotencyKey` | Stable per logical chart output. A retry of the same output reuses the same key; multiple charts use distinct keys.                                                             |
-| `render`         | Optional capture dimensions. Omit for the deterministic 720 x 336 default unless the product contract requires another size.                                                    |
+
+Preview sizing and visual styling are SDK-owned. Do not pass render overrides
+from generated Automation code.
 
 Minimal jagent adapter shape:
 

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -49,9 +49,6 @@ Pass one already-resolved immutable snapshot:
 | `origin`         | `{ kind: "automation", ownerUserId, channelId, feedId?, cronjobRunId?, outputRowId? }`. Owner and channel are required and must come from the authenticated Automation context. |
 | `idempotencyKey` | Stable per logical chart output. A retry of the same output reuses the same key; multiple charts use distinct keys.                                                             |
 
-Preview sizing and visual styling are SDK-owned. Do not pass render overrides
-from generated Automation code.
-
 Minimal jagent adapter shape:
 
 ```javascript


### PR DESCRIPTION
## Summary
- remove the stale `720 x 336` render-dimension guidance
- remove `render` from the generated Automation publication inputs
- keep preview sizing and visual styling owned by `@alva/price-chart-sdk`

## Verification
- Alva skill doc regression: 90/90 cases, 932/932 checks
- mutation smoke: 19/19 expected failures
- no price-chart SDK size literals remain in the Alva Skill reference