### PR TITLE
fix(alva): restore released Skill version metadata

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1310,7 +1310,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.22.1",
+        "version: v1.22.0",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.22.1
+  version: v1.22.0
 ---
 
 # Alva


### PR DESCRIPTION
## Summary

- restore the Alva Skill metadata from `v1.22.1` to the latest released version, `v1.22.0`
- keep the mainline eval pin aligned with the Skill metadata
- leave the contextual investment-disclaimer behavior from #622 unchanged

This repairs the release bookkeeping so the next version can be bumped in a dedicated main PR and then carried to `rel/v1.22`.

## Validation

- skill-creator `quick_validate.py`: passed
- `node evals/alva-skill-docs/skill-doc-eval.mjs`: 90/90 cases, 930/930 checks
- `git diff --check`