### PR TITLE
chore(alva): bump version to v1.22.2

### DIFF
--- a/evals/alva-skill-docs/cases.json
+++ b/evals/alva-skill-docs/cases.json
@@ -1310,7 +1310,7 @@
       "target": "corpus",
       "description": "Latest mainline Alva skill updates remain integrated after rebasing the refactor.",
       "includes": [
-        "version: v1.22.1",
+        "version: v1.22.2",
         "Capability Help",
         "Reply 1, 2, or 3 to start",
         "feedback",

--- a/skills/alva/SKILL.md
+++ b/skills/alva/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   backtesting. Also use when the user asks about Alva platform capabilities.
 metadata:
   author: alva
-  version: v1.22.1
+  version: v1.22.2
 ---
 
 # Alva


### PR DESCRIPTION
## Summary

- bump the Alva Skill metadata from `v1.22.1` to `v1.22.2`
- update the mainline eval pin to the same version

This is a dedicated release-version PR. After it merges to main, the feature commit and resulting bump commit will be cherry-picked to `rel/v1.22` before tagging `v1.22.2`.

## Validation

- skill-creator `quick_validate.py`: passed
- `node evals/alva-skill-docs/skill-doc-eval.mjs`: passed
- `node evals/alva-skill-docs/mutation-smoke.mjs`: 19/19 passed
- `git diff --check`: passed