### PR TITLE
chore(alva): bump version to v1.22.1

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1310,7 +1310,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.22.0",
+        "version: v1.22.1",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.22.0
+  version: v1.22.1
 ---
 
 # Alva


### PR DESCRIPTION
## Summary

- bump the Alva Skill metadata from `v1.22.0` to `v1.22.1`
- update the mainline eval pin to the same version

This is a dedicated release-version PR. After it merges to main, the resulting commit will be cherry-picked to `rel/v1.22` before tagging `v1.22.1`.

## Validation

- skill-creator `quick_validate.py`: passed
- `node evals/alva-skill-docs/skill-doc-eval.mjs`: 90/90 cases, 930/930 checks
- `git diff --check`