### PR TITLE
docs(alva): backport Automation price charts to v1.22

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1310,7 +1310,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.21.4",
+        "version: v1.22.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",
@@ -1381,6 +1381,42 @@
           "file": "SKILL.md",
           "includes": [
             "[lightweight-charts.md](references/lightweight-charts.md)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "target.automation-price-chart-sdk",
+      "group": "target",
+      "target": "corpus",
+      "description": "Scheduled Automation price charts route to the dedicated runtime SDK while one-off Ask/chat and Playbook chart paths stay separate.",
+      "file_includes": [
+        {
+          "file": "SKILL.md",
+          "includes": [
+            "@alva/price-chart-sdk",
+            "[price-chart-sdk.md](references/price-chart-sdk.md)",
+            "Do not add charts by default or apply this route to one-off chat or Playbook charts"
+          ]
+        },
+        {
+          "file": "references/price-chart-sdk.md",
+          "includes": [
+            "only when a deployed Automation/Feed producer is explicitly designed",
+            "Do not add charts to Automations by default",
+            "does not fetch market data",
+            "publishPriceChart()",
+            "PRICE_CHART_SCHEMA_VERSION",
+            "ohlcv:",
+            "published chart starts in Candlestick view",
+            "overlays?:",
+            "overlay points may extend beyond",
+            "markers?:",
+            "marker time must match an existing OHLCV time",
+            "previewUrl?: string",
+            "publishedUrl: string",
+            "already includes `interactive=1`",
+            "Do not call `@alva/automation-chart` directly"
           ]
         }
       ]

--- a/evals/alva-skill-docs/scenarios.json
+++ b/evals/alva-skill-docs/scenarios.json
@@ -745,6 +745,27 @@
       }
     },
     {
+      "id": "scenario.automation-price-chart",
+      "group": "scenarios.automation",
+      "prompt": "Create an hourly NVDA Automation that returns a static chart preview and opens an interactive Area/Candles chart.",
+      "description": "A chart produced on every scheduled run uses the Automation-only price chart SDK, not the one-off chat publisher or Playbook renderer.",
+      "expect": {
+        "route": "Automation / Push",
+        "top_level_route": "Data Product Layer: Feed Lifecycle And Automation",
+        "references": [
+          "price-chart-sdk.md",
+          "feed-sdk.md"
+        ],
+        "behaviors": [
+          "@alva/price-chart-sdk",
+          "does not fetch market data",
+          "previewUrl",
+          "publishedUrl",
+          "Do not add charts by default or apply this route to one-off chat or Playbook charts"
+        ]
+      }
+    },
+    {
       "id": "scenario.udf-strict-opt-in",
       "group": "scenarios.udf",
       "prompt": "Add a button so viewers can run my custom analysis function.",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.22.0
+  version: v1.22.1
 ---
 
 # Alva
@@ -349,6 +349,7 @@ code. Common modules:
 | HTTP                          | `require("net/http")`                                                                                         |
 | statistics / indicators       | `@alva/algorithm` or runtime `alva sdk` modules                                                               |
 | persistent feed output        | `@alva/feed`; [feed-sdk.md](references/feed-sdk.md)                                                           |
+| Automation price chart        | `@alva/price-chart-sdk`; [price-chart-sdk.md](references/price-chart-sdk.md)                                  |
 | Platform Data digest module   | `@alva/fintwit-digest`; see Platform Data above and [fintwit-digest-sdk.md](references/fintwit-digest-sdk.md) |
 | trading engine                | `FeedAltra`; [altra-trading.md](references/altra-trading.md)                                                  |
 | scheduled LLM reasoning       | `@alva/pi`; [alpi.md](references/alpi.md)                                                                     |
@@ -448,7 +449,7 @@ reusable dataset, or future answer.
 
 Read [alva-knowledge.md](references/alva-knowledge.md) before designing an
 automation. Read [feed-lifecycle.md](references/feed-lifecycle.md) and
-[feed-sdk.md](references/feed-sdk.md) when creating or changing a feed. The
+[feed-sdk.md](references/feed-sdk.md) when creating or changing a feed; only if an Automation explicitly needs a price chart on each run, read [price-chart-sdk.md](references/price-chart-sdk.md). Do not add charts by default or apply this route to one-off chat or Playbook charts. The
 short creation lifecycle is: write schema and logic to ALFS, `alva run`,
 deploy, publish once with `alva automation publish`, then use its returned
 `feed_id` with `alva feed set-visibility` when public access is required.
@@ -791,6 +792,7 @@ Use this index to open only the file needed for the current task.
 | [operational-pitfalls.md](references/operational-pitfalls.md)                         | Runtime, ALFS, chart, watermark, and resource pitfalls.                                                                                       |
 | [jagent-runtime.md](references/jagent-runtime.md)                                     | V8 runtime, modules, async model, constraints, built-ins.                                                                                     |
 | [feed-sdk.md](references/feed-sdk.md)                                                 | Feed SDK API, schemas, time series, grouped records, upstreams, examples.                                                                     |
+| [price-chart-sdk.md](references/price-chart-sdk.md)                                   | Automation-only price chart rendering, publication inputs, and preview/interactive URL contract.                                              |
 | [altra-trading.md](references/altra-trading.md)                                       | Altra strategy engine, features, signals, tests, PIT compliance.                                                                              |
 | [alpi.md](references/alpi.md)                                                         | Scheduled LLM reasoning/tool-loop API and examples.                                                                                           |
 | [agent-schedules.md](references/agent-schedules.md)                                   | Named Channel Agent schedules, rule/bound contracts, lifecycle, and legacy Channel Loop compatibility.                                        |

--- a/skills/alva/references/price-chart-sdk.md
+++ b/skills/alva/references/price-chart-sdk.md
@@ -1,0 +1,170 @@
+# Automation Price Chart SDK
+
+Use `@alva/price-chart-sdk` only when a deployed Automation/Feed producer is
+explicitly designed to publish a standard time-based price chart on each run.
+Do not add charts to Automations by default.
+
+The SDK is deterministic infrastructure, not an Agent. It does not fetch market
+data, write Feed rows, run screenshot review loops, or decide whether a chart is
+needed. The Automation resolves legitimate price data first, calls the SDK, and
+decides how to store or deliver the returned URLs. Do not call
+`@alva/automation-chart` directly or hand-write chart HTML for this route.
+
+## Business Input
+
+Pass one already-resolved immutable snapshot:
+
+```typescript
+{
+  schemaVersion: PRICE_CHART_SCHEMA_VERSION,
+  title: string,
+  ticker: string,
+  dataAsOfMs: number,
+  ohlcv: {
+    time: number | string,
+    open: number,
+    high: number,
+    low: number,
+    close: number,
+    volume: number
+  }[],
+  overlays?: {
+    type: "line",
+    data: { time: number | string, value: number }[],
+    color?: string,
+    lineStyle?: "solid" | "dotted" | "dashed"
+  }[],
+  markers?: {
+    time: number | string,
+    position: "aboveBar" | "belowBar" | "inBar" | "atPriceTop" | "atPriceMiddle" | "atPriceBottom",
+    price?: number,
+    shape?: "circle" | "square" | "arrowUp" | "arrowDown",
+    color?: string,
+    text?: string
+  }[],
+  levels?: { label: string, price: number, color?: string }[]
+}
+```
+
+- `dataAsOfMs` is epoch milliseconds.
+- Intraday `time` is Unix seconds; daily `time` is `YYYY-MM-DD`. Use one time
+  representation across OHLCV, overlays, and markers. OHLCV points must not be
+  later than `dataAsOfMs`; overlay points may extend beyond it.
+- `overlays` adds time-aligned lines on the chart's price scale.
+- Each marker time must match an existing OHLCV time. Positions that
+  start with `atPrice` require `price`.
+- The SDK derives the Area preview from close values. The published chart starts
+  in Candlestick view and provides the Area/Candles toggle.
+- Financial values must come from Data Skills, a Feed, or validated BYOD data.
+  The generated HTML template is fixed; the Agent must not write financial
+  values or chart HTML from memory.
+
+## Publication Input
+
+`publishPriceChart()` also needs platform-owned publication context:
+
+Every deployed Automation must load its creator-scoped platform credential in
+the main script with `require("secret-manager").loadPlaintext("ALVA_API_KEY")`
+and pass it as `X-Alva-Api-Key`. Never copy a Sandbox credential or ask the
+user to provide one.
+
+| Field            | Source / rule                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`       | Current environment's chart publication endpoint. Use explicit runtime/platform configuration; do not guess an environment.                                                     |
+| `http`           | A `postJson(url, body, headers)` adapter over `require("net/http")`.                                                                                                            |
+| `headers`        | Platform authentication such as `X-Alva-Api-Key`; load it from runtime configuration/Secret Manager, never inline or log it.                                                    |
+| `origin`         | `{ kind: "automation", ownerUserId, channelId, feedId?, cronjobRunId?, outputRowId? }`. Owner and channel are required and must come from the authenticated Automation context. |
+| `idempotencyKey` | Stable per logical chart output. A retry of the same output reuses the same key; multiple charts use distinct keys.                                                             |
+
+Minimal jagent adapter shape:
+
+```javascript
+const {
+  PRICE_CHART_SCHEMA_VERSION,
+  publishPriceChart,
+} = require("@alva/price-chart-sdk");
+const env = require("env");
+const netHttp = require("net/http");
+const secrets = require("secret-manager");
+
+function jsonClient(http) {
+  return {
+    async postJson(url, body, headers) {
+      const response = await http.fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Chart publication failed: HTTP ${response.status}`);
+      }
+      return JSON.parse(text);
+    },
+  };
+}
+
+(async () => {
+  const args = env.args || {};
+  const ticker = resolvedTicker;
+  const dataAsOfMs = resolvedDataAsOfMs;
+  const channelId = String(args.channelId || "");
+  const endpoint = String(args.chartEndpoint || "");
+  const apiKey = secrets.loadPlaintext("ALVA_API_KEY");
+  if (!channelId || !endpoint || !apiKey) {
+    throw new Error("Missing chart publication context");
+  }
+
+  const outputRowId = [
+    "price-chart",
+    args.feedId || channelId,
+    args.chartSlot || ticker,
+    String(dataAsOfMs),
+  ].join(":");
+
+  return publishPriceChart({
+    endpoint,
+    http: jsonClient(netHttp),
+    headers: { "X-Alva-Api-Key": apiKey },
+    idempotencyKey: outputRowId,
+    origin: {
+      kind: "automation",
+      ownerUserId: String(env.userId),
+      channelId,
+      ...(args.feedId ? { feedId: String(args.feedId) } : {}),
+      ...(args.cronjobRunId ? { cronjobRunId: String(args.cronjobRunId) } : {}),
+      outputRowId,
+    },
+    spec: {
+      schemaVersion: PRICE_CHART_SCHEMA_VERSION,
+      title: ticker,
+      ticker,
+      dataAsOfMs,
+      ohlcv: resolvedOhlcv,
+    },
+  });
+})();
+```
+
+`resolvedTicker`, `resolvedDataAsOfMs`, and `resolvedOhlcv` stand for data
+already fetched and validated by the Automation; they are not literals to copy.
+
+## Result Contract
+
+```typescript
+{
+  artifactId: string,
+  previewUrl?: string,
+  publishedUrl: string
+}
+```
+
+- `previewUrl` is a static image without the Area/Candles toggle. It is optional
+  because HTML publication may succeed when screenshot capture fails.
+- `publishedUrl` already includes `interactive=1`; pass it directly to an iframe
+  or Native WebView. It starts in Candlestick view and shows the Area/Candles
+  toggle. Do not rewrite it in the client.
+- The interactive artifact fills its iframe/WebView. The SDK does not implement
+  Feed cards, click handlers, or modals.
+- Do not fabricate either URL or fall back to embedding generated HTML in a Feed
+  output when publication fails.


### PR DESCRIPTION
## Summary

- backport the final Automation Price Chart SDK guidance onto the production v1.22 release line
- document the OHLCV, overlays, markers, creator-auth, and preview/published URL contracts
- keep one-off chat and Playbook chart routes unchanged
- bump the Alva Skill metadata to v1.22.1 and add focused regression coverage

This applies the final net Skill state only. It intentionally excludes the superseded execution-effect guidance and its revert, as well as unrelated mainline Skill changes.

## Validation

- skill-creator `quick_validate.py`: passed
- `node evals/alva-skill-docs/skill-doc-eval.mjs`: 90/90 cases, 932/932 checks
- `git diff --check`