### PR TITLE
docs(alva): document price chart overlays

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1407,6 +1407,8 @@
             "does not fetch market data",
             "publishPriceChart()",
             "PRICE_CHART_SCHEMA_VERSION",
+            "overlays?:",
+            "overlay points may extend beyond",
             "previewUrl?: string",
             "publishedUrl: string",
             "already includes `interactive=1`",

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -23,14 +23,23 @@ Pass one already-resolved immutable snapshot:
   series:
     | { type: "area" | "line"; data: { time: number | string, value: number }[] }
     | { type: "candlestick"; data: { time: number | string, open: number, high: number, low: number, close: number }[] },
+  overlays?: {
+    type: "line",
+    data: { time: number | string, value: number }[],
+    color?: string,
+    lineStyle?: "solid" | "dotted" | "dashed"
+  }[],
   levels?: { label: string, price: number, color?: string }[],
   viewToggle?: { enabled: boolean, initialView?: "area" | "candlestick" }
 }
 ```
 
 - `dataAsOfMs` is epoch milliseconds.
-- Intraday `time` is Unix seconds; daily `time` is `YYYY-MM-DD`. Use one
-  representation per series and never include a point after `dataAsOfMs`.
+- Intraday `time` is Unix seconds; daily `time` is `YYYY-MM-DD`. Use one time
+  representation across the primary series and its overlays. Primary series
+  points must not be later than `dataAsOfMs`; overlay points may extend beyond
+  it.
+- `overlays` adds time-aligned lines on the primary series' price scale.
 - `viewToggle` requires candlestick OHLC input. The Area view derives close
   values; `initialView` is the preview image view.
 - Financial values must come from Data Skills, a Feed, or validated BYOD data.


### PR DESCRIPTION
## Summary\n- document the new optional line overlay input from sdk-monorepo#102\n- require one time representation across primary data and overlays\n- keep observed primary points bounded by dataAsOfMs while allowing overlays to extend beyond it\n- retain existing data provenance rules without adding business-specific scenario semantics\n\n## Validation\n- skill regression: 90/90 cases, 926/926 checks\n- mutation smoke: 19/19